### PR TITLE
BREAKING CHANGE: Use ES2015 syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
   - node
+  - lts/*
   - 6
-  - 4

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -1,21 +1,22 @@
+"use strict";
+
 (function() {
-  var tokenise = function(str) {
-    var tokens = [],
-      re = {
-        "float": /^-?(([0-9]+\.[0-9]*|[0-9]*\.[0-9]+)([Ee][-+]?[0-9]+)?|[0-9]+[Ee][-+]?[0-9]+)/,
-        "integer": /^-?(0([Xx][0-9A-Fa-f]+|[0-7]*)|[1-9][0-9]*)/,
-        "identifier": /^[A-Z_a-z][0-9A-Z_a-z-]*/,
-        "string": /^"[^"]*"/,
-        "whitespace": /^(?:[\t\n\r ]+|[\t\n\r ]*((\/\/.*|\/\*(.|\n|\r)*?\*\/)[\t\n\r ]*))+/,
-        "other": /^[^\t\n\r 0-9A-Z_a-z]/
-      },
-      types = ["float", "integer", "identifier", "string", "whitespace", "other"];
+  function tokenise(str) {
+    const tokens = [];
+    const re = {
+      "float": /^-?(([0-9]+\.[0-9]*|[0-9]*\.[0-9]+)([Ee][-+]?[0-9]+)?|[0-9]+[Ee][-+]?[0-9]+)/,
+      "integer": /^-?(0([Xx][0-9A-Fa-f]+|[0-7]*)|[1-9][0-9]*)/,
+      "identifier": /^[A-Z_a-z][0-9A-Z_a-z-]*/,
+      "string": /^"[^"]*"/,
+      "whitespace": /^(?:[\t\n\r ]+|[\t\n\r ]*((\/\/.*|\/\*(.|\n|\r)*?\*\/)[\t\n\r ]*))+/,
+      "other": /^[^\t\n\r 0-9A-Z_a-z]/
+    };
+    const types = ["float", "integer", "identifier", "string", "whitespace", "other"];
     while (str.length > 0) {
-      var matched = false;
-      for (var i = 0, n = types.length; i < n; i++) {
-        var type = types[i];
-        str = str.replace(re[type], function(tok) {
-          tokens.push({ type: type, value: tok });
+      let matched = false;
+      for (const type of types) {
+        str = str.replace(re[type], tok => {
+          tokens.push({ type, value: tok });
           matched = true;
           return "";
         });
@@ -27,41 +28,42 @@
     return tokens;
   };
 
-  function WebIDLParseError(str, line, input, tokens) {
-    this.message = str;
-    this.line = line;
-    this.input = input;
-    this.tokens = tokens;
-  };
+  class WebIDLParseError {
+    constructor(str, line, input, tokens) {
+      this.message = str;
+      this.line = line;
+      this.input = input;
+      this.tokens = tokens;
+    }
 
-  WebIDLParseError.prototype.toString = function() {
-    return this.message + ", line " + this.line + " (tokens: '" + this.input + "')\n" +
-      JSON.stringify(this.tokens, null, 4);
-  };
+    toString() {
+      return `${this.message}, line ${this.line} (tokens: '${this.input}')\n${JSON.stringify(this.tokens, null, 4)}`;
+    }
+  }
 
-  var parse = function(tokens, opt) {
-    var line = 1;
+  function parse(tokens, opt) {
+    let line = 1;
     tokens = tokens.slice();
-    var names = new Map();
+    const names = new Map();
 
-    var FLOAT = "float",
-      INT = "integer",
-      ID = "identifier",
-      STR = "string",
-      OTHER = "other";
+    const FLOAT = "float";
+    const INT = "integer";
+    const ID = "identifier";
+    const STR = "string";
+    const OTHER = "other";
 
-    var error = function(str) {
-      var tok = "";
-      var numTokens = 0;
-      var maxTokens = 5;
+    function error(str) {
+      let tok = "";
+      let numTokens = 0;
+      const maxTokens = 5;
       while (numTokens < maxTokens && tokens.length > numTokens) {
         tok += tokens[numTokens].value;
         numTokens++;
       }
-      throw new WebIDLParseError(str, line, tok, tokens.slice(0, 5));
+      throw new WebIDLParseError(str, line, tok, tokens.slice(0, maxTokens));
     };
 
-    var sanitize_name = function(name, type) {
+    function sanitize_name(name, type) {
       if (names.has(name)) {
         error(`The name "${name}" of type "${names.get(name)}" is already seen`);
       }
@@ -69,9 +71,9 @@
       return name;
     }
 
-    var last_token = null;
+    let last_token = null;
 
-    var consume = function(type, value) {
+    function consume(type, value) {
       if (!tokens.length || tokens[0].type !== type) return;
       if (typeof value === "undefined" || tokens[0].value === value) {
         last_token = tokens.shift();
@@ -80,38 +82,39 @@
       }
     };
 
-    var ws = function() {
+    function ws() {
       if (!tokens.length) return;
       if (tokens[0].type === "whitespace") {
-        var t = tokens.shift();
-        t.value.replace(/\n/g, function(m) { line++;
-          return m; });
+        const t = tokens.shift();
+        t.value.replace(/\n/g, m => {
+          line++;
+          return m;
+        });
         return t;
       }
     };
 
-    var all_ws = function(store, pea) { // pea == post extended attribute, tpea = same for types
-      var t = { type: "whitespace", value: "" };
+    function all_ws(store, pea) { // pea == post extended attribute, tpea = same for types
+      const t = { type: "whitespace", value: "" };
       while (true) {
-        var w = ws();
+        const w = ws();
         if (!w) break;
         t.value += w.value;
       }
       if (t.value.length > 0) {
         if (store) {
-          var w = t.value,
-            re = {
-              "ws": /^([\t\n\r ]+)/,
-              "line-comment": /^\/\/(.*)\n?/m,
-              "multiline-comment": /^\/\*((?:.|\n|\r)*?)\*\//
-            },
-            wsTypes = [];
-          for (var k in re) wsTypes.push(k);
+          let w = t.value;
+          const re = {
+            "ws": /^([\t\n\r ]+)/,
+            "line-comment": /^\/\/(.*)\n?/m,
+            "multiline-comment": /^\/\*((?:.|\n|\r)*?)\*\//
+          };
+          const wsTypes = [];
+          for (const k in re) wsTypes.push(k);
           while (w.length) {
-            var matched = false;
-            for (var i = 0, n = wsTypes.length; i < n; i++) {
-              var type = wsTypes[i];
-              w = w.replace(re[type], function(tok, m1) {
+            let matched = false;
+            for (const type of wsTypes) {
+              w = w.replace(re[type], (tok, m1) => {
                 store.push({ type: type + (pea ? ("-" + pea) : ""), value: m1 });
                 matched = true;
                 return "";
@@ -126,8 +129,8 @@
       }
     };
 
-    var integer_type = function() {
-      var ret = "";
+    function integer_type() {
+      let ret = "";
       all_ws();
       if (consume(ID, "unsigned")) ret = "unsigned ";
       all_ws();
@@ -141,8 +144,8 @@
       if (ret) error("Failed to parse integer type");
     };
 
-    var float_type = function() {
-      var ret = "";
+    function float_type() {
+      let ret = "";
       all_ws();
       if (consume(ID, "unrestricted")) ret = "unrestricted ";
       all_ws();
@@ -151,8 +154,8 @@
       if (ret) error("Failed to parse float type");
     };
 
-    var primitive_type = function() {
-      var num_type = integer_type() || float_type();
+    function primitive_type() {
+      const num_type = integer_type() || float_type();
       if (num_type) return num_type;
       all_ws();
       if (consume(ID, "boolean")) return "boolean";
@@ -160,22 +163,22 @@
       if (consume(ID, "octet")) return "octet";
     };
 
-    var const_value = function() {
+    function const_value() {
       if (consume(ID, "true")) return { type: "boolean", value: true };
       if (consume(ID, "false")) return { type: "boolean", value: false };
       if (consume(ID, "null")) return { type: "null" };
       if (consume(ID, "Infinity")) return { type: "Infinity", negative: false };
       if (consume(ID, "NaN")) return { type: "NaN" };
-      var ret = consume(FLOAT) || consume(INT);
+      const ret = consume(FLOAT) || consume(INT);
       if (ret) return { type: "number", value: 1 * ret.value };
-      var tok = consume(OTHER, "-");
+      const tok = consume(OTHER, "-");
       if (tok) {
         if (consume(ID, "Infinity")) return { type: "Infinity", negative: true };
         else tokens.unshift(tok);
       }
     };
 
-    var type_suffix = function(obj) {
+    function type_suffix(obj) {
       while (true) {
         all_ws();
         if (consume(OTHER, "?")) {
@@ -185,10 +188,11 @@
       }
     };
 
-    var single_type = function() {
-      var prim = primitive_type(),
-        ret = { sequence: false, generic: null, nullable: false, union: false },
-        name, value;
+    function single_type() {
+      const prim = primitive_type();
+      const ret = { sequence: false, generic: null, nullable: false, union: false };
+      let name;
+      let value;
       if (prim) {
         ret.idlType = prim;
       } else if (name = consume(ID)) {
@@ -201,7 +205,7 @@
             ret.sequence = true;
           }
           ret.generic = value;
-          var types = [];
+          const types = [];
           do {
             all_ws();
             types.push(type_with_extended_attributes() || error("Error parsing generic type " + value));
@@ -235,16 +239,16 @@
       return ret;
     };
 
-    var union_type = function() {
+    function union_type() {
       all_ws();
       if (!consume(OTHER, "(")) return;
-      var ret = { sequence: false, generic: null, nullable: false, union: true, idlType: [] };
-      var fst = type_with_extended_attributes() || error("Union type with no content");
+      const ret = { sequence: false, generic: null, nullable: false, union: true, idlType: [] };
+      const fst = type_with_extended_attributes() || error("Union type with no content");
       ret.idlType.push(fst);
       while (true) {
         all_ws();
         if (!consume(ID, "or")) break;
-        var typ = type_with_extended_attributes() || error("No type after 'or' in union type");
+        const typ = type_with_extended_attributes() || error("No type after 'or' in union type");
         ret.idlType.push(typ);
       }
       if (!consume(OTHER, ")")) error("Unterminated union type");
@@ -252,22 +256,22 @@
       return ret;
     };
 
-    var type = function() {
+    function type() {
       return single_type() || union_type();
     };
 
-    var type_with_extended_attributes = function() {
-      var extAttrs = extended_attrs();
-      var ret = single_type() || union_type();
+    function type_with_extended_attributes() {
+      const extAttrs = extended_attrs();
+      const ret = single_type() || union_type();
       if (extAttrs.length && ret) ret.extAttrs = extAttrs;
       return ret;
     };
 
-    var argument = function(store) {
-      var ret = { optional: false, variadic: false };
+    function argument(store) {
+      const ret = { optional: false, variadic: false };
       ret.extAttrs = extended_attrs(store);
       all_ws(store, "pea");
-      var opt_token = consume(ID, "optional");
+      const opt_token = consume(ID, "optional");
       if (opt_token) {
         ret.optional = true;
         all_ws();
@@ -277,7 +281,7 @@
         if (opt_token) tokens.unshift(opt_token);
         return;
       }
-      var type_token = last_token;
+      const type_token = last_token;
       if (!ret.optional) {
         all_ws();
         if (tokens.length >= 3 &&
@@ -292,7 +296,7 @@
         }
       }
       all_ws();
-      var name = consume(ID);
+      const name = consume(ID);
       if (!name) {
         if (opt_token) tokens.unshift(opt_token);
         tokens.unshift(type_token);
@@ -301,7 +305,7 @@
       ret.name = name.value;
       if (ret.optional) {
         all_ws();
-        var dflt = default_();
+        const dflt = default_();
         if (typeof dflt !== "undefined") {
           ret["default"] = dflt;
         }
@@ -309,31 +313,31 @@
       return ret;
     };
 
-    var argument_list = function(store) {
-      var ret = [],
-        arg = argument(store ? ret : null);
+    function argument_list(store) {
+      const ret = [];
+      const arg = argument(store ? ret : null);
       if (!arg) return;
       ret.push(arg);
       while (true) {
         all_ws(store ? ret : null);
         if (!consume(OTHER, ",")) return ret;
-        var nxt = argument(store ? ret : null) || error("Trailing comma in arguments list");
+        const nxt = argument(store ? ret : null) || error("Trailing comma in arguments list");
         ret.push(nxt);
       }
     };
 
-    var simple_extended_attr = function(store) {
+    function simple_extended_attr(store) {
       all_ws();
-      var name = consume(ID);
+      const name = consume(ID);
       if (!name) return;
-      var ret = {
+      const ret = {
         name: name.value,
         "arguments": null
       };
       all_ws();
-      var eq = consume(OTHER, "=");
+      const eq = consume(OTHER, "=");
       if (eq) {
-        var rhs;
+        let rhs;
         all_ws();
         if (rhs = consume(ID)) {
           ret.rhs = rhs;
@@ -346,7 +350,7 @@
         } else if (consume(OTHER, "(")) {
           // [Exposed=(Window,Worker)]
           rhs = [];
-          var id = consume(ID);
+          const id = consume(ID);
           if (id) {
             rhs = [id.value];
           }
@@ -361,7 +365,7 @@
       }
       all_ws();
       if (consume(OTHER, "(")) {
-        var args, pair;
+        let args, pair;
         // [Constructor(DOMString str)]
         if (args = argument_list(store)) {
           ret["arguments"] = args;
@@ -378,8 +382,8 @@
 
     // Note: we parse something simpler than the official syntax. It's all that ever
     // seems to be used
-    var extended_attrs = function(store) {
-      var eas = [];
+    function extended_attrs(store) {
+      const eas = [];
       all_ws(store);
       if (!consume(OTHER, "[")) return eas;
       eas[0] = simple_extended_attr(store) || error("Extended attribute with not content");
@@ -396,30 +400,30 @@
       return eas;
     };
 
-    var default_ = function() {
+    function default_() {
       all_ws();
       if (consume(OTHER, "=")) {
         all_ws();
-        var def = const_value();
+        const def = const_value();
         if (def) {
           return def;
         } else if (consume(OTHER, "[")) {
           if (!consume(OTHER, "]")) error("Default sequence value must be empty");
           return { type: "sequence", value: [] };
         } else {
-          var str = consume(STR) || error("No value for default");
+          const str = consume(STR) || error("No value for default");
           str.value = str.value.replace(/^"/, "").replace(/"$/, "");
           return str;
         }
       }
     };
 
-    var const_ = function(store) {
+    function const_(store) {
       all_ws(store, "pea");
       if (!consume(ID, "const")) return;
-      var ret = { type: "const", nullable: false };
+      const ret = { type: "const", nullable: false };
       all_ws();
-      var typ = primitive_type();
+      let typ = primitive_type();
       if (!typ) {
         typ = consume(ID) || error("No type for const");
         typ = typ.value;
@@ -430,12 +434,12 @@
         ret.nullable = true;
         all_ws();
       }
-      var name = consume(ID) || error("No name for const");
+      const name = consume(ID) || error("No name for const");
       ret.name = name.value;
       all_ws();
       consume(OTHER, "=") || error("No value assignment for const");
       all_ws();
-      var cnt = const_value();
+      const cnt = const_value();
       if (cnt) ret.value = cnt;
       else error("No value for const");
       all_ws();
@@ -443,19 +447,19 @@
       return ret;
     };
 
-    var inheritance = function() {
+    function inheritance() {
       all_ws();
       if (consume(OTHER, ":")) {
         all_ws();
-        var inh = consume(ID) || error("No type in inheritance");
+        const inh = consume(ID) || error("No type in inheritance");
         return inh.value;
       }
     };
 
-    var operation_rest = function(ret, store) {
+    function operation_rest(ret, store) {
       all_ws();
       if (!ret) ret = {};
-      var name = consume(ID);
+      const name = consume(ID);
       ret.name = name ? name.value : null;
       all_ws();
       consume(OTHER, "(") || error("Invalid operation");
@@ -467,19 +471,19 @@
       return ret;
     };
 
-    var callback = function(store) {
+    function callback(store) {
       all_ws(store, "pea");
-      var ret;
+      let ret;
       if (!consume(ID, "callback")) return;
       all_ws();
-      var tok = consume(ID, "interface");
+      const tok = consume(ID, "interface");
       if (tok) {
         tokens.unshift(tok);
         ret = interface_();
         ret.type = "callback interface";
         return ret;
       }
-      var name = consume(ID) || error("No name for callback");
+      const name = consume(ID) || error("No name for callback");
       ret = { type: "callback", name: sanitize_name(name.value, "callback") };
       all_ws();
       consume(OTHER, "=") || error("No assignment in callback");
@@ -495,16 +499,16 @@
       return ret;
     };
 
-    var attribute = function(store) {
+    function attribute(store) {
       all_ws(store, "pea");
-      var grabbed = [],
-        ret = {
-          type: "attribute",
-          "static": false,
-          stringifier: false,
-          inherit: false,
-          readonly: false
-        };
+      const grabbed = [];
+      const ret = {
+        type: "attribute",
+        "static": false,
+        stringifier: false,
+        inherit: false,
+        readonly: false
+      };
       if (consume(ID, "static")) {
         ret["static"] = true;
         grabbed.push(last_token);
@@ -512,29 +516,29 @@
         ret.stringifier = true;
         grabbed.push(last_token);
       }
-      var w = all_ws();
+      const w = all_ws();
       if (w) grabbed.push(w);
       if (consume(ID, "inherit")) {
         if (ret["static"] || ret.stringifier) error("Cannot have a static or stringifier inherit");
         ret.inherit = true;
         grabbed.push(last_token);
-        var w = all_ws();
+        const w = all_ws();
         if (w) grabbed.push(w);
       }
       if (consume(ID, "readonly")) {
         ret.readonly = true;
         grabbed.push(last_token);
-        var w = all_ws();
+        const w = all_ws();
         if (w) grabbed.push(w);
       }
-      var rest = attribute_rest(ret);
+      const rest = attribute_rest(ret);
       if (!rest) {
         tokens = grabbed.concat(tokens);
       }
       return rest;
     };
 
-    var attribute_rest = function(ret) {
+    function attribute_rest(ret) {
       if (!consume(ID, "attribute")) {
         return;
       }
@@ -543,15 +547,15 @@
       if (ret.idlType.sequence) error("Attributes cannot accept sequence types");
       if (ret.idlType.generic === "record") error("Attributes cannot accept record types");
       all_ws();
-      var name = consume(ID) || error("No name in attribute");
+      const name = consume(ID) || error("No name in attribute");
       ret.name = name.value;
       all_ws();
       consume(OTHER, ";") || error("Unterminated attribute");
       return ret;
     };
 
-    var return_type = function() {
-      var typ = type();
+    function return_type() {
+      const typ = type();
       if (!typ) {
         if (consume(ID, "void")) {
           return "void";
@@ -560,9 +564,9 @@
       return typ;
     };
 
-    var operation = function(store) {
+    function operation(store) {
       all_ws(store, "pea");
-      var ret = {
+      const ret = {
         type: "operation",
         getter: false,
         setter: false,
@@ -619,18 +623,18 @@
       }
     };
 
-    var identifiers = function(arr) {
+    function identifiers(arr) {
       while (true) {
         all_ws();
         if (consume(OTHER, ",")) {
           all_ws();
-          var name = consume(ID) || error("Trailing comma in identifiers list");
+          const name = consume(ID) || error("Trailing comma in identifiers list");
           arr.push(name.value);
         } else break;
       }
     };
 
-    var iterable_type = function() {
+    function iterable_type() {
       if (consume(ID, "iterable")) return "iterable";
       else if (consume(ID, "legacyiterable")) return "legacyiterable";
       else if (consume(ID, "maplike")) return "maplike";
@@ -638,41 +642,41 @@
       else return;
     };
 
-    var readonly_iterable_type = function() {
+    function readonly_iterable_type() {
       if (consume(ID, "maplike")) return "maplike";
       else if (consume(ID, "setlike")) return "setlike";
       else return;
     };
 
-    var iterable = function(store) {
+    function iterable(store) {
       all_ws(store, "pea");
-      var grabbed = [],
-        ret = { type: null, idlType: null, readonly: false };
+      const grabbed = [];
+      const ret = { type: null, idlType: null, readonly: false };
       if (consume(ID, "readonly")) {
         ret.readonly = true;
         grabbed.push(last_token);
         var w = all_ws();
         if (w) grabbed.push(w);
       }
-      var consumeItType = ret.readonly ? readonly_iterable_type : iterable_type;
+      const consumeItType = ret.readonly ? readonly_iterable_type : iterable_type;
 
-      var ittype = consumeItType();
+      const ittype = consumeItType();
       if (!ittype) {
         tokens = grabbed.concat(tokens);
         return;
       }
 
-      var secondTypeRequired = ittype === "maplike";
-      var secondTypeAllowed = secondTypeRequired || ittype === "iterable";
+      const secondTypeRequired = ittype === "maplike";
+      const secondTypeAllowed = secondTypeRequired || ittype === "iterable";
       ret.type = ittype;
       if (ret.type !== 'maplike' && ret.type !== 'setlike')
         delete ret.readonly;
       all_ws();
       if (consume(OTHER, "<")) {
-        ret.idlType = type_with_extended_attributes() || error("Error parsing " + ittype + " declaration");
+        ret.idlType = type_with_extended_attributes() || error(`Error parsing ${ittype} declaration`);
         all_ws();
         if (secondTypeAllowed) {
-          var type2 = null;
+          let type2 = null;
           if (consume(OTHER, ",")) {
             all_ws();
             type2 = type_with_extended_attributes();
@@ -681,29 +685,29 @@
           if (type2)
             ret.idlType = [ret.idlType, type2];
           else if (secondTypeRequired)
-            error("Missing second type argument in " + ittype + " declaration");
+            error(`Missing second type argument in ${ittype} declaration`);
         }
-        if (!consume(OTHER, ">")) error("Unterminated " + ittype + " declaration");
+        if (!consume(OTHER, ">")) error(`Unterminated ${ittype} declaration`);
         all_ws();
-        if (!consume(OTHER, ";")) error("Missing semicolon after " + ittype + " declaration");
+        if (!consume(OTHER, ";")) error(`Missing semicolon after ${ittype} declaration`);
       } else
-        error("Error parsing " + ittype + " declaration");
+        error(`Error parsing ${ittype} declaration`);
 
       return ret;
     };
 
-    var interface_ = function(isPartial, store) {
+    function interface_(isPartial, store) {
       all_ws(isPartial ? null : store, "pea");
       if (!consume(ID, "interface")) return;
       all_ws();
-      var name = consume(ID) || error("No name for interface");
-      var mems = [],
-        ret = {
-          type: "interface",
-          name: isPartial ? name.value : sanitize_name(name.value, "interface"),
-          partial: false,
-          members: mems
-        };
+      const name = consume(ID) || error("No name for interface");
+      const mems = [];
+      const ret = {
+        type: "interface",
+        name: isPartial ? name.value : sanitize_name(name.value, "interface"),
+        partial: false,
+        members: mems
+      };
       if (!isPartial) ret.inheritance = inheritance() || null;
       all_ws();
       consume(OTHER, "{") || error("Bodyless interface");
@@ -714,15 +718,15 @@
           consume(OTHER, ";") || error("Missing semicolon after interface");
           return ret;
         }
-        var ea = extended_attrs(store ? mems : null);
+        const ea = extended_attrs(store ? mems : null);
         all_ws();
-        var cnt = const_(store ? mems : null);
+        const cnt = const_(store ? mems : null);
         if (cnt) {
           cnt.extAttrs = ea;
           ret.members.push(cnt);
           continue;
         }
-        var mem = (opt.allowNestedTypedefs && typedef(store ? mems : null)) ||
+        const mem = (opt.allowNestedTypedefs && typedef(store ? mems : null)) ||
           iterable(store ? mems : null) ||
           attribute(store ? mems : null) ||
           operation(store ? mems : null) ||
@@ -732,18 +736,18 @@
       }
     };
 
-    var namespace = function(isPartial, store) {
+    function namespace(isPartial, store) {
       all_ws(isPartial ? null : store, "pea");
       if (!consume(ID, "namespace")) return;
       all_ws();
-      var name = consume(ID) || error("No name for namespace");
-      var mems = [],
-        ret = {
-          type: "namespace",
-          name: isPartial ? name.value : sanitize_name(name.value, "namespace"),
-          partial: isPartial,
-          members: mems
-        };
+      const name = consume(ID) || error("No name for namespace");
+      const mems = [];
+      const ret = {
+        type: "namespace",
+        name: isPartial ? name.value : sanitize_name(name.value, "namespace"),
+        partial: isPartial,
+        members: mems
+      };
       all_ws();
       consume(OTHER, "{") || error("Bodyless namespace");
       while (true) {
@@ -753,9 +757,9 @@
           consume(OTHER, ";") || error("Missing semicolon after namespace");
           return ret;
         }
-        var ea = extended_attrs(store ? mems : null);
+        const ea = extended_attrs(store ? mems : null);
         all_ws();
-        var mem = noninherited_attribute(store ? mems : null) ||
+        const mem = noninherited_attribute(store ? mems : null) ||
           nonspecial_operation(store ? mems : null) ||
           error("Unknown member");
         mem.extAttrs = ea;
@@ -763,33 +767,33 @@
       }
     }
 
-    var noninherited_attribute = function(store) {
-      var w = all_ws(store, "pea"), 
-        grabbed = [],
-        ret = {
-          type: "attribute",
-          "static": false,
-          stringifier: false,
-          inherit: false,
-          readonly: false
-        };
+    function noninherited_attribute(store) {
+      const w = all_ws(store, "pea");
+      const grabbed = [];
+      const ret = {
+        type: "attribute",
+        "static": false,
+        stringifier: false,
+        inherit: false,
+        readonly: false
+      };
       if (w) grabbed.push(w);
       if (consume(ID, "readonly")) {
         ret.readonly = true;
         grabbed.push(last_token);
-        var w = all_ws();
+        const w = all_ws();
         if (w) grabbed.push(w);
       }
-      var rest = attribute_rest(ret);
+      const rest = attribute_rest(ret);
       if (!rest) {
         tokens = grabbed.concat(tokens);
       }
       return rest;
     }
     
-    var nonspecial_operation = function(store) {
+    function nonspecial_operation(store) {
       all_ws(store, "pea");
-      var ret = {
+      const ret = {
         type: "operation",
         getter: false,
         setter: false,
@@ -802,10 +806,10 @@
       return operation_rest(ret, store);
     }
 
-    var partial = function(store) {
+    function partial(store) {
       all_ws(store, "pea");
       if (!consume(ID, "partial")) return;
-      var thing = dictionary(true, store) ||
+      const thing = dictionary(true, store) ||
         interface_(true, store) ||
         namespace(true, store) ||
         error("Partial doesn't apply to anything");
@@ -813,18 +817,18 @@
       return thing;
     };
 
-    var dictionary = function(isPartial, store) {
+    function dictionary(isPartial, store) {
       all_ws(isPartial ? null : store, "pea");
       if (!consume(ID, "dictionary")) return;
       all_ws();
-      var name = consume(ID) || error("No name for dictionary");
-      var mems = [],
-        ret = {
-          type: "dictionary",
-          name: isPartial ? name.value : sanitize_name(name.value, "dictionary"),
-          partial: false,
-          members: mems
-        };
+      const name = consume(ID) || error("No name for dictionary");
+      const mems = [];
+      const ret = {
+        type: "dictionary",
+        name: isPartial ? name.value : sanitize_name(name.value, "dictionary"),
+        partial: false,
+        members: mems
+      };
       if (!isPartial) ret.inheritance = inheritance() || null;
       all_ws();
       consume(OTHER, "{") || error("Bodyless dictionary");
@@ -835,15 +839,15 @@
           consume(OTHER, ";") || error("Missing semicolon after dictionary");
           return ret;
         }
-        var ea = extended_attrs(store ? mems : null);
+        const ea = extended_attrs(store ? mems : null);
         all_ws(store ? mems : null, "pea");
-        var required = consume(ID, "required");
-        var typ = type_with_extended_attributes() || error("No type for dictionary member");
+        const required = consume(ID, "required");
+        const typ = type_with_extended_attributes() || error("No type for dictionary member");
         all_ws();
-        var name = consume(ID) || error("No name for dictionary member");
-        var dflt = default_();
+        const name = consume(ID) || error("No name for dictionary member");
+        const dflt = default_();
         if (required && dflt) error("Required member must not have a default");
-        var member = {
+        const member = {
           type: "field",
           name: name.value,
           required: !!required,
@@ -859,20 +863,20 @@
       }
     };
 
-    var enum_ = function(store) {
+    const enum_ = function(store) {
       all_ws(store, "pea");
       if (!consume(ID, "enum")) return;
       all_ws();
-      var name = consume(ID) || error("No name for enum");
-      var vals = [],
-        ret = {
-          type: "enum",
-          name: sanitize_name(name.value, "enum"),
-          values: vals
-        };
+      const name = consume(ID) || error("No name for enum");
+      const vals = [];
+      const ret = {
+        type: "enum",
+        name: sanitize_name(name.value, "enum"),
+        values: vals
+      };
       all_ws();
       consume(OTHER, "{") || error("No curly for enum");
-      var saw_comma = false;
+      let saw_comma = false;
       while (true) {
         all_ws(store ? vals : null);
         if (consume(OTHER, "}")) {
@@ -880,7 +884,7 @@
           consume(OTHER, ";") || error("No semicolon after enum");
           return ret;
         }
-        var val = consume(STR) || error("Unexpected value in enum");
+        const val = consume(STR) || error("Unexpected value in enum");
         ret.values.push(val.value.replace(/"/g, ""));
         all_ws(store ? vals : null);
         if (consume(OTHER, ",")) {
@@ -893,34 +897,34 @@
       }
     };
 
-    var typedef = function(store) {
+    function typedef(store) {
       all_ws(store, "pea");
       if (!consume(ID, "typedef")) return;
-      var ret = {
+      const ret = {
         type: "typedef"
       };
       all_ws();
       ret.idlType = type_with_extended_attributes() || error("No type in typedef");
       all_ws();
-      var name = consume(ID) || error("No name in typedef");
+      const name = consume(ID) || error("No name in typedef");
       ret.name = sanitize_name(name.value, "typedef");
       all_ws();
       consume(OTHER, ";") || error("Unterminated typedef");
       return ret;
     };
 
-    var implements_ = function(store) {
+    function implements_(store) {
       all_ws(store, "pea");
-      var target = consume(ID);
+      const target = consume(ID);
       if (!target) return;
-      var w = all_ws();
+      const w = all_ws();
       if (consume(ID, "implements")) {
-        var ret = {
+        const ret = {
           type: "implements",
           target: target.value
         };
         all_ws();
-        var imp = consume(ID) || error("Incomplete implements statement");
+        const imp = consume(ID) || error("Incomplete implements statement");
         ret["implements"] = imp.value;
         all_ws();
         consume(OTHER, ";") || error("No terminating ; for implements statement");
@@ -932,7 +936,7 @@
       }
     };
 
-    var definition = function(store) {
+    function definition(store) {
       return callback(store) ||
         interface_(false, store) ||
         partial(store) ||
@@ -943,12 +947,12 @@
         namespace(false, store);
     };
 
-    var definitions = function(store) {
+    function definitions(store) {
       if (!tokens.length) return [];
-      var defs = [];
+      const defs = [];
       while (true) {
-        var ea = extended_attrs(store ? defs : null),
-          def = definition(store ? defs : null);
+        const ea = extended_attrs(store ? defs : null);
+        const def = definition(store ? defs : null);
         if (!def) {
           if (ea.length) error("Stray extended attributes");
           break;
@@ -958,15 +962,15 @@
       }
       return defs;
     };
-    var res = definitions(opt.ws);
+    const res = definitions(opt.ws);
     if (tokens.length) error("Unrecognised tokens");
     return res;
   };
 
-  var obj = {
-    parse: function(str, opt) {
+  const obj = {
+    parse(str, opt) {
       if (!opt) opt = {};
-      var tokens = tokenise(str);
+      const tokens = tokenise(str);
       return parse(tokens, opt);
     }
   };
@@ -974,9 +978,7 @@
   if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
     module.exports = obj;
   } else if (typeof define === 'function' && define.amd) {
-    define([], function() {
-      return obj;
-    });
+    define([], () => obj);
   } else {
     (self || window).WebIDL2 = obj;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,7 +2,6 @@
   "name": "webidl2",
   "version": "4.2.0",
   "lockfileVersion": 1,
-  "requires": true,
   "dependencies": {
     "ansi-regex": {
       "version": "0.2.1",
@@ -16,6 +15,24 @@
       "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
       "dev": true
     },
+    "arr-diff": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "dev": true
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "array-unique": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "dev": true
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -26,11 +43,13 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true,
-      "requires": {
-        "balanced-match": "1.0.0",
-        "concat-map": "0.0.1"
-      }
+      "dev": true
+    },
+    "braces": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "dev": true
     },
     "browser-stdout": {
       "version": "1.3.0",
@@ -42,23 +61,25 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
       "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "1.1.0",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "0.1.0",
-        "strip-ansi": "0.3.0",
-        "supports-color": "0.2.0"
-      }
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "dev": true
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "commander": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true,
-      "requires": {
-        "graceful-readlink": "1.0.1"
-      }
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -70,20 +91,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
       "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-      "dev": true,
-      "requires": {
-        "ms": "0.7.2"
-      }
-    },
-    "define-properties": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "dev": true,
-      "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
-      }
+      "dev": true
     },
     "diff": {
       "version": "3.2.0",
@@ -91,55 +99,66 @@
       "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
       "dev": true
     },
-    "es-abstract": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.2.tgz",
-      "integrity": "sha512-dvhwFL3yjQxNNsOWx6exMlaDrRHCRGMQlnx5lsXDCZ/J7G/frgIIl94zhZSp/galVAYp7VzPi1OrAHta89/yGQ==",
-      "dev": true,
-      "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.1",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
-      }
-    },
-    "es-to-primitive": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-      "dev": true,
-      "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
-      }
-    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "expand-brackets": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "dev": true
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "dev": true
+    },
     "expect": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-1.20.2.tgz",
-      "integrity": "sha1-1Fj+TFYAQDa64yMkFqP2Nh8E+WU=",
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-21.2.1.tgz",
+      "integrity": "sha512-orfQQqFRTX0jH7znRIGi8ZMR8kTNpXklTTz8+HGTpmTKZo3Occ6JNB5FXMb8cRuiiC/GyDqsr30zUa66ACYlYw==",
       "dev": true,
-      "requires": {
-        "define-properties": "1.1.2",
-        "has": "1.0.1",
-        "is-equal": "1.5.5",
-        "is-regex": "1.0.4",
-        "object-inspect": "1.3.0",
-        "object-keys": "1.0.11",
-        "tmatch": "2.0.1"
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true
+        }
       }
     },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+    "extglob": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "dev": true
+    },
+    "filename-regex": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+      "dev": true
+    },
+    "fill-range": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "dev": true
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true
     },
     "fs.realpath": {
@@ -148,25 +167,23 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
-    },
     "glob": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-      "dev": true,
-      "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
-      }
+      "dev": true
+    },
+    "glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "dev": true
+    },
+    "glob-parent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "dev": true
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -180,23 +197,11 @@
       "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true
     },
-    "has": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "dev": true,
-      "requires": {
-        "function-bind": "1.1.1"
-      }
-    },
     "has-ansi": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
       "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "0.2.1"
-      }
+      "dev": true
     },
     "has-flag": {
       "version": "1.0.0",
@@ -208,11 +213,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
-      "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
-      }
+      "dev": true
     },
     "inherits": {
       "version": "2.0.3",
@@ -220,83 +221,178 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
-    "is-arrow-function": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-arrow-function/-/is-arrow-function-2.0.3.tgz",
-      "integrity": "sha1-Kb4sLY2UUIUri7r7Y1unuNjofsI=",
-      "dev": true,
-      "requires": {
-        "is-callable": "1.1.3"
-      }
-    },
-    "is-boolean-object": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.0.tgz",
-      "integrity": "sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M=",
+    "is-buffer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
       "dev": true
     },
-    "is-callable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
-      "dev": true
-    },
-    "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
-    },
-    "is-equal": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/is-equal/-/is-equal-1.5.5.tgz",
-      "integrity": "sha1-XoXxlX4FKIMkf+s4aWWju6Ffuz0=",
-      "dev": true,
-      "requires": {
-        "has": "1.0.1",
-        "is-arrow-function": "2.0.3",
-        "is-boolean-object": "1.0.0",
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-generator-function": "1.0.6",
-        "is-number-object": "1.0.3",
-        "is-regex": "1.0.4",
-        "is-string": "1.0.4",
-        "is-symbol": "1.0.1",
-        "object.entries": "1.0.4"
-      }
-    },
-    "is-generator-function": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.6.tgz",
-      "integrity": "sha1-nnFlPNFf/zQcecQVFGChMdMen8Q=",
-      "dev": true
-    },
-    "is-number-object": {
+    "is-dotfile": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.3.tgz",
-      "integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k=",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
       "dev": true
     },
-    "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "dev": true
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "dev": true
+    },
+    "is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "dev": true
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+      "dev": true
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "dev": true
+    },
+    "jest-diff": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-21.2.1.tgz",
+      "integrity": "sha512-E5fu6r7PvvPr5qAWE1RaUwIh/k6Zx/3OOkZ4rk5dBJkEWRrUuSgbMt2EO8IUTPTd6DOqU3LW6uTIwX5FRvXoFA==",
       "dev": true,
-      "requires": {
-        "has": "1.0.1"
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true
+        }
       }
     },
-    "is-string": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
-      "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ=",
+    "jest-get-type": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
+      "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
       "dev": true
     },
-    "is-symbol": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+    "jest-matcher-utils": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz",
+      "integrity": "sha512-kn56My+sekD43dwQPrXBl9Zn9tAqwoy25xxe7/iY4u+mG8P3ALj5IK7MLHZ4Mi3xW7uWVCjGY8cm4PqgbsqMCg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true
+        }
+      }
+    },
+    "jest-message-util": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-21.2.1.tgz",
+      "integrity": "sha512-EbC1X2n0t9IdeMECJn2BOg7buOGivCvVNjqKMXTzQOu7uIfLml+keUfCALDh8o4rbtndIeyGU8/BKfoTr/LVDQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true
+        }
+      }
+    },
+    "jest-regex-util": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-21.2.0.tgz",
+      "integrity": "sha512-BKQ1F83EQy0d9Jen/mcVX7D+lUt2tthhK/2gDWRgLDJRNOdRgSp1iVqFxP8EN1ARuypvDflRfPzYT8fQnoBQFQ==",
       "dev": true
     },
     "json3": {
@@ -309,20 +405,19 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.2.4.tgz",
       "integrity": "sha1-1LbFOz/H2htLkcHCrsi5MrdRHVw=",
-      "dev": true,
-      "requires": {
-        "chalk": "0.5.1"
-      }
+      "dev": true
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true
     },
     "lodash._baseassign": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true,
-      "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
-      }
+      "dev": true
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -352,12 +447,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true,
-      "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
-      }
+      "dev": true
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -375,21 +465,19 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true,
-      "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
-      }
+      "dev": true
+    },
+    "micromatch": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "1.1.8"
-      }
+      "dev": true
     },
     "minimist": {
       "version": "0.0.8",
@@ -401,38 +489,19 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
-      "requires": {
-        "minimist": "0.0.8"
-      }
+      "dev": true
     },
     "mocha": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.1.tgz",
       "integrity": "sha1-o4ArSqOBk0yss43nDPdxYh2o+a8=",
       "dev": true,
-      "requires": {
-        "browser-stdout": "1.3.0",
-        "commander": "2.9.0",
-        "debug": "2.6.0",
-        "diff": "3.2.0",
-        "escape-string-regexp": "1.0.5",
-        "glob": "7.1.1",
-        "growl": "1.9.2",
-        "json3": "3.3.2",
-        "lodash.create": "3.1.1",
-        "mkdirp": "0.5.1",
-        "supports-color": "3.1.2"
-      },
       "dependencies": {
         "supports-color": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-          "dev": true,
-          "requires": {
-            "has-flag": "1.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -442,38 +511,29 @@
       "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
       "dev": true
     },
-    "object-inspect": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.3.0.tgz",
-      "integrity": "sha512-OHHnLgLNXpM++GnJRyyhbr2bwl3pPVm4YvaraHrRvDt/N3r+s/gDVHciA7EJBTkijKXj61ssgSAikq1fb0IBRg==",
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true
     },
-    "object-keys": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+    "object.omit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true
-    },
-    "object.entries": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
-      "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
-      "dev": true,
-      "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.8.2",
-        "function-bind": "1.1.1",
-        "has": "1.0.1"
-      }
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
-      "requires": {
-        "wrappy": "1.0.2"
-      }
+      "dev": true
+    },
+    "parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -481,25 +541,100 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "preserve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "dev": true
+    },
+    "pretty-format": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
+      "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true
+        }
+      }
+    },
+    "randomatic": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "dev": true,
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true
+        }
+      }
+    },
+    "regex-cache": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "dev": true
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "repeat-element": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+      "dev": true
+    },
     "strip-ansi": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
       "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "0.2.1"
-      }
+      "dev": true
     },
     "supports-color": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
       "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
-      "dev": true
-    },
-    "tmatch": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/tmatch/-/tmatch-2.0.1.tgz",
-      "integrity": "sha1-DFYkbzPzDaG409colauvFmYPOM8=",
       "dev": true
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -4,14 +4,15 @@
   "version": "4.2.0",
   "contributors": [
     "Robin Berjon <robin@berjon.com> (https://berjon.com)",
-    "Marcos Caceres <marcos@marcosc.com> (https://marcosc.com)"
+    "Marcos Caceres <marcos@marcosc.com> (https://marcosc.com)",
+    "Kagami Sascha Rosylight <saschaplas@outlook.com>"
   ],
   "license": "W3C",
   "dependencies": {},
   "devDependencies": {
-    "mocha": "4.0.1",
     "expect": "21.2.1",
-    "jsondiffpatch": "0.2.4"
+    "jsondiffpatch": "0.2.4",
+    "mocha": "4.0.1"
   },
   "scripts": {
     "test": "mocha"

--- a/test/invalid.js
+++ b/test/invalid.js
@@ -30,7 +30,7 @@ describe("Parses all of the invalid IDLs to check that they blow up correctly", 
                     error = e;
                 }
                 finally {
-                    expect(error).toExist();
+                    expect(error).toBeTruthy();
                     expect(error.message).toEqual(err.message);
                     expect(error.line).toEqual(err.line);
                 }


### PR DESCRIPTION
This is related to #82 but not really breaking compat with Node.js 4.

This PR converts:

* `var func = function() { }` style to `function func() { }`
* `var x` to `let x` or `const x` depending on the variable is reassigned or not
* ES5-style class declaration for WebIDLParseError to ES2015 one
* `for (var i = 0; i < array.length; i++)` to `for (const item of array)`
* callback functions to use arrow syntax
* object literal member functions `{ func: function () { } }` to `{ func() { } }`

PS: Now fixes #82 by removing it on `.travis.yml`.