### PR TITLE
Test for latest LTS/stable node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
-  - "0.10"
+  - node
+  - 6
+  - 4

--- a/package.json
+++ b/package.json
@@ -11,10 +11,7 @@
   "devDependencies": {
     "mocha": "3.4.1",
     "expect": "1.20.2",
-    "underscore": "1.8.3",
-    "jsondiffpatch": "0.2.4",
-    "benchmark": "*",
-    "microtime": "2.1.3"
+    "jsondiffpatch": "0.2.4"
   },
   "scripts": {
     "test": "mocha"


### PR DESCRIPTION
1. Add Node LTS and stable branches to CI
2. Remove unused dependencies (specifically `microtime` fails to build on Node 7 with unknown reason)