### PR TITLE
Fix bug where instrumented version of webidl2 was loaded.

### DIFF
--- a/test/invalid.js
+++ b/test/invalid.js
@@ -3,7 +3,7 @@
 //  - the errors actually still need to be reviewed to check that they
 //    are fully correct interpretations of the IDLs
 
-var wp = process.env.JSCOV ? require("../lib/webidl2") : require("../lib-cov/webidl2")
+var wp = process.env.JSCOV ? require("../lib-cov/webidl2") : require("../lib/webidl2")
 ,   expect = require("expect.js")
 ,   pth = require("path")
 ,   fs = require("fs")


### PR DESCRIPTION
Despite JSCOV not being defined.
