### PR TITLE
Use https:// instead of git://

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "test/widlproc"]
 	path = test/widlproc
-	url = git://github.com/dontcallmedom/widlproc.git
+	url = https://github.com/dontcallmedom/widlproc.git


### PR DESCRIPTION
git:// uses ports which are usually not available behind many firewalls (especially in universities). This patch makes the submodule use https://, which works over most networks.
