### PR TITLE
feat: add types on idlTypes

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -208,9 +208,9 @@
       }
     };
 
-    function single_type() {
+    function single_type(typeName) {
       const prim = primitive_type();
-      const ret = { sequence: false, generic: null, nullable: false, union: false };
+      const ret = { type: typeName || null, sequence: false, generic: null, nullable: false, union: false };
       let name;
       let value;
       if (prim) {
@@ -228,7 +228,7 @@
           const types = [];
           do {
             all_ws();
-            types.push(type_with_extended_attributes() || error("Error parsing generic type " + value));
+            types.push(type_with_extended_attributes(typeName) || error("Error parsing generic type " + value));
             all_ws();
           }
           while (consume(OTHER, ","));
@@ -259,16 +259,16 @@
       return ret;
     };
 
-    function union_type() {
+    function union_type(typeName) {
       all_ws();
       if (!consume(OTHER, "(")) return;
       const ret = { sequence: false, generic: null, nullable: false, union: true, idlType: [] };
-      const fst = type_with_extended_attributes() || error("Union type with no content");
+      const fst = type_with_extended_attributes(typeName) || error("Union type with no content");
       ret.idlType.push(fst);
       while (true) {
         all_ws();
         if (!consume(ID, "or")) break;
-        const typ = type_with_extended_attributes() || error("No type after 'or' in union type");
+        const typ = type_with_extended_attributes(typeName) || error("No type after 'or' in union type");
         ret.idlType.push(typ);
       }
       if (!consume(OTHER, ")")) error("Unterminated union type");
@@ -280,9 +280,9 @@
       return single_type() || union_type();
     };
 
-    function type_with_extended_attributes() {
+    function type_with_extended_attributes(typeName) {
       const extAttrs = extended_attrs();
-      const ret = single_type() || union_type();
+      const ret = single_type(typeName) || union_type(typeName);
       if (extAttrs.length && ret) ret.extAttrs = extAttrs;
       return ret;
     };
@@ -551,7 +551,7 @@
         return;
       }
       all_ws();
-      ret.idlType = type_with_extended_attributes() || error("No type in attribute");
+      ret.idlType = type_with_extended_attributes("attribute-type") || error("No type in attribute");
       if (ret.idlType.sequence) error("Attributes cannot accept sequence types");
       if (ret.idlType.generic === "record") error("Attributes cannot accept record types");
       all_ws();

--- a/test/syntax/json/allowany.json
+++ b/test/syntax/json/allowany.json
@@ -12,6 +12,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -30,6 +31,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -43,6 +45,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -62,6 +65,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -82,6 +86,7 @@
                             }
                         ],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,

--- a/test/syntax/json/attributes.json
+++ b/test/syntax/json/attributes.json
@@ -11,6 +11,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,

--- a/test/syntax/json/callback.json
+++ b/test/syntax/json/callback.json
@@ -3,6 +3,7 @@
         "type": "callback",
         "name": "AsyncOperationCallback",
         "idlType": {
+            "type": null,
             "sequence": false,
             "generic": null,
             "nullable": false,
@@ -15,6 +16,7 @@
                 "variadic": false,
                 "extAttrs": [],
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -39,6 +41,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -52,6 +55,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -71,6 +75,7 @@
         "type": "callback",
         "name": "SortCallback",
         "idlType": {
+            "type": null,
             "sequence": false,
             "generic": null,
             "nullable": false,
@@ -83,6 +88,7 @@
                 "variadic": false,
                 "extAttrs": [],
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -96,6 +102,7 @@
                 "variadic": false,
                 "extAttrs": [],
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,

--- a/test/syntax/json/constructor.json
+++ b/test/syntax/json/constructor.json
@@ -11,6 +11,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -27,6 +28,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -43,6 +45,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -59,6 +62,7 @@
                 "inherit": false,
                 "readonly": true,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -85,6 +89,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,

--- a/test/syntax/json/dictionary-inherits.json
+++ b/test/syntax/json/dictionary-inherits.json
@@ -9,6 +9,7 @@
                 "name": "fillPattern",
                 "required": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": true,
@@ -26,6 +27,7 @@
                 "name": "strokePattern",
                 "required": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": true,
@@ -42,6 +44,7 @@
                 "name": "position",
                 "required": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -64,6 +67,7 @@
                 "name": "hydrometry",
                 "required": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,

--- a/test/syntax/json/dictionary.json
+++ b/test/syntax/json/dictionary.json
@@ -9,6 +9,7 @@
                 "name": "fillPattern",
                 "required": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": true,
@@ -26,6 +27,7 @@
                 "name": "strokePattern",
                 "required": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": true,
@@ -42,6 +44,7 @@
                 "name": "position",
                 "required": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -55,11 +58,13 @@
                 "name": "seq",
                 "required": false,
                 "idlType": {
+                    "type": null,
                     "sequence": true,
                     "generic": "sequence",
                     "nullable": false,
                     "union": false,
                     "idlType": {
+                        "type": null,
                         "sequence": false,
                         "generic": null,
                         "nullable": false,
@@ -78,6 +83,7 @@
                 "name": "reqSeq",
                 "required": true,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -100,6 +106,7 @@
                 "name": "h",
                 "required": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -113,6 +120,7 @@
                 "name": "d",
                 "required": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,

--- a/test/syntax/json/enum.json
+++ b/test/syntax/json/enum.json
@@ -30,6 +30,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -46,6 +47,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -63,6 +65,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -76,6 +79,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -89,6 +93,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,

--- a/test/syntax/json/equivalent-decl.json
+++ b/test/syntax/json/equivalent-decl.json
@@ -11,6 +11,7 @@
                 "inherit": false,
                 "readonly": true,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -28,6 +29,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -41,6 +43,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -60,6 +63,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -73,6 +77,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -86,6 +91,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -113,6 +119,7 @@
                 "inherit": false,
                 "readonly": true,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -130,6 +137,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -143,6 +151,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -162,6 +171,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -175,6 +185,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -188,6 +199,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -207,6 +219,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -220,6 +233,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -239,6 +253,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -252,6 +267,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -265,6 +281,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,

--- a/test/syntax/json/extended-attributes.json
+++ b/test/syntax/json/extended-attributes.json
@@ -77,6 +77,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -93,6 +94,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -109,6 +111,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -125,6 +128,7 @@
                 "inherit": false,
                 "readonly": true,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -151,6 +155,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -183,6 +188,7 @@
                     "union": true,
                     "idlType": [
                         {
+                            "type": "attribute-type",
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -190,6 +196,7 @@
                             "idlType": "long"
                         },
                         {
+                            "type": "attribute-type",
                             "sequence": false,
                             "generic": null,
                             "nullable": false,

--- a/test/syntax/json/generic.json
+++ b/test/syntax/json/generic.json
@@ -12,21 +12,25 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": "Promise",
                     "nullable": false,
                     "union": false,
                     "idlType": {
+                        "type": null,
                         "sequence": false,
                         "generic": "ResponsePromise",
                         "nullable": false,
                         "union": false,
                         "idlType": {
+                            "type": null,
                             "sequence": true,
                             "generic": "sequence",
                             "nullable": false,
                             "union": false,
                             "idlType": {
+                                "type": null,
                                 "sequence": false,
                                 "generic": null,
                                 "nullable": true,
@@ -47,11 +51,13 @@
                 "inherit": false,
                 "readonly": true,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": "Promise",
                     "nullable": false,
                     "union": false,
                     "idlType": {
+                        "type": "attribute-type",
                         "sequence": false,
                         "generic": null,
                         "nullable": false,
@@ -79,11 +85,13 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": "Promise",
                     "nullable": false,
                     "union": false,
                     "idlType": {
+                        "type": null,
                         "sequence": false,
                         "generic": null,
                         "nullable": true,
@@ -103,11 +111,13 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": "Promise",
                     "nullable": false,
                     "union": false,
                     "idlType": {
+                        "type": null,
                         "sequence": false,
                         "generic": null,
                         "nullable": false,
@@ -136,11 +146,13 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": "ResponsePromise",
                     "nullable": false,
                     "union": false,
                     "idlType": {
+                        "type": null,
                         "sequence": false,
                         "generic": null,
                         "nullable": false,

--- a/test/syntax/json/getter-setter.json
+++ b/test/syntax/json/getter-setter.json
@@ -11,6 +11,7 @@
                 "inherit": false,
                 "readonly": true,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -28,6 +29,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -41,6 +43,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -60,6 +63,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -73,6 +77,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -86,6 +91,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,

--- a/test/syntax/json/identifier-qualified-names.json
+++ b/test/syntax/json/identifier-qualified-names.json
@@ -2,6 +2,7 @@
     {
         "type": "typedef",
         "idlType": {
+            "type": null,
             "sequence": false,
             "generic": null,
             "nullable": false,
@@ -24,6 +25,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -37,6 +39,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -56,6 +59,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -69,6 +73,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -96,6 +101,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -112,6 +118,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": true,
@@ -138,6 +145,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -151,6 +159,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,

--- a/test/syntax/json/implements.json
+++ b/test/syntax/json/implements.json
@@ -11,6 +11,7 @@
                 "inherit": false,
                 "readonly": true,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -37,6 +38,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -50,6 +52,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -63,6 +66,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -76,6 +80,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,

--- a/test/syntax/json/indexed-properties.json
+++ b/test/syntax/json/indexed-properties.json
@@ -11,6 +11,7 @@
                 "inherit": false,
                 "readonly": true,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -28,6 +29,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -41,6 +43,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -60,6 +63,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -73,6 +77,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -86,6 +91,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -105,6 +111,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -118,6 +125,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -137,6 +145,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -150,6 +159,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -169,6 +179,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -182,6 +193,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -195,6 +207,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -214,6 +227,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -227,6 +241,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,

--- a/test/syntax/json/inherits-getter.json
+++ b/test/syntax/json/inherits-getter.json
@@ -11,6 +11,7 @@
                 "inherit": false,
                 "readonly": true,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -36,6 +37,7 @@
                 "inherit": false,
                 "readonly": true,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -52,6 +54,7 @@
                 "inherit": true,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,

--- a/test/syntax/json/interface-inherits.json
+++ b/test/syntax/json/interface-inherits.json
@@ -11,6 +11,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -36,6 +37,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -61,6 +63,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,

--- a/test/syntax/json/iterable.json
+++ b/test/syntax/json/iterable.json
@@ -8,6 +8,7 @@
                 "type": "iterable",
                 "idlType": [
                     {
+                        "type": null,
                         "sequence": false,
                         "generic": null,
                         "nullable": false,
@@ -30,6 +31,7 @@
                 "type": "iterable",
                 "idlType": [
                     {
+                        "type": null,
                         "sequence": false,
                         "generic": null,
                         "nullable": false,
@@ -37,6 +39,7 @@
                         "idlType": "short"
                     },
                     {
+                        "type": null,
                         "sequence": false,
                         "generic": null,
                         "nullable": true,
@@ -59,6 +62,7 @@
                 "type": "iterable",
                 "idlType": [
                     {
+                        "type": null,
                         "sequence": false,
                         "generic": null,
                         "nullable": false,

--- a/test/syntax/json/legacyiterable.json
+++ b/test/syntax/json/legacyiterable.json
@@ -8,6 +8,7 @@
                 "type": "legacyiterable",
                 "idlType": [
                     {
+                        "type": null,
                         "sequence": false,
                         "generic": null,
                         "nullable": false,

--- a/test/syntax/json/maplike.json
+++ b/test/syntax/json/maplike.json
@@ -8,6 +8,7 @@
                 "type": "maplike",
                 "idlType": [
                     {
+                        "type": null,
                         "sequence": false,
                         "generic": null,
                         "nullable": false,
@@ -15,6 +16,7 @@
                         "idlType": "long"
                     },
                     {
+                        "type": null,
                         "sequence": false,
                         "generic": null,
                         "nullable": false,
@@ -38,6 +40,7 @@
                 "type": "maplike",
                 "idlType": [
                     {
+                        "type": null,
                         "sequence": false,
                         "generic": null,
                         "nullable": false,
@@ -45,6 +48,7 @@
                         "idlType": "long"
                     },
                     {
+                        "type": null,
                         "sequence": false,
                         "generic": null,
                         "nullable": false,
@@ -68,6 +72,7 @@
                 "type": "maplike",
                 "idlType": [
                     {
+                        "type": null,
                         "sequence": false,
                         "generic": null,
                         "nullable": false,
@@ -83,6 +88,7 @@
                         ]
                     },
                     {
+                        "type": null,
                         "sequence": false,
                         "generic": null,
                         "nullable": false,

--- a/test/syntax/json/mixin.json
+++ b/test/syntax/json/mixin.json
@@ -11,6 +11,7 @@
                 "inherit": false,
                 "readonly": true,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -47,6 +48,7 @@
                 "inherit": false,
                 "readonly": true,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,

--- a/test/syntax/json/namedconstructor.json
+++ b/test/syntax/json/namedconstructor.json
@@ -23,6 +23,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,

--- a/test/syntax/json/namespace.json
+++ b/test/syntax/json/namespace.json
@@ -11,6 +11,7 @@
                 "inherit": false,
                 "readonly": true,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -28,6 +29,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -41,6 +43,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -54,6 +57,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -73,6 +77,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -86,6 +91,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -99,6 +105,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,

--- a/test/syntax/json/nointerfaceobject.json
+++ b/test/syntax/json/nointerfaceobject.json
@@ -12,6 +12,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -25,6 +26,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,

--- a/test/syntax/json/nullable.json
+++ b/test/syntax/json/nullable.json
@@ -31,6 +31,7 @@
                 "inherit": false,
                 "readonly": true,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": true,

--- a/test/syntax/json/nullableobjects.json
+++ b/test/syntax/json/nullableobjects.json
@@ -28,6 +28,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -41,6 +42,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": true,
@@ -60,6 +62,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -73,6 +76,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": true,

--- a/test/syntax/json/operation-optional-arg.json
+++ b/test/syntax/json/operation-optional-arg.json
@@ -12,6 +12,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -25,6 +26,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -38,6 +40,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -51,6 +54,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -64,6 +68,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,

--- a/test/syntax/json/overloading.json
+++ b/test/syntax/json/overloading.json
@@ -28,6 +28,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -41,6 +42,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -60,6 +62,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -73,6 +76,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -101,6 +105,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -114,6 +119,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -133,6 +139,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -153,6 +160,7 @@
                             }
                         ],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -166,6 +174,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -179,6 +188,7 @@
                         "variadic": true,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -198,6 +208,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -216,6 +227,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -229,6 +241,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -242,6 +255,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -255,6 +269,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -268,6 +283,7 @@
                         "variadic": true,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,

--- a/test/syntax/json/overridebuiltins.json
+++ b/test/syntax/json/overridebuiltins.json
@@ -11,6 +11,7 @@
                 "inherit": false,
                 "readonly": true,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -28,6 +29,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -41,6 +43,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,

--- a/test/syntax/json/partial-interface.json
+++ b/test/syntax/json/partial-interface.json
@@ -11,6 +11,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -36,6 +37,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,

--- a/test/syntax/json/primitives.json
+++ b/test/syntax/json/primitives.json
@@ -11,6 +11,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -27,6 +28,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -43,6 +45,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -59,6 +62,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -75,6 +79,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -91,6 +96,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -107,6 +113,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -123,6 +130,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -139,6 +147,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -155,6 +164,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -171,6 +181,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -187,6 +198,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -203,6 +215,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -219,6 +232,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -235,6 +249,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -251,6 +266,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -267,6 +283,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,

--- a/test/syntax/json/prototyperoot.json
+++ b/test/syntax/json/prototyperoot.json
@@ -11,6 +11,7 @@
                 "inherit": false,
                 "readonly": true,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,

--- a/test/syntax/json/putforwards.json
+++ b/test/syntax/json/putforwards.json
@@ -11,6 +11,7 @@
                 "inherit": false,
                 "readonly": true,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -37,6 +38,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,

--- a/test/syntax/json/record.json
+++ b/test/syntax/json/record.json
@@ -12,6 +12,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -25,17 +26,20 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": true,
                             "generic": "sequence",
                             "nullable": false,
                             "union": false,
                             "idlType": {
+                                "type": null,
                                 "sequence": false,
                                 "generic": "record",
                                 "nullable": false,
                                 "union": false,
                                 "idlType": [
                                     {
+                                        "type": null,
                                         "sequence": false,
                                         "generic": null,
                                         "nullable": false,
@@ -43,6 +47,7 @@
                                         "idlType": "ByteString"
                                     },
                                     {
+                                        "type": null,
                                         "sequence": false,
                                         "generic": null,
                                         "nullable": false,
@@ -65,12 +70,14 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": "record",
                     "nullable": false,
                     "union": false,
                     "idlType": [
                         {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -84,6 +91,7 @@
                             "union": true,
                             "idlType": [
                                 {
+                                    "type": null,
                                     "sequence": false,
                                     "generic": null,
                                     "nullable": false,
@@ -91,6 +99,7 @@
                                     "idlType": "float"
                                 },
                                 {
+                                    "type": null,
                                     "sequence": false,
                                     "generic": null,
                                     "nullable": false,
@@ -113,6 +122,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -134,12 +144,14 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": "record",
                             "nullable": false,
                             "union": false,
                             "idlType": [
                                 {
+                                    "type": null,
                                     "sequence": false,
                                     "generic": null,
                                     "nullable": false,
@@ -147,6 +159,7 @@
                                     "idlType": "USVString"
                                 },
                                 {
+                                    "type": null,
                                     "sequence": false,
                                     "generic": null,
                                     "nullable": false,
@@ -176,12 +189,14 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": "record",
                     "nullable": false,
                     "union": false,
                     "idlType": [
                         {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -189,6 +204,7 @@
                             "idlType": "DOMString"
                         },
                         {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,

--- a/test/syntax/json/reg-operations.json
+++ b/test/syntax/json/reg-operations.json
@@ -11,6 +11,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -27,6 +28,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -53,6 +55,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -71,6 +74,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -84,6 +88,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -103,6 +108,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -116,6 +122,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -129,6 +136,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,

--- a/test/syntax/json/replaceable.json
+++ b/test/syntax/json/replaceable.json
@@ -11,6 +11,7 @@
                 "inherit": false,
                 "readonly": true,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -35,6 +36,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,

--- a/test/syntax/json/sequence.json
+++ b/test/syntax/json/sequence.json
@@ -12,6 +12,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -25,11 +26,13 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": true,
                             "generic": "sequence",
                             "nullable": false,
                             "union": false,
                             "idlType": {
+                                "type": null,
                                 "sequence": false,
                                 "generic": null,
                                 "nullable": false,
@@ -50,11 +53,13 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": true,
                     "generic": "sequence",
                     "nullable": false,
                     "union": false,
                     "idlType": {
+                        "type": null,
                         "sequence": false,
                         "generic": null,
                         "nullable": false,
@@ -83,6 +88,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -110,6 +116,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -123,11 +130,13 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": true,
                             "generic": "sequence",
                             "nullable": false,
                             "union": false,
                             "idlType": {
+                                "type": null,
                                 "sequence": false,
                                 "generic": null,
                                 "nullable": false,

--- a/test/syntax/json/setlike.json
+++ b/test/syntax/json/setlike.json
@@ -8,6 +8,7 @@
                 "type": "setlike",
                 "idlType": [
                     {
+                        "type": null,
                         "sequence": false,
                         "generic": null,
                         "nullable": false,
@@ -31,6 +32,7 @@
                 "type": "setlike",
                 "idlType": [
                     {
+                        "type": null,
                         "sequence": false,
                         "generic": null,
                         "nullable": false,
@@ -54,6 +56,7 @@
                 "type": "setlike",
                 "idlType": [
                     {
+                        "type": null,
                         "sequence": false,
                         "generic": null,
                         "nullable": false,

--- a/test/syntax/json/static.json
+++ b/test/syntax/json/static.json
@@ -19,6 +19,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -35,6 +36,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -51,6 +53,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -67,6 +70,7 @@
                 "inherit": false,
                 "readonly": true,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -84,6 +88,7 @@
                 "static": true,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -97,6 +102,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -110,6 +116,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -123,6 +130,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,

--- a/test/syntax/json/stringifier-attribute.json
+++ b/test/syntax/json/stringifier-attribute.json
@@ -11,6 +11,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -27,6 +28,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,

--- a/test/syntax/json/stringifier-custom.json
+++ b/test/syntax/json/stringifier-custom.json
@@ -11,6 +11,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -27,6 +28,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": true,
@@ -43,6 +45,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -60,6 +63,7 @@
                 "static": false,
                 "stringifier": true,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,

--- a/test/syntax/json/stringifier.json
+++ b/test/syntax/json/stringifier.json
@@ -12,6 +12,7 @@
                 "static": false,
                 "stringifier": true,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,

--- a/test/syntax/json/treatasnull.json
+++ b/test/syntax/json/treatasnull.json
@@ -11,6 +11,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -27,6 +28,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -44,6 +46,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -67,6 +70,7 @@
                             }
                         ],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,

--- a/test/syntax/json/treatasundefined.json
+++ b/test/syntax/json/treatasundefined.json
@@ -11,6 +11,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -27,6 +28,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -44,6 +46,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -67,6 +70,7 @@
                             }
                         ],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,

--- a/test/syntax/json/typedef-union.json
+++ b/test/syntax/json/typedef-union.json
@@ -8,6 +8,7 @@
             "union": true,
             "idlType": [
                 {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -15,6 +16,7 @@
                     "idlType": "ImageData"
                 },
                 {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -22,6 +24,7 @@
                     "idlType": "HTMLImageElement"
                 },
                 {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -29,6 +32,7 @@
                     "idlType": "HTMLCanvasElement"
                 },
                 {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,

--- a/test/syntax/json/typedef.json
+++ b/test/syntax/json/typedef.json
@@ -11,6 +11,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -27,6 +28,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -43,11 +45,13 @@
     {
         "type": "typedef",
         "idlType": {
+            "type": null,
             "sequence": true,
             "generic": "sequence",
             "nullable": false,
             "union": false,
             "idlType": {
+                "type": null,
                 "sequence": false,
                 "generic": null,
                 "nullable": false,
@@ -70,6 +74,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -86,6 +91,7 @@
                 "inherit": false,
                 "readonly": false,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -111,6 +117,7 @@
                 "inherit": false,
                 "readonly": true,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -128,6 +135,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -141,6 +149,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -160,6 +169,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -173,6 +183,7 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -191,6 +202,7 @@
     {
         "type": "typedef",
         "idlType": {
+            "type": null,
             "sequence": false,
             "generic": null,
             "nullable": false,

--- a/test/syntax/json/typesuffixes.json
+++ b/test/syntax/json/typesuffixes.json
@@ -12,6 +12,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -25,11 +26,13 @@
                         "variadic": false,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": true,
                             "generic": "sequence",
                             "nullable": true,
                             "union": false,
                             "idlType": {
+                                "type": null,
                                 "sequence": false,
                                 "generic": null,
                                 "nullable": true,

--- a/test/syntax/json/uniontype.json
+++ b/test/syntax/json/uniontype.json
@@ -17,6 +17,7 @@
                     "union": true,
                     "idlType": [
                         {
+                            "type": "attribute-type",
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -30,6 +31,7 @@
                             "union": true,
                             "idlType": [
                                 {
+                                    "type": "attribute-type",
                                     "sequence": false,
                                     "generic": null,
                                     "nullable": false,
@@ -37,6 +39,7 @@
                                     "idlType": "Date"
                                 },
                                 {
+                                    "type": "attribute-type",
                                     "sequence": false,
                                     "generic": null,
                                     "nullable": false,
@@ -52,6 +55,7 @@
                             "union": true,
                             "idlType": [
                                 {
+                                    "type": "attribute-type",
                                     "sequence": false,
                                     "generic": null,
                                     "nullable": false,
@@ -59,6 +63,7 @@
                                     "idlType": "Node"
                                 },
                                 {
+                                    "type": "attribute-type",
                                     "sequence": false,
                                     "generic": null,
                                     "nullable": false,
@@ -85,6 +90,7 @@
                     "union": true,
                     "idlType": [
                         {
+                            "type": "attribute-type",
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -100,6 +106,7 @@
                             ]
                         },
                         {
+                            "type": "attribute-type",
                             "sequence": false,
                             "generic": null,
                             "nullable": false,

--- a/test/syntax/json/variadic-operations.json
+++ b/test/syntax/json/variadic-operations.json
@@ -11,6 +11,7 @@
                 "inherit": false,
                 "readonly": true,
                 "idlType": {
+                    "type": "attribute-type",
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -28,6 +29,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -41,6 +43,7 @@
                         "variadic": true,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,
@@ -60,6 +63,7 @@
                 "static": false,
                 "stringifier": false,
                 "idlType": {
+                    "type": null,
                     "sequence": false,
                     "generic": null,
                     "nullable": false,
@@ -73,6 +77,7 @@
                         "variadic": true,
                         "extAttrs": [],
                         "idlType": {
+                            "type": null,
                             "sequence": false,
                             "generic": null,
                             "nullable": false,


### PR DESCRIPTION
Fixes #93 

(Happy one-tap acquisition :tada:)

I added only `attribute-type` to get some feedback first. Consts (or anything that call `primitive_type()`) define idlType as mere strings, do we want to make them objects with `type: "const-type"`?