### PR TITLE
Consistent array type for iterable.idlType

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -670,17 +670,14 @@
         delete ret.readonly;
       all_ws();
       if (consume(OTHER, "<")) {
-        ret.idlType = type_with_extended_attributes() || error(`Error parsing ${ittype} declaration`);
+        ret.idlType = [type_with_extended_attributes()] || error(`Error parsing ${ittype} declaration`);
         all_ws();
         if (secondTypeAllowed) {
-          let type2 = null;
           if (consume(OTHER, ",")) {
             all_ws();
-            type2 = type_with_extended_attributes();
+            ret.idlType.push(type_with_extended_attributes());
             all_ws();
           }
-          if (type2)
-            ret.idlType = [ret.idlType, type2];
           else if (secondTypeRequired)
             error(`Missing second type argument in ${ittype} declaration`);
         }

--- a/test/syntax/json/iterable.json
+++ b/test/syntax/json/iterable.json
@@ -6,13 +6,15 @@
         "members": [
             {
                 "type": "iterable",
-                "idlType": {
-                    "sequence": false,
-                    "generic": null,
-                    "nullable": false,
-                    "union": false,
-                    "idlType": "long"
-                },
+                "idlType": [
+                        {
+                        "sequence": false,
+                        "generic": null,
+                        "nullable": false,
+                        "union": false,
+                        "idlType": "long"
+                    }
+                ],
                 "extAttrs": []
             }
         ],
@@ -55,21 +57,23 @@
         "members": [
             {
                 "type": "iterable",
-                "idlType": {
-                    "sequence": false,
-                    "generic": null,
-                    "nullable": false,
-                    "union": false,
-                    "idlType": "long",
-                    "extAttrs": [
-                        {
-                            "name": "XAttr",
-                            "arguments": null,
-                            "type": "extended-attribute",
-                            "rhs": null
-                        }
-                    ]
-                },
+                "idlType": [
+                    {
+                        "sequence": false,
+                        "generic": null,
+                        "nullable": false,
+                        "union": false,
+                        "idlType": "long",
+                        "extAttrs": [
+                            {
+                                "name": "XAttr",
+                                "arguments": null,
+                                "type": "extended-attribute",
+                                "rhs": null
+                            }
+                        ]
+                    }
+                ],
                 "extAttrs": []
             }
         ],

--- a/test/syntax/json/legacyiterable.json
+++ b/test/syntax/json/legacyiterable.json
@@ -6,13 +6,15 @@
         "members": [
             {
                 "type": "legacyiterable",
-                "idlType": {
-                    "sequence": false,
-                    "generic": null,
-                    "nullable": false,
-                    "union": false,
-                    "idlType": "long"
-                },
+                "idlType": [
+                    {
+                        "sequence": false,
+                        "generic": null,
+                        "nullable": false,
+                        "union": false,
+                        "idlType": "long"
+                    }
+                ],
                 "extAttrs": []
             }
         ],

--- a/test/syntax/json/setlike.json
+++ b/test/syntax/json/setlike.json
@@ -6,13 +6,15 @@
         "members": [
             {
                 "type": "setlike",
-                "idlType": {
-                    "sequence": false,
-                    "generic": null,
-                    "nullable": false,
-                    "union": false,
-                    "idlType": "long"
-                },
+                "idlType": [
+                    {
+                        "sequence": false,
+                        "generic": null,
+                        "nullable": false,
+                        "union": false,
+                        "idlType": "long"
+                    }
+                ],
                 "readonly": false,
                 "extAttrs": []
             }
@@ -27,13 +29,15 @@
         "members": [
             {
                 "type": "setlike",
-                "idlType": {
-                    "sequence": false,
-                    "generic": null,
-                    "nullable": false,
-                    "union": false,
-                    "idlType": "long"
-                },
+                "idlType": [
+                    {
+                        "sequence": false,
+                        "generic": null,
+                        "nullable": false,
+                        "union": false,
+                        "idlType": "long"
+                    }
+                ],
                 "readonly": true,
                 "extAttrs": []
             }
@@ -48,21 +52,23 @@
         "members": [
             {
                 "type": "setlike",
-                "idlType": {
-                    "sequence": false,
-                    "generic": null,
-                    "nullable": false,
-                    "union": false,
-                    "idlType": "long",
-                    "extAttrs": [
-                        {
-                            "name": "XAttr",
-                            "arguments": null,
-                            "type": "extended-attribute",
-                            "rhs": null
-                        }
-                    ]
-                },
+                "idlType": [
+                    {
+                        "sequence": false,
+                        "generic": null,
+                        "nullable": false,
+                        "union": false,
+                        "idlType": "long",
+                        "extAttrs": [
+                            {
+                                "name": "XAttr",
+                                "arguments": null,
+                                "type": "extended-attribute",
+                                "rhs": null
+                            }
+                        ]
+                    }
+                ],
                 "readonly": false,
                 "extAttrs": []
             }


### PR DESCRIPTION
This removes pain when processing `iterable` and its friends with different member counts. See #113