### PR TITLE
BREAKING CHANGE: ret enum value as object

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,9 +279,9 @@ An enum looks like this:
   "type": "enum",
   "name": "MealType",
   "values": [
-    "rice",
-    "noodles",
-    "other"
+    { "type": "string", "value": "rice" },
+    { "type": "string", "value": "noodles" },
+    { "type": "string", "value": "other" }
   ],
   "extAttrs": []
 }
@@ -291,7 +291,7 @@ The fields are as follows:
 
 * `type`: Always "enum".
 * `name`: The enum's name.
-* `value`: An array of values (strings).
+* `value`: An array of values.
 * `extAttrs`: A list of [extended attributes](#extended-attributes).
 
 ### Typedef
@@ -327,7 +327,7 @@ The fields are as follows:
 * `name`: The typedef's name.
 * `idlType`: An [IDL Type](#idl-type) describing what typedef's type.
 * `extAttrs`: A list of [extended attributes](#extended-attributes).
-* `typeExtAttrs`: A list of [extended attributes](#extended-attributes) that apply to the 
+* `typeExtAttrs`: A list of [extended attributes](#extended-attributes) that apply to the
 type rather than to the typedef as a whole.
 
 ### Implements

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -885,7 +885,8 @@
           return ret;
         }
         const val = consume(STR) || error("Unexpected value in enum");
-        ret.values.push(val.value.replace(/"/g, ""));
+        val.value = val.value.replace(/"/g, "");
+        ret.values.push( val );
         all_ws(store ? vals : null);
         if (consume(OTHER, ",")) {
           if (store) vals.push({ type: "," });

--- a/test/syntax/json/enum.json
+++ b/test/syntax/json/enum.json
@@ -3,9 +3,9 @@
         "type": "enum",
         "name": "MealType",
         "values": [
-            "rice",
-            "noodles",
-            "other"
+            { "type": "string", "value": "rice" },
+            { "type": "string", "value": "noodles" },
+            { "type": "string", "value": "other" }
         ],
         "extAttrs": []
     },
@@ -100,9 +100,9 @@
         "type": "enum",
         "name": "AltMealType",
         "values": [
-            "rice",
-            "noodles",
-            "other"
+            { "type": "string", "value": "rice" },
+            { "type": "string", "value": "noodles" },
+            { "type": "string", "value": "other" }
         ],
         "extAttrs": []
     }


### PR DESCRIPTION
* closes #86 

This changes the return type of parsed `emum.values` from strings to objects. The Objects have two members, `type` and `value`: `{type: "string", value: "value" }`.  
