### PR TITLE
Fix whitespace error on parsing extended attributes

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -379,6 +379,7 @@
           eas.push(simple_extended_attr(store) || error("Trailing comma in extended attribute"));
         }
       }
+      all_ws();
       consume(OTHER, "]") || error("No end of extended attribute");
       return eas;
     };

--- a/test/syntax/idl/extended-attributes.widl
+++ b/test/syntax/idl/extended-attributes.widl
@@ -9,3 +9,15 @@ interface ServiceWorkerGlobalScope : WorkerGlobalScope {
 // Section 3.11
 [IntAttr=0, FloatAttr=3.14, StringAttr="abc"]
 interface IdInterface {};
+
+// Extracted from http://www.w3.org/TR/2016/REC-WebIDL-1-20161215/#Constructor on 2017-5-18 with whitespace differences
+[
+  Constructor,
+  Constructor(double radius)
+]
+interface Circle {
+  attribute double r;
+  attribute double cx;
+  attribute double cy;
+  readonly attribute double circumference;
+};

--- a/test/syntax/json/extended-attributes.json
+++ b/test/syntax/json/extended-attributes.json
@@ -59,5 +59,101 @@
           }
         }
       ]
+    },
+    {
+      "type": "interface",
+      "name": "Circle",
+      "partial": false,
+      "members": [
+        {
+          "type": "attribute",
+          "static": false,
+          "stringifier": false,
+          "inherit": false,
+          "readonly": false,
+          "idlType": {
+            "sequence": false,
+            "generic": null,
+            "nullable": false,
+            "union": false,
+            "idlType": "double"
+          },
+          "name": "r",
+          "extAttrs": []
+        },
+        {
+          "type": "attribute",
+          "static": false,
+          "stringifier": false,
+          "inherit": false,
+          "readonly": false,
+          "idlType": {
+            "sequence": false,
+            "generic": null,
+            "nullable": false,
+            "union": false,
+            "idlType": "double"
+          },
+          "name": "cx",
+          "extAttrs": []
+        },
+        {
+          "type": "attribute",
+          "static": false,
+          "stringifier": false,
+          "inherit": false,
+          "readonly": false,
+          "idlType": {
+            "sequence": false,
+            "generic": null,
+            "nullable": false,
+            "union": false,
+            "idlType": "double"
+          },
+          "name": "cy",
+          "extAttrs": []
+        },
+        {
+          "type": "attribute",
+          "static": false,
+          "stringifier": false,
+          "inherit": false,
+          "readonly": true,
+          "idlType": {
+            "sequence": false,
+            "generic": null,
+            "nullable": false,
+            "union": false,
+            "idlType": "double"
+          },
+          "name": "circumference",
+          "extAttrs": []
+        }
+      ],
+      "inheritance": null,
+      "extAttrs": [
+        {
+          "name": "Constructor",
+          "arguments": null
+        },
+        {
+          "name": "Constructor",
+          "arguments": [
+            {
+              "optional": false,
+              "variadic": false,
+              "extAttrs": [],
+              "idlType": {
+                "sequence": false,
+                "generic": null,
+                "nullable": false,
+                "union": false,
+                "idlType": "double"
+              },
+              "name": "radius"
+            }
+          ]
+        }
+      ]
     }
 ]


### PR DESCRIPTION
```WebIDL
[
  Constructor,
  Constructor(double radius)
] // Currently errors here because the parser does not consume whitespaces before consuming bracket
interface Circle {
  attribute double r;
  attribute double cx;
  attribute double cy;
  readonly attribute double circumference;
};
```