### PR TITLE
Support TypeWithExtendedAttributes on generics

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -195,7 +195,7 @@
           var types = [];
           do {
             all_ws();
-            types.push(type() || error("Error parsing generic type " + value));
+            types.push(type_with_extended_attributes() || error("Error parsing generic type " + value));
             all_ws();
           }
           while (consume(OTHER, ","));
@@ -206,6 +206,9 @@
             if (!/^(DOMString|USVString|ByteString)$/.test(types[0].idlType)) {
               error("Record key must be DOMString, USVString, or ByteString");
             }
+            if (types[0].extAttrs) error("Record key cannot have extended attribute");
+          } else if (value === "Promise") {
+            if (types[0].extAttrs) error("Promise type cannot have extended attribute");
           }
           ret.idlType = types.length === 1 ? types[0] : types;
           all_ws();

--- a/test/invalid/idl/promise-with-extended-attribute.widl
+++ b/test/invalid/idl/promise-with-extended-attribute.widl
@@ -1,0 +1,3 @@
+interface Foo {
+  Promise<[XAttr] DOMString> foo(any param);
+};

--- a/test/invalid/idl/record-key-with-extended-attribute.widl
+++ b/test/invalid/idl/record-key-with-extended-attribute.widl
@@ -1,0 +1,3 @@
+interface Foo {
+  void foo(record<[XAttr] DOMString, any> param);
+};

--- a/test/invalid/json/promise-with-extended-attribute.json
+++ b/test/invalid/json/promise-with-extended-attribute.json
@@ -1,0 +1,4 @@
+{
+    "message": "Promise type cannot have extended attribute",
+    "line": 2
+}

--- a/test/invalid/json/record-key-with-extended-attribute.json
+++ b/test/invalid/json/record-key-with-extended-attribute.json
@@ -1,0 +1,4 @@
+{
+    "message": "Record key cannot have extended attribute",
+    "line": 2
+}

--- a/test/syntax/idl/iterable.widl
+++ b/test/syntax/idl/iterable.widl
@@ -5,3 +5,7 @@ interface IterableOne {
 interface IterableTwo {
 	iterable<short, double?>;
 };
+
+interface IterableThree {
+	iterable<[XAttr] long>;
+};

--- a/test/syntax/idl/maplike.widl
+++ b/test/syntax/idl/maplike.widl
@@ -5,3 +5,9 @@ interface MapLike {
 interface ReadOnlyMapLike {
 	readonly maplike<long, float>;
 };
+
+// Extracted from https://heycam.github.io/webidl/#idl-type-extended-attribute-associated-with on 2017-07-01
+
+interface I {
+    maplike<[XAttr2] DOMString, [XAttr3] long>;
+};

--- a/test/syntax/idl/record.widl
+++ b/test/syntax/idl/record.widl
@@ -6,3 +6,7 @@ interface Foo {
   // Make sure record can still be registered as a type.
   record baz();
 };
+
+interface Bar {
+  record<DOMString, [XAttr] float> bar();
+};

--- a/test/syntax/idl/sequence.widl
+++ b/test/syntax/idl/sequence.widl
@@ -10,3 +10,9 @@ interface Canvas {
 interface Foo {
   sequence bar();
 };
+
+// Extracted from https://heycam.github.io/webidl/#idl-type-extended-attribute-associated-with on 2017-07-01
+
+interface I {
+    void f1(sequence<[XAttr] long> arg);
+};

--- a/test/syntax/idl/setlike.widl
+++ b/test/syntax/idl/setlike.widl
@@ -5,3 +5,7 @@ interface SetLike {
 interface ReadOnlySetLike {
 	readonly setlike<long>;
 };
+
+interface SetLikeExt {
+	setlike<[XAttr] long>;
+};

--- a/test/syntax/json/iterable.json
+++ b/test/syntax/json/iterable.json
@@ -47,6 +47,32 @@
         ],
         "inheritance": null,
         "extAttrs": []
+    },
+    {
+        "type": "interface",
+        "name": "IterableThree",
+        "partial": false,
+        "members": [
+            {
+                "type": "iterable",
+                "idlType": {
+                    "sequence": false,
+                    "generic": null,
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "long",
+                    "extAttrs": [
+                        {
+                            "name": "XAttr",
+                            "arguments": null
+                        }
+                    ]
+                },
+                "extAttrs": []
+            }
+        ],
+        "inheritance": null,
+        "extAttrs": []
     }
 ]
 

--- a/test/syntax/json/maplike.json
+++ b/test/syntax/json/maplike.json
@@ -58,6 +58,48 @@
         ],
         "inheritance": null,
         "extAttrs": []
