### PR TITLE
Support ID list in extended attributes

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -331,8 +331,21 @@
             all_ws();
             var eq = consume(OTHER, "=");
             if (eq) {
+                var rhs;
                 all_ws();
-                ret.rhs = consume(ID);
+                if (rhs = consume(ID)) {
+                  ret.rhs = rhs
+                }
+                else if (consume(OTHER, "(")) {
+                    rhs = [];
+                    var id = consume(ID);
+                    if (id) {
+                      rhs = [id.value];
+                    }
+                    identifiers(rhs);
+                    consume(OTHER, ")") || error("Unexpected token in extended attribute argument list or type pair");
+                    ret.rhs = rhs;
+                }
                 if (!ret.rhs) return error("No right hand side to extended attribute assignment");
             }
             all_ws();


### PR DESCRIPTION
WebIDL 2nd edition support identifier list at right hand side of extended attribute.
WebIDL 2 is not a W3C recommendation.
But many new spec is using this, ex: html5, fetch

ref: https://heycam.github.io/webidl/#dfn-extended-attribute
