### PR TITLE
Extended Attribute rhs of `=` support string

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -335,6 +335,9 @@
                 if (rhs = consume(ID)) {
                   ret.rhs = rhs
                 }
+                else if (rhs = consume(STR)) {
+                  ret.rhs = rhs
+                }
                 else if (consume(OTHER, "(")) {
                     rhs = [];
                     var id = consume(ID);


### PR DESCRIPTION
Not in 1.0 spec or 2.0 draft.
But Mozilla is using this kind of syntax.

EX: https://github.com/mozilla/gecko-dev/blob/master/dom/webidl/BrowserElement.webidl