### PR TITLE
chore: drop Node 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: node_js
 node_js:
   - node
   - lts/*
-  - 6


### PR DESCRIPTION
Follow latest stable and LTS going forward.