+    },
+    {
+        "type": "interface",
+        "name": "I",
+        "partial": false,
+        "members": [
+            {
+                "type": "maplike",
+                "idlType": [
+                    {
+                        "sequence": false,
+                        "generic": null,
+                        "nullable": false,
+                        "union": false,
+                        "idlType": "DOMString",
+                        "extAttrs": [
+                            {
+                                "name": "XAttr2",
+                                "arguments": null
+                            }
+                        ]
+                    },
+                    {
+                        "sequence": false,
+                        "generic": null,
+                        "nullable": false,
+                        "union": false,
+                        "idlType": "long",
+                        "extAttrs": [
+                            {
+                                "name": "XAttr3",
+                                "arguments": null
+                            }
+                        ]
+                    }
+                ],
+                "readonly": false,
+                "extAttrs": []
+            }
+        ],
+        "inheritance": null,
+        "extAttrs": []
     }
 ]
 

--- a/test/syntax/json/record.json
+++ b/test/syntax/json/record.json
@@ -166,5 +166,55 @@
                 ]
             }
         ]
+    },
+    {
+        "type": "interface",
+        "name": "Bar",
+        "partial": false,
+        "members": [
+            {
+                "type": "operation",
+                "getter": false,
+                "setter": false,
+                "creator": false,
+                "deleter": false,
+                "legacycaller": false,
+                "static": false,
+                "stringifier": false,
+                "idlType": {
+                    "sequence": false,
+                    "generic": "record",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": [
+                        {
+                            "sequence": false,
+                            "generic": null,
+                            "nullable": false,
+                            "union": false,
+                            "idlType": "DOMString"
+                        },
+                        {
+                            "sequence": false,
+                            "generic": null,
+                            "nullable": false,
+                            "union": false,
+                            "idlType": "float",
+                            "extAttrs": [
+                                {
+                                    "name": "XAttr",
+                                    "arguments": null
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "name": "bar",
+                "arguments": [],
+                "extAttrs": []
+            }
+        ],
+        "inheritance": null,
+        "extAttrs": []
     }
 ]

--- a/test/syntax/json/sequence.json
+++ b/test/syntax/json/sequence.json
@@ -103,5 +103,61 @@
         ],
         "inheritance": null,
         "extAttrs": []
-    }    
+    },
+    
+    {
+        "type": "interface",
+        "name": "I",
+        "partial": false,
+        "members": [
+            {
+                "type": "operation",
+                "getter": false,
+                "setter": false,
+                "creator": false,
+                "deleter": false,
+                "legacycaller": false,
+                "static": false,
+                "stringifier": false,
+                "idlType": {
+                    "sequence": false,
+                    "generic": null,
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "void"
+                },
+                "name": "f1",
+                "arguments": [
+                    {
+                        "optional": false,
+                        "variadic": false,
+                        "extAttrs": [],
+                        "idlType": {
+                            "sequence": true,
+                            "generic": "sequence",
+                            "nullable": false,
+                            "union": false,
+                            "idlType": {
+                                "sequence": false,
+                                "generic": null,
+                                "nullable": false,
+                                "union": false,
+                                "idlType": "long",
+                                "extAttrs": [
+                                    {
+                                        "name": "XAttr",
+                                        "arguments": null
+                                    }
+                                ]
+                            }
+                        },
+                        "name": "arg"
+                    }
+                ],
+                "extAttrs": []
+            }
+        ],
+        "inheritance": null,
+        "extAttrs": []
+    }
 ]

--- a/test/syntax/json/setlike.json
+++ b/test/syntax/json/setlike.json
@@ -40,6 +40,33 @@
         ],
         "inheritance": null,
         "extAttrs": []
+    },
+    {
+        "type": "interface",
+        "name": "SetLikeExt",
+        "partial": false,
+        "members": [
+            {
+                "type": "setlike",
+                "idlType": {
+                    "sequence": false,
+                    "generic": null,
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "long",
+                    "extAttrs": [
+                        {
+                            "name": "XAttr",
+                            "arguments": null
+                        }
+                    ]
+                },
+                "readonly": false,
+                "extAttrs": []
+            }
+        ],
+        "inheritance": null,
+        "extAttrs": []
     }
 ]
 


### PR DESCRIPTION
... which includes `sequence`, `FrozenArray` and `record`. `Promise` is intentionally not supported because of [the spec](https://heycam.github.io/webidl/#idl-types):

```
PromiseType ::
    Promise < ReturnType >
```