### PR TITLE
Replace expect.js with expct

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "2.2.5",
-    "expect.js": "0.3.1",
+    "expect": "1.20.1",
     "underscore": "1.8.3",
     "jsondiffpatch": "0.1.31",
     "benchmark": "*",

--- a/test/invalid.js
+++ b/test/invalid.js
@@ -4,7 +4,7 @@
 //    are fully correct interpretations of the IDLs
 
 var wp = process.env.JSCOV ? require("../lib-cov/webidl2") : require("../lib/webidl2")
-,   expect = require("expect.js")
+,   expect = require("expect")
 ,   pth = require("path")
 ,   fs = require("fs")
 ;
@@ -16,7 +16,7 @@ describe("Parses all of the invalid IDLs to check that they blow up correctly", 
                   .map(function (it) { return pth.join(dir, it); })
     ,   errors = idls.map(function (it) { return pth.join(__dirname, "invalid", "json", pth.basename(it).replace(/\.w?idl/, ".json")); })
     ;
-    
+
     for (var i = 0, n = idls.length; i < n; i++) {
         var idl = idls[i], error = JSON.parse(fs.readFileSync(errors[i], "utf8"));
         var func = (function (idl, err) {
@@ -30,11 +30,11 @@ describe("Parses all of the invalid IDLs to check that they blow up correctly", 
                     error = e;
                 }
                 finally {
-                    expect(error).to.be.ok();
-                    expect(error.message).to.equal(err.message);
-                    expect(error.line).to.equal(err.line);
+                    expect(error).toExist();
+                    expect(error.message).toEqual(err.message);
+                    expect(error.line).toEqual(err.line);
                 }
-                
+
             };
         }(idl, error));
         it("should produce the right error for " + idl, func);

--- a/test/syntax.js
+++ b/test/syntax.js
@@ -1,6 +1,6 @@
 
 var wp = process.env.JSCOV ? require("../lib-cov/webidl2") : require("../lib/webidl2")
-,   expect = require("expect.js")
+,   expect = require("expect")
 ,   pth = require("path")
 ,   fs = require("fs")
 ,   jdp = require("jsondiffpatch")
@@ -14,7 +14,7 @@ describe("Parses all of the IDLs to produce the correct ASTs", function () {
                   .map(function (it) { return pth.join(dir, it); })
     ,   jsons = idls.map(function (it) { return pth.join(__dirname, "syntax/json", pth.basename(it).replace(".widl", ".json")); })
     ;
-    
+
     for (var i = 0, n = idls.length; i < n; i++) {
         var idl = idls[i], json = jsons[i];
 
@@ -28,7 +28,7 @@ describe("Parses all of the IDLs to produce the correct ASTs", function () {
                     var diff = jdp.diff(JSON.parse(fs.readFileSync(json, "utf8")),
                                         wp.parse(fs.readFileSync(idl, "utf8"), opt));
                     if (diff && debug) console.log(JSON.stringify(diff, null, 4));
-                    expect(diff).to.be(undefined);
+                    expect(diff).toBe(undefined);
                 }
                 catch (e) {
                     console.log(e.toString());

--- a/test/web/make-web-tests.js
+++ b/test/web/make-web-tests.js
@@ -36,7 +36,7 @@ var pth = require("path")
     ,   "  </head>"
     ,   "  <body><div id='mocha'></div>"
     ,   "  <script src='https://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js'></script>"
-    ,   "  <script src='../../node_modules/expect.js/expect.js'></script>"
+    ,   "  <script src='../../node_modules/expect/umd/expect.min.js'></script>"
     ,   "  <script src='../../node_modules/mocha/mocha.js'></script>"
     ,   "  <script src='../../node_modules/jsondiffpatch/jsondiffpatch.min.js'></script>"
     ,   "  <script src='../../lib/webidl2.js'></script>"

--- a/test/web/run-tests.js
+++ b/test/web/run-tests.js
@@ -10,7 +10,7 @@ describe("Parses all of the IDLs to produce the correct ASTs", function () {
                     // so we compare based on that
                     var diff = jsondiffpatch.diff(json, WebIDL2.parse(idl));
                     if (diff && debug) console.log(JSON.stringify(diff, null, 4));
-                    expect(diff).to.be(undefined);
+                    expect(diff).toBe(undefined);
                 }
                 catch (e) {
                     console.log(e.toString());
@@ -36,11 +36,11 @@ describe("Parses all of the invalid IDLs to check that they blow up correctly", 
                     error = e;
                 }
                 finally {
-                    expect(error).to.be.ok();
-                    expect(error.message).to.equal(err.message);
-                    expect(error.line).to.equal(err.line);
+                    expect(error).toExist();
+                    expect(error.message).toEqual(err.message);
+                    expect(error.line).toEqual(err.line);
                 }
-                
+
             };
         }(idl, error));
         it("should produce the right error for " + i, func);


### PR DESCRIPTION
expect.js does not exist under node_modules/expect.js, where
test/web/make-web-test.js wrongly referenced. Besides, the expect.js
project (https://www.npmjs.com/package/expect.js) is not actively
maintained, expect (https://www.npmjs.com/package/expect) is an good
alternative library to be used.