### PR TITLE
Use ES2015 syntax for tests

### DIFF
--- a/test/invalid.js
+++ b/test/invalid.js
@@ -1,42 +1,40 @@
-
 // NOTES:
 //  - the errors actually still need to be reviewed to check that they
 //    are fully correct interpretations of the IDLs
 
-var wp = process.env.JSCOV ? require("../lib-cov/webidl2") : require("../lib/webidl2")
-,   expect = require("expect")
-,   pth = require("path")
-,   fs = require("fs")
-;
-describe("Parses all of the invalid IDLs to check that they blow up correctly", function () {
-    var dir = pth.join(__dirname, "invalid/idl")
-    ,   skip = {}
-    ,   idls = fs.readdirSync(dir)
-                  .filter(function (it) { return (/\.w?idl$/).test(it) && !skip[it]; })
-                  .map(function (it) { return pth.join(dir, it); })
-    ,   errors = idls.map(function (it) { return pth.join(__dirname, "invalid", "json", pth.basename(it).replace(/\.w?idl/, ".json")); })
-    ;
+"use strict";
 
-    for (var i = 0, n = idls.length; i < n; i++) {
-        var idl = idls[i], error = JSON.parse(fs.readFileSync(errors[i], "utf8"));
-        var func = (function (idl, err) {
-            return function () {
-                var error;
-                try {
-                    var ast = wp.parse(fs.readFileSync(idl, "utf8"));
-                    console.log(JSON.stringify(ast, null, 4));
-                }
-                catch (e) {
-                    error = e;
-                }
-                finally {
-                    expect(error).toBeTruthy();
-                    expect(error.message).toEqual(err.message);
-                    expect(error.line).toEqual(err.line);
-                }
+const wp = require("../lib/webidl2");
+const expect = require("expect");
+const pth = require("path");
+const fs = require("fs");
 
-            };
-        }(idl, error));
-        it("should produce the right error for " + idl, func);
-    }
+describe("Parses all of the invalid IDLs to check that they blow up correctly", () => {
+  const dir = pth.join(__dirname, "invalid/idl");
+  const skip = {};
+  const idls = fs.readdirSync(dir)
+    .filter(it => (/\.w?idl$/).test(it) && !skip[it])
+    .map(it => pth.join(dir, it));
+  const errors = idls.map(it => pth.join(__dirname, "invalid", "json", pth.basename(it).replace(/\.w?idl/, ".json")));
+
+  for (let i = 0, n = idls.length; i < n; i++) {
+    const idl = idls[i];
+    const err = JSON.parse(fs.readFileSync(errors[i], "utf8"));
+
+    it(`should produce the right error for ${idl}`, () => {
+      let error;
+      try {
+        var ast = wp.parse(fs.readFileSync(idl, "utf8"));
+        console.log(JSON.stringify(ast, null, 4));
+      }
+      catch (e) {
+        error = e;
+      }
+      finally {
+        expect(error).toBeTruthy();
+        expect(error.message).toEqual(err.message);
+        expect(error.line).toEqual(err.line);
+      }
+    });
+  }
 });

--- a/test/syntax.js
+++ b/test/syntax.js
@@ -1,41 +1,39 @@
+"use strict";
 
-var wp = process.env.JSCOV ? require("../lib-cov/webidl2") : require("../lib/webidl2")
-,   expect = require("expect")
-,   pth = require("path")
-,   fs = require("fs")
-,   jdp = require("jsondiffpatch")
-,   debug = true
-;
-describe("Parses all of the IDLs to produce the correct ASTs", function () {
-    var dir = pth.join(__dirname, "syntax/idl")
-    ,   skip = {} // use if we have a broken test
-    ,   idls = fs.readdirSync(dir)
-                  .filter(function (it) { return (/\.widl$/).test(it) && !skip[it]; })
-                  .map(function (it) { return pth.join(dir, it); })
-    ,   jsons = idls.map(function (it) { return pth.join(__dirname, "syntax/json", pth.basename(it).replace(".widl", ".json")); })
-    ;
+const wp = require("../lib/webidl2");
+const expect = require("expect");
+const pth = require("path");
+const fs = require("fs");
+const jdp = require("jsondiffpatch");
+const debug = true;
 
-    for (var i = 0, n = idls.length; i < n; i++) {
-        var idl = idls[i], json = jsons[i];
+describe("Parses all of the IDLs to produce the correct ASTs", () => {
+  const dir = pth.join(__dirname, "syntax/idl");
+  const skip = {}; // use if we have a broken test
+  const idls = fs.readdirSync(dir)
+    .filter(it => (/\.widl$/).test(it) && !skip[it])
+    .map(it => pth.join(dir, it));
+  const jsons = idls.map(it => pth.join(__dirname, "syntax/json", pth.basename(it).replace(".widl", ".json")));
 
-        var func = (function (idl, json) {
-            return function () {
-                try {
-                    var optFile = pth.join(__dirname, "syntax/opt", pth.basename(json));
-                    var opt = undefined;
-                    if (fs.existsSync(optFile))
-                        opt = JSON.parse(fs.readFileSync(optFile, "utf8"));
-                    var diff = jdp.diff(JSON.parse(fs.readFileSync(json, "utf8")),
-                                        wp.parse(fs.readFileSync(idl, "utf8"), opt));
-                    if (diff && debug) console.log(JSON.stringify(diff, null, 4));
-                    expect(diff).toBe(undefined);
-                }
-                catch (e) {
-                    console.log(e.toString());
-                    throw e;
-                }
-            };
-        }(idl, json));
-        it("should produce the same AST for " + idl, func);
-    }
+  for (let i = 0, n = idls.length; i < n; i++) {
+    const idl = idls[i];
+    const json = jsons[i];
+
+    it(`should produce the same AST for ${idl}`, () => {
+      try {
+        const optFile = pth.join(__dirname, "syntax/opt", pth.basename(json));
+        let opt = undefined;
+        if (fs.existsSync(optFile))
+          opt = JSON.parse(fs.readFileSync(optFile, "utf8"));
+        const diff = jdp.diff(JSON.parse(fs.readFileSync(json, "utf8")),
+          wp.parse(fs.readFileSync(idl, "utf8"), opt));
+        if (diff && debug) console.log(JSON.stringify(diff, null, 4));
+        expect(diff).toBe(undefined);
+      }
+      catch (e) {
+        console.log(e.toString());
+        throw e;
+      }
+    });
+  }
 });


### PR DESCRIPTION
Looking at the tests I thought they should be rewritten in ES2015 before any possible fix here.

Additionally this removes lib-cov references that don't exist.