### PR TITLE
Pull out static_member/stringifier

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -54,6 +54,15 @@
     const STR = "string";
     const OTHER = "other";
 
+    const EMPTY_OPERATION = Object.freeze({
+      type: "operation",
+      getter: false,
+      setter: false,
+      deleter: false,
+      "static": false,
+      stringifier: false
+    });
+
     function error(str) {
       let tok = "";
       let numTokens = 0;
@@ -512,13 +521,6 @@
         inherit: false,
         readonly: false
       };
-      if (consume(ID, "static")) {
-        ret["static"] = true;
-        grabbed.push(last_token);
-      } else if (consume(ID, "stringifier")) {
-        ret.stringifier = true;
-        grabbed.push(last_token);
-      }
       const w = all_ws();
       if (w) grabbed.push(w);
       if (consume(ID, "inherit")) {
@@ -569,14 +571,7 @@
 
     function operation(store) {
       all_ws(store, "pea");
-      const ret = {
-        type: "operation",
-        getter: false,
-        setter: false,
-        deleter: false,
-        "static": false,
-        stringifier: false
-      };
+      const ret = Object.assign({}, EMPTY_OPERATION);
       while (true) {
         all_ws();
         if (consume(ID, "getter")) ret.getter = true;
@@ -586,19 +581,6 @@
       }
       if (ret.getter || ret.setter || ret.deleter) {
         all_ws();
-        ret.idlType = return_type();
-        operation_rest(ret, store);
-        return ret;
-      }
-      if (consume(ID, "static")) {
-        ret["static"] = true;
-        ret.idlType = return_type();
-        operation_rest(ret, store);
-        return ret;
-      } else if (consume(ID, "stringifier")) {
-        ret.stringifier = true; -
-        all_ws();
-        if (consume(OTHER, ";")) return ret;
         ret.idlType = return_type();
         operation_rest(ret, store);
         return ret;
@@ -623,6 +605,29 @@
         return ret;
       }
     };
+
+    function static_member(store) {
+      all_ws(store, "pea");
+      if (!consume(ID, "static")) return;
+      const prefix = "static";
+      all_ws();
+      return noninherited_attribute(store, prefix) ||
+        regular_operation(store, prefix) ||
+        error("No body in static member");
+    }
+
+    function stringifier(store) {
+      all_ws(store, "pea");
+      if (!consume(ID, "stringifier")) return;
+      const prefix = "stringifier";
+      all_ws();
+      if (consume(OTHER, ";")) {
+        return Object.assign({}, EMPTY_OPERATION, { stringifier: true });
+      }
+      return noninherited_attribute(store, prefix) ||
+        regular_operation(store, prefix) ||
+        error("Unterminated stringifier");
+    }
 
     function identifiers(arr) {
       while (true) {
@@ -728,6 +733,8 @@
           continue;
         }
         const mem = (opt.allowNestedTypedefs && typedef(store ? mems : null)) ||
+          static_member(store ? mems : null) ||
+          stringifier(store ? mems : null) ||
           iterable(store ? mems : null) ||
           attribute(store ? mems : null) ||
           operation(store ? mems : null) ||
@@ -761,14 +768,14 @@
         const ea = extended_attrs(store ? mems : null);
         all_ws();
         const mem = noninherited_attribute(store ? mems : null) ||
-          nonspecial_operation(store ? mems : null) ||
+          regular_operation(store ? mems : null) ||
           error("Unknown member");
         mem.extAttrs = ea;
         ret.members.push(mem);
       }
     }
 
-    function noninherited_attribute(store) {
+    function noninherited_attribute(store, prefix) {
       const w = all_ws(store, "pea");
       const grabbed = [];
       const ret = {
@@ -778,6 +785,9 @@
         inherit: false,
         readonly: false
       };
+      if (prefix) {
+        ret[prefix] = true;
+      }
       if (w) grabbed.push(w);
       if (consume(ID, "readonly")) {
         ret.readonly = true;
@@ -792,16 +802,12 @@
       return rest;
     }
 
-    function nonspecial_operation(store) {
+    function regular_operation(store, prefix) {
       all_ws(store, "pea");
-      const ret = {
-        type: "operation",
-        getter: false,
-        setter: false,
-        deleter: false,
-        "static": false,
-        stringifier: false
-      };
+      const ret = Object.assign({}, EMPTY_OPERATION);
+      if (prefix) {
+        ret[prefix] = true;
+      }
       ret.idlType = return_type();
       return operation_rest(ret, store);
     }


### PR DESCRIPTION
[MixinMember](https://heycam.github.io/webidl/#prod-MixinMember) only includes stringifiers but not static members, while current `operation()`/`attribute()` always include both.

This PR pulls `static_member()` and `stringifier()` out of `operation()`/`attribute()` so that supporting mixin can be easier.

```
MixinMember ::
    Const
    RegularOperation
    Stringifier
    ReadOnly AttributeRest
```

Bonus: This renames nonspecial_operation to regular_operation to [match the spec naming](https://heycam.github.io/webidl/#prod-RegularOperation).