### PR TITLE
Use for-of on tests

### DIFF
--- a/test/invalid.js
+++ b/test/invalid.js
@@ -15,16 +15,17 @@ describe("Parses all of the invalid IDLs to check that they blow up correctly", 
   const idls = fs.readdirSync(dir)
     .filter(it => (/\.w?idl$/).test(it) && !skip[it])
     .map(it => pth.join(dir, it));
-  const errors = idls.map(it => pth.join(__dirname, "invalid", "json", pth.basename(it).replace(/\.w?idl/, ".json")));
 
-  for (let i = 0, n = idls.length; i < n; i++) {
-    const idl = idls[i];
-    const err = JSON.parse(fs.readFileSync(errors[i], "utf8"));
+  for (const idl of idls) {
+    const err = JSON.parse(fs.readFileSync(
+      pth.join(__dirname, "invalid", "json", pth.basename(idl).replace(/\.w?idl/, ".json")),
+      "utf8"
+    ));
 
     it(`should produce the right error for ${idl}`, () => {
       let error;
       try {
-        var ast = wp.parse(fs.readFileSync(idl, "utf8"));
+        const ast = wp.parse(fs.readFileSync(idl, "utf8"));
         console.log(JSON.stringify(ast, null, 4));
       }
       catch (e) {

--- a/test/syntax.js
+++ b/test/syntax.js
@@ -13,11 +13,9 @@ describe("Parses all of the IDLs to produce the correct ASTs", () => {
   const idls = fs.readdirSync(dir)
     .filter(it => (/\.widl$/).test(it) && !skip[it])
     .map(it => pth.join(dir, it));
-  const jsons = idls.map(it => pth.join(__dirname, "syntax/json", pth.basename(it).replace(".widl", ".json")));
 
-  for (let i = 0, n = idls.length; i < n; i++) {
-    const idl = idls[i];
-    const json = jsons[i];
+  for (const idl of idls) {
+    const json = pth.join(__dirname, "syntax/json", pth.basename(idl).replace(".widl", ".json"));
 
     it(`should produce the same AST for ${idl}`, () => {
       try {


### PR DESCRIPTION
Because I don't want to see those `i++`s 😁

Removed `idls.map` to do this.