### PR TITLE
Fix "default": undefined

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -287,7 +287,10 @@
             ret.name = name.value;
             if (ret.optional) {
                 all_ws();
-                ret["default"] = default_();
+                var dflt = default_();
+                if (typeof dflt !== "undefined") {
+                    ret["default"] = dflt;
+                }
             }
             return ret;
         };
@@ -831,14 +834,17 @@
                 var name = consume(ID) || error("No name for dictionary member");
                 var dflt = default_();
                 if (required && dflt) error("Required member must not have a default");
-                ret.members.push({
+                var member = {
                     type:       "field"
                 ,   name:       name.value
                 ,   required:   !!required
                 ,   idlType:    typ
                 ,   extAttrs:   ea
-                ,   "default":  dflt
-                });
+                };
+                if (typeof dflt !== "undefined") {
+                    member["default"] = dflt;
+                }
+                ret.members.push(member);
                 all_ws();
                 consume(OTHER, ";") || error("Unterminated dictionary member");
             }


### PR DESCRIPTION
`{"default": undefined}` in this 3 file.

```
test/syntax/idl/dictionary-inherits.widl
test/syntax/idl/dictionary.widl
test/syntax/idl/overloading.widl
```

tried this assertion in the `test/syntax.js`.

```js
assert.deepEqual(wp.parse(fs.readFileSync(idl, "utf8"), opt), JSON.parse(fs.readFileSync(json, "utf8")));
```
