### PR TITLE
Support namespaces

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -531,8 +531,15 @@
         var w = all_ws();
         if (w) grabbed.push(w);
       }
-      if (!consume(ID, "attribute")) {
+      var rest = attribute_rest(ret);
+      if (!rest) {
         tokens = grabbed.concat(tokens);
+      }
+      return rest;
+    };
+
+    var attribute_rest = function(ret) {
+      if (!consume(ID, "attribute")) {
         return;
       }
       all_ws();
@@ -787,11 +794,83 @@
       }
     };
 
+    var namespace = function(isPartial, store) {
+      all_ws(isPartial ? null : store, "pea");
+      if (!consume(ID, "namespace")) return;
+      all_ws();
+      var name = consume(ID) || error("No name for namespace");
+      var mems = [],
+        ret = {
+          type: "namespace",
+          name: name.value,
+          partial: isPartial,
+          members: mems
+        };
+      all_ws();
+      consume(OTHER, "{") || error("Bodyless namespace");
+      while (true) {
+        all_ws(store ? mems : null);
+        if (consume(OTHER, "}")) {
+          all_ws();
+          consume(OTHER, ";") || error("Missing semicolon after namespace");
+          return ret;
+        }
+        var ea = extended_attrs(store ? mems : null);
+        all_ws();
+        var mem = noninherited_attribute(store ? mems : null) ||
+          nonspecial_operation(store ? mems : null) ||
+          error("Unknown member");
+        mem.extAttrs = ea;
+        ret.members.push(mem);
+      }
+    }
+
+    var noninherited_attribute = function(store) {
+      var w = all_ws(store, "pea"), 
+        grabbed = [],
+        ret = {
+          type: "attribute",
+          "static": false,
+          stringifier: false,
+          inherit: false,
+          readonly: false
+        };
+      if (w) grabbed.push(w);
+      if (consume(ID, "readonly")) {
+        ret.readonly = true;
+        grabbed.push(last_token);
+        var w = all_ws();
+        if (w) grabbed.push(w);
+      }
+      var rest = attribute_rest(ret);
+      if (!rest) {
+        tokens = grabbed.concat(tokens);
+      }
+      return rest;
+    }
+    
+    var nonspecial_operation = function(store) {
+      all_ws(store, "pea");
+      var ret = {
+        type: "operation",
+        getter: false,
+        setter: false,
+        creator: false,
+        deleter: false,
+        legacycaller: false,
+        "static": false,
+        stringifier: false
+      };
+      ret.idlType = return_type();
+      return operation_rest(ret, store);
+    }
+
     var partial = function(store) {
       all_ws(store, "pea");
       if (!consume(ID, "partial")) return;
       var thing = dictionary(true, store) ||
         interface_(true, store) ||
+        namespace(true, store) ||
         error("Partial doesn't apply to anything");
       thing.partial = true;
       return thing;
@@ -969,7 +1048,8 @@
         exception(store) ||
         enum_(store) ||
         typedef(store) ||
-        implements_(store);
+        implements_(store) ||
+        namespace(false, store);
     };
 
     var definitions = function(store) {

--- a/test/syntax/idl/namespace.widl
+++ b/test/syntax/idl/namespace.widl
@@ -1,0 +1,10 @@
+// Extracted from Web IDL editors draft March 27 2017
+namespace VectorUtils {
+  readonly attribute Vector unit;
+  double dotProduct(Vector x, Vector y);
+  Vector crossProduct(Vector x, Vector y);
+};
+
+partial namespace SomeNamespace {
+  /* namespace_members... */
+};

--- a/test/syntax/json/namespace.json
+++ b/test/syntax/json/namespace.json
@@ -1,0 +1,134 @@
+[
+    {
+        "type": "namespace",
+        "name": "VectorUtils",
+        "partial": false,
+        "members": [
+            {
+                "type": "attribute",
+                "static": false,
+                "stringifier": false,
+                "inherit": false,
+                "readonly": true,
+                "idlType": {
+                    "sequence": false,
+                    "generic": null,
+                    "nullable": false,
+                    "array": false,
+                    "union": false,
+                    "idlType": "Vector"
+                },
+                "name": "unit",
+                "extAttrs": []
+            },
+            {
+                "type": "operation",
+                "getter": false,
+                "setter": false,
+                "creator": false,
+                "deleter": false,
+                "legacycaller": false,
+                "static": false,
+                "stringifier": false,
+                "idlType": {
+                    "sequence": false,
+                    "generic": null,
+                    "nullable": false,
+                    "array": false,
+                    "union": false,
+                    "idlType": "double"
+                },
+                "name": "dotProduct",
+                "arguments": [
+                    {
+                        "optional": false,
+                        "variadic": false,
+                        "extAttrs": [],
+                        "idlType": {
+                            "sequence": false,
+                            "generic": null,
+                            "nullable": false,
+                            "array": false,
+                            "union": false,
+                            "idlType": "Vector"
+                        },
+                        "name": "x"
+                    },
+                    {
+                        "optional": false,
+                        "variadic": false,
+                        "extAttrs": [],
+                        "idlType": {
+                            "sequence": false,
+                            "generic": null,
+                            "nullable": false,
+                            "array": false,
+                            "union": false,
+                            "idlType": "Vector"
+                        },
+                        "name": "y"
+                    }
+                ],
+                "extAttrs": []
+            },
+            {
+                "type": "operation",
+                "getter": false,
+                "setter": false,
+                "creator": false,
+                "deleter": false,
+                "legacycaller": false,
+                "static": false,
+                "stringifier": false,
+                "idlType": {
+                    "sequence": false,
+                    "generic": null,
+                    "nullable": false,
+                    "array": false,
+                    "union": false,
+                    "idlType": "Vector"
+                },
+                "name": "crossProduct",
+                "arguments": [
+                    {
+                        "optional": false,
+                        "variadic": false,
+                        "extAttrs": [],
+                        "idlType": {
+                            "sequence": false,
+                            "generic": null,
+                            "nullable": false,
+                            "array": false,
+                            "union": false,
+                            "idlType": "Vector"
+                        },
+                        "name": "x"
+                    },
+                    {
+                        "optional": false,
+                        "variadic": false,
+                        "extAttrs": [],
+                        "idlType": {
+                            "sequence": false,
+                            "generic": null,
+                            "nullable": false,
+                            "array": false,
+                            "union": false,
+                            "idlType": "Vector"
+                        },
+                        "name": "y"
+                    }
+                ],
+                "extAttrs": []
+            }
+        ],
+        "extAttrs": []
+    },
+    {
+        "type": "namespace",
+        "name": "SomeNamespace",
+        "partial": true,
+        "members": [],
+        "extAttrs": []
+    }
+]


### PR DESCRIPTION
Fixes #51. Specifically this adds `namespace`, `noninherited_attribute` and `nonspecial_operation` functions to match the namespace syntax.