### PR TITLE
refactor: small syntax changes

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -58,7 +58,7 @@
       getter: false,
       setter: false,
       deleter: false,
-      "static": false,
+      static: false,
       stringifier: false
     });
 
@@ -519,7 +519,7 @@
       const grabbed = [];
       const ret = {
         type: "attribute",
-        "static": false,
+        static: false,
         stringifier: false,
         inherit: false,
         readonly: false
@@ -527,7 +527,7 @@
       const w = all_ws();
       if (w) grabbed.push(w);
       if (consume(ID, "inherit")) {
-        if (ret["static"] || ret.stringifier) error("Cannot have a static or stringifier inherit");
+        if (ret.static || ret.stringifier) error("Cannot have a static or stringifier inherit");
         ret.inherit = true;
         grabbed.push(last_token);
         const w = all_ws();
@@ -807,7 +807,7 @@
       const grabbed = [];
       const ret = {
         type: "attribute",
-        "static": false,
+        static: false,
         stringifier: false,
         inherit: false,
         readonly: false

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -10,7 +10,7 @@
       "string": /^"[^"]*"/,
       "whitespace": /^(?:[\t\n\r ]+|[\t\n\r ]*((\/\/.*|\/\*(.|\n|\r)*?\*\/)[\t\n\r ]*))+/,
       "other": /^[^\t\n\r 0-9A-Z_a-z]/
-    };
+    }
     const types = ["float", "integer", "identifier", "string", "whitespace", "other"];
     while (str.length > 0) {
       let matched = false;
@@ -26,7 +26,7 @@
       throw new Error("Token stream not progressing");
     }
     return tokens;
-  };
+  }
 
   class WebIDLParseError {
     constructor(str, line, input, tokens) {
@@ -81,7 +81,7 @@
       }
 
       throw new WebIDLParseError(message, line, tok, tokens.slice(0, maxTokens));
-    };
+    }
 
     function sanitize_name(name, type) {
       if (names.has(name)) {
@@ -100,7 +100,7 @@
         if (type === ID) last_token.value = last_token.value.replace(/^_/, "");
         return last_token;
       }
-    };
+    }
 
     function ws() {
       if (!tokens.length) return;
@@ -112,7 +112,7 @@
         });
         return t;
       }
-    };
+    }
 
     function all_ws(store, pea) { // pea == post extended attribute, tpea = same for types
       const t = { type: "whitespace", value: "" };
@@ -147,7 +147,7 @@
         }
         return t;
       }
-    };
+    }
 
     function integer_type() {
       let ret = "";
@@ -162,7 +162,7 @@
         return ret;
       }
       if (ret) error("Failed to parse integer type");
-    };
+    }
 
     function float_type() {
       let ret = "";
@@ -172,7 +172,7 @@
       if (consume(ID, "float")) return ret + "float";
       if (consume(ID, "double")) return ret + "double";
       if (ret) error("Failed to parse float type");
-    };
+    }
 
     function primitive_type() {
       const num_type = integer_type() || float_type();
@@ -181,7 +181,7 @@
       if (consume(ID, "boolean")) return "boolean";
       if (consume(ID, "byte")) return "byte";
       if (consume(ID, "octet")) return "octet";
-    };
+    }
 
     function const_value() {
       if (consume(ID, "true")) return { type: "boolean", value: true };
@@ -196,7 +196,7 @@
         if (consume(ID, "Infinity")) return { type: "Infinity", negative: true };
         else tokens.unshift(tok);
       }
-    };
+    }
 
     function type_suffix(obj) {
       while (true) {
@@ -206,7 +206,7 @@
           obj.nullable = true;
         } else return;
       }
-    };
+    }
 
     function single_type(typeName) {
       const prim = primitive_type();
@@ -257,7 +257,7 @@
       type_suffix(ret);
       if (ret.nullable && ret.idlType === "any") error("Type any cannot be made nullable");
       return ret;
-    };
+    }
 
     function union_type(typeName) {
       all_ws();
@@ -274,18 +274,18 @@
       if (!consume(OTHER, ")")) error("Unterminated union type");
       type_suffix(ret);
       return ret;
-    };
+    }
 
     function type(typeName) {
       return single_type(typeName) || union_type(typeName);
-    };
+    }
 
     function type_with_extended_attributes(typeName) {
       const extAttrs = extended_attrs();
       const ret = single_type(typeName) || union_type(typeName);
       if (extAttrs.length && ret) ret.extAttrs = extAttrs;
       return ret;
-    };
+    }
 
     function argument(store) {
       const ret = { optional: false, variadic: false };
@@ -331,7 +331,7 @@
         }
       }
       return ret;
-    };
+    }
 
     function argument_list(store) {
       const ret = [];
@@ -344,7 +344,7 @@
         const nxt = argument(store ? ret : null) || error("Trailing comma in arguments list");
         ret.push(nxt);
       }
-    };
+    }
 
     function simple_extended_attr(store) {
       all_ws();
@@ -395,7 +395,7 @@
         consume(OTHER, ")") || error("Unexpected token in extended attribute argument list");
       }
       return ret;
-    };
+    }
 
     // Note: we parse something simpler than the official syntax. It's all that ever
     // seems to be used
@@ -415,7 +415,7 @@
       all_ws();
       consume(OTHER, "]") || error("No end of extended attribute");
       return eas;
-    };
+    }
 
     function default_() {
       all_ws();
@@ -433,7 +433,7 @@
           return str;
         }
       }
-    };
+    }
 
     function const_(store) {
       all_ws(store, "pea");
@@ -462,7 +462,7 @@
       all_ws();
       consume(OTHER, ";") || error("Unterminated const");
       return ret;
-    };
+    }
 
     function inheritance() {
       all_ws();
@@ -471,7 +471,7 @@
         const inh = consume(ID) || error("No type in inheritance");
         return inh.value;
       }
