### PR TITLE
Accept wider (but still incomplete) set of allowed syntax for extended attributes

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -335,6 +335,15 @@
                 if (rhs = consume(ID)) {
                   ret.rhs = rhs
                 }
+                else if (rhs = consume(FLOAT)) {
+                  ret.rhs = rhs
+                }
+                else if (rhs = consume(INT)) {
+                  ret.rhs = rhs
+                }
+                else if (rhs = consume(STR)) {
+                  ret.rhs = rhs
+                }
                 else if (consume(OTHER, "(")) {
                     // [Exposed=(Window,Worker)]
                     rhs = [];

--- a/test/syntax/idl/extended-attributes.widl
+++ b/test/syntax/idl/extended-attributes.widl
@@ -4,3 +4,8 @@
 interface ServiceWorkerGlobalScope : WorkerGlobalScope {
   
 };
+
+// Conformance with ExtendedAttributeList grammar in http://www.w3.org/TR/WebIDL/#idl-extended-attributes
+// Section 3.11
+[IntAttr=0, FloatAttr=3.14, StringAttr="abc"]
+interface IdInterface {};

--- a/test/syntax/json/extended-attributes.json
+++ b/test/syntax/json/extended-attributes.json
@@ -26,5 +26,38 @@
                 }
             }
         ]
+    },
+    {
+      "type": "interface",
+      "name": "IdInterface",
+      "partial": false,
+      "members": [],
+      "inheritance": null,
+      "extAttrs": [
+        {
+          "name": "IntAttr",
+          "arguments": null,
+          "rhs": {
+            "type": "integer",
+            "value": "0"
+          }
+        },
+        {
+          "name": "FloatAttr",
+          "arguments": null,
+          "rhs": {
+            "type": "float",
+            "value": "3.14"
+          }
+        },
+        {
+          "name": "StringAttr",
+          "arguments": null,
+          "rhs": {
+            "type": "string",
+            "value": "\"abc\""
+          }
+        }
+      ]
     }
 ]


### PR DESCRIPTION
This allows things like:

     [Id=0] interface Foo {};

The spec (http://www.w3.org/TR/WebIDL/#idl-extended-attributes) isn't super clear on whether this should be allowed or not. I believe that it is saying that extended attributes have very permissive grammar in general, but the specific extended attributes discussed in the spec have specific restrictions.