### PR TITLE
Normalize some whitespace to pass wpt's lint

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -793,7 +793,7 @@
       }
       return rest;
     }
-    
+
     function nonspecial_operation(store) {
       all_ws(store, "pea");
       const ret = {

--- a/test/invalid/idl/maplike-1type.widl
+++ b/test/invalid/idl/maplike-1type.widl
@@ -1,3 +1,3 @@
 interface MapLikeOneType {
-	maplike<long>;
+  maplike<long>;
 }

--- a/test/invalid/idl/readonly-iterable.widl
+++ b/test/invalid/idl/readonly-iterable.widl
@@ -1,3 +1,3 @@
 interface ReadonlyIterable {
-	readonly iterable<long>;
+  readonly iterable<long>;
 }

--- a/test/invalid/idl/setlike-2types.widl
+++ b/test/invalid/idl/setlike-2types.widl
@@ -1,3 +1,3 @@
 interface SetLikeTwoTypes {
-	setlike<long, long>;
+  setlike<long, long>;
 }

--- a/test/invalid/idl/typedef-nested.widl
+++ b/test/invalid/idl/typedef-nested.widl
@@ -19,4 +19,4 @@
     boolean allPointsWithinBounds(PointSequence ps);
   };
 
-  typedef [Clamp] octet value; 
+  typedef [Clamp] octet value;

--- a/test/syntax/idl/extended-attributes.widl
+++ b/test/syntax/idl/extended-attributes.widl
@@ -2,7 +2,7 @@
 
 [Global=(Worker,ServiceWorker), Exposed=ServiceWorker]
 interface ServiceWorkerGlobalScope : WorkerGlobalScope {
-  
+
 };
 
 // Conformance with ExtendedAttributeList grammar in http://www.w3.org/TR/WebIDL/#idl-extended-attributes

--- a/test/syntax/idl/identifier-qualified-names.widl
+++ b/test/syntax/idl/identifier-qualified-names.widl
@@ -15,7 +15,7 @@
     getter DOMString (DOMString keyName);
   };
 
-    
+
     // Interface identifier: "TextField"
     // Qualified name:       "::framework::gui::TextField"
     interface TextField {

--- a/test/syntax/idl/iterable.widl
+++ b/test/syntax/idl/iterable.widl
@@ -1,11 +1,11 @@
 interface IterableOne {
-	iterable<long>;
+  iterable<long>;
 };
 
 interface IterableTwo {
-	iterable<short, double?>;
+  iterable<short, double?>;
 };
 
 interface IterableThree {
-	iterable<[XAttr] long>;
+  iterable<[XAttr] long>;
 };

--- a/test/syntax/idl/legacyiterable.widl
+++ b/test/syntax/idl/legacyiterable.widl
@@ -1,3 +1,3 @@
 interface LegacyIterable {
-	legacyiterable<long>;
+  legacyiterable<long>;
 };

--- a/test/syntax/idl/maplike.widl
+++ b/test/syntax/idl/maplike.widl
@@ -1,9 +1,9 @@
 interface MapLike {
-	maplike<long, float>;
+  maplike<long, float>;
 };
 
 interface ReadOnlyMapLike {
-	readonly maplike<long, float>;
+  readonly maplike<long, float>;
 };
 
 // Extracted from https://heycam.github.io/webidl/#idl-type-extended-attribute-associated-with on 2017-07-01

--- a/test/syntax/idl/primitives.widl
+++ b/test/syntax/idl/primitives.widl
@@ -9,11 +9,11 @@ interface Primitives {
   attribute long long bigbig;
   attribute  unsigned long long bigbigpositive;
   attribute float real;
-  attribute double bigreal; 
+  attribute double bigreal;
   attribute unrestricted float realwithinfinity;
-  attribute unrestricted double bigrealwithinfinity; 
-  attribute DOMString string; 
-  attribute ByteString bytes; 
+  attribute unrestricted double bigrealwithinfinity;
+  attribute DOMString string;
+  attribute ByteString bytes;
   attribute Date date;
   attribute RegExp regexp;
 };

--- a/test/syntax/idl/setlike.widl
+++ b/test/syntax/idl/setlike.widl
@@ -1,11 +1,11 @@
 interface SetLike {
-	setlike<long>;
+  setlike<long>;
 };
 
 interface ReadOnlySetLike {
-	readonly setlike<long>;
+  readonly setlike<long>;
 };
 
 interface SetLikeExt {
-	setlike<[XAttr] long>;
+  setlike<[XAttr] long>;
 };

--- a/test/syntax/json/sequence.json
+++ b/test/syntax/json/sequence.json
@@ -101,7 +101,7 @@
         "inheritance": null,
         "extAttrs": []
     },
-    
+
     {
         "type": "interface",
         "name": "I",


### PR DESCRIPTION
See https://github.com/w3c/web-platform-tests/pull/8027. With these
changes, most of wpt's lints would pass for webidl2.js.