-    };
+    }
 
     function operation_rest(ret, store) {
       all_ws();
@@ -486,7 +486,7 @@
       all_ws();
       consume(OTHER, ";") || error("Unterminated operation");
       return ret;
-    };
+    }
 
     function callback(store) {
       all_ws(store, "pea");
@@ -512,7 +512,7 @@
       all_ws();
       consume(OTHER, ";") || error("Unterminated callback");
       return ret;
-    };
+    }
 
     function attribute(store) {
       all_ws(store, "pea");
@@ -544,7 +544,7 @@
         tokens = grabbed.concat(tokens);
       }
       return rest;
-    };
+    }
 
     function attribute_rest(ret) {
       if (!consume(ID, "attribute")) {
@@ -560,7 +560,7 @@
       all_ws();
       consume(OTHER, ";") || error("Unterminated attribute");
       return ret;
-    };
+    }
 
     function return_type() {
       const typ = type("return-type");
@@ -570,7 +570,7 @@
         } else error("No return type");
       }
       return typ;
-    };
+    }
 
     function operation(store) {
       all_ws(store, "pea");
@@ -592,7 +592,7 @@
       all_ws();
       operation_rest(ret, store);
       return ret;
-    };
+    }
 
     function static_member(store) {
       all_ws(store, "pea");
@@ -624,7 +624,7 @@
           arr.push(name.value);
         } else break;
       }
-    };
+    }
 
     function iterable_type() {
       if (consume(ID, "iterable")) return "iterable";
@@ -632,13 +632,13 @@
       else if (consume(ID, "maplike")) return "maplike";
       else if (consume(ID, "setlike")) return "setlike";
       else return;
-    };
+    }
 
     function readonly_iterable_type() {
       if (consume(ID, "maplike")) return "maplike";
       else if (consume(ID, "setlike")) return "setlike";
       else return;
-    };
+    }
 
     function iterable(store) {
       all_ws(store, "pea");
@@ -683,7 +683,7 @@
         error(`Error parsing ${ittype} declaration`);
 
       return ret;
-    };
+    }
 
     function interface_rest(isPartial, store, typeName = "interface") {
       all_ws();
@@ -723,7 +723,7 @@
         mem.extAttrs = ea;
         ret.members.push(mem);
       }
-    };
+    }
 
     function mixin_rest(isPartial, store) {
       all_ws();
@@ -847,7 +847,7 @@
         namespace(true, store) ||
         error("Partial doesn't apply to anything");
       return thing;
-    };
+    }
 
     function dictionary(isPartial, store) {
       all_ws(isPartial ? null : store, "pea");
@@ -893,7 +893,7 @@
         all_ws();
         consume(OTHER, ";") || error("Unterminated dictionary member");
       }
-    };
+    }
 
     function enum_(store) {
       all_ws(store, "pea");
@@ -928,7 +928,7 @@
           saw_comma = false;
         }
       }
-    };
+    }
 
     function typedef(store) {
       all_ws(store, "pea");
@@ -945,7 +945,7 @@
       all_ws();
       consume(OTHER, ";") || error("Unterminated typedef");
       return ret;
-    };
+    }
 
     function implements_(store) {
       all_ws(store, "pea");
@@ -968,7 +968,7 @@
         tokens.unshift(w);
         tokens.unshift(target);
       }
-    };
+    }
 
     function includes(store) {
       all_ws(store, "pea");
@@ -991,7 +991,7 @@
         tokens.unshift(w);
         tokens.unshift(target);
       }
-    };
+    }
 
     function definition(store) {
       return callback(store) ||
@@ -1003,7 +1003,7 @@
         implements_(store) ||
         includes(store) ||
         namespace(false, store);
-    };
+    }
 
     function definitions(store) {
       if (!tokens.length) return [];
@@ -1019,11 +1019,11 @@
         defs.push(def);
       }
       return defs;
-    };
+    }
     const res = definitions(opt.ws);
     if (tokens.length) error("Unrecognised tokens");
     return res;
-  };
+  }
 
   const obj = {
     parse(str, opt) {

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -223,19 +223,19 @@
       "ws-tpea": wsTPea,
       "line-comment": lineComment,
       "multiline-comment": multilineComment,
-      "interface": interface_,
+      interface: interface_,
       "interface mixin": interface_mixin,
       namespace,
       operation,
       attribute,
       dictionary,
       field,
-      "const": const_,
+      const: const_,
       typedef,
-      "implements": implements_,
+      implements: implements_,
       includes,
       callback,
-      "enum": enum_,
+      enum: enum_,
       iterable,
       legacyiterable,
       maplike,
@@ -260,9 +260,7 @@
 
 
   const obj = {
-    write(ast, opt = {}) {
-      return write(ast, opt);
-    }
+    write
   };
 
   if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {

--- a/test/util/collect.js
+++ b/test/util/collect.js
@@ -31,7 +31,7 @@ function* collect(base, { expectError } = {}) {
         yield new TestItem({ path, error });
       }
       else {
-        throw e;
+        throw error;
       }
     }
   }


### PR DESCRIPTION
Keywords can be used as property names in ES5 so this PR removes quotes for them.

Originally I intended to use `array.join()` for string concatenation in writer.js and then found that [it's actually slower on V8](http://jsben.ch/ltdI2). Hmm.

```diff
 function iterate(things) {
   if (!things) return;
-  let ret = "";
-  for (const thing of things) ret += dispatch(thing);
-  return ret;
+  return things.map(dispatch).join('');
 };