### PR TITLE
Optimise tokenisation and whitespace skipping

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -188,6 +188,8 @@
           let lastIndex = 0;
           while (lastIndex < w.length) {
             let matched = false;
+            // Servo doesn't support using "const" in this construction yet.
+            // |type| can be made const once Servo supports it.
             for (let type in all_ws_re) {
               const re = all_ws_re[type];
               re.lastIndex = lastIndex;

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -189,6 +189,7 @@
           while (lastIndex < w.length) {
             let matched = false;
             // Servo doesn't support using "const" in this construction yet.
+            // See https://github.com/servo/servo/issues/20231.
             // |type| can be made const once Servo supports it.
             for (let type in all_ws_re) {
               const re = all_ws_re[type];
@@ -489,10 +490,6 @@
           return { type: "sequence", value: [] };
         } else {
           const str = consume(STR) || error("No value for default");
-          if (!str.value.startsWith('"'))
-            error(`string '${str.value}' doesn't start with a quote`);
-          if (!str.value.endsWith('"'))
-            error(`string '${str.value}' doesn't end with a quote`);
           str.value = str.value.slice(1, -1);
           return str;
         }

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -178,7 +178,7 @@
           let lastIndex = 0;
           while (lastIndex < w.length) {
             let matched = false;
-            for (var type in all_ws_re) {
+            for (let type in all_ws_re) {
               const re = all_ws_re[type];
               re.lastIndex = lastIndex;
               const result = re.exec(w);

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -45,7 +45,7 @@
       } else if (/[A-Z_a-z]/.test(nextChar)) {
         result = attemptTokenMatch(str, "identifier", tokenRe.identifier,
                                    lastIndex, tokens);
-      } else if (/"/.test(nextChar)) {
+      } else if (nextChar === '"') {
         result = attemptTokenMatch(str, "string", tokenRe.string,
                                    lastIndex, tokens);
         if (result === -1) {
@@ -137,24 +137,25 @@
       if (!tokens.length || tokens[0].type !== type) return;
       if (typeof value === "undefined" || tokens[0].value === value) {
         last_token = tokens.shift();
-        if (type === ID && last_token.value.charAt(0) === '_')
+        if (type === ID && last_token.value.startsWith('_'))
           last_token.value = last_token.value.substring(1);
         return last_token;
       }
+    }
+
+    function count(str, char) {
+      let total = 0;
+      for (let i = str.indexOf(char); i !== -1; i = str.indexOf(char, i + 1)) {
+        ++total;
+      }
+      return total;
     }
 
     function ws() {
       if (!tokens.length) return;
       if (tokens[0].type === "whitespace") {
         const t = tokens.shift();
-        let i = 0;
-        while (i !== -1) {
-          i = t.value.indexOf('\n', i);
-          if (i !== -1) {
-            ++line;
-            ++i;
-          }
-        }
+        line += count(t.value, '\n');
         return t;
       }
     }
@@ -476,11 +477,11 @@
           return { type: "sequence", value: [] };
         } else {
           const str = consume(STR) || error("No value for default");
-          if (str.value.charAt(0) !== '"')
+          if (!str.value.startsWith('"'))
             error(`string '${str.value}' doesn't start with a quote`);
-          if (str.value.charAt(str.value.length - 1) !== '"')
+          if (!str.value.endsWith('"'))
             error(`string '${str.value}' doesn't end with a quote`);
-          str.value = str.value.substring(1, str.value.length - 1);
+          str.value = str.value.slice(1, -1);
           return str;
         }
       }
@@ -968,7 +969,7 @@
           return ret;
         }
         const val = consume(STR) || error("Unexpected value in enum");
-        val.value = val.value.substring(1, val.value.length - 1);
+        val.value = val.value.slice(1, -1);
         ret.values.push(val);
         all_ws(store ? vals : null);
         if (consume(OTHER, ",")) {

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -1,29 +1,69 @@
 "use strict";
 
 (() => {
+  // These regular expressions use the sticky flag so they will only match at
+  // the current location (ie. the offset of lastIndex).
+  const tokenRe = {
+    // This expression uses a lookahead assertion to catch false matches
+    // against integers early.
+    "float": /-?(?=[0-9]*\.|[0-9]+[eE])(([0-9]+\.[0-9]*|[0-9]*\.[0-9]+)([Ee][-+]?[0-9]+)?|[0-9]+[Ee][-+]?[0-9]+)/y,
+    "integer": /-?(0([Xx][0-9A-Fa-f]+|[0-7]*)|[1-9][0-9]*)/y,
+    "identifier": /[A-Z_a-z][0-9A-Z_a-z-]*/y,
+    "string": /"[^"]*"/y,
+    "whitespace": /(?:[\t\n\r ]+|(\/(\/.*|\*([^*]|\*[^\/])*\*\/)[\t\n\r ]*)+)/y,
+    "other": /[^\t\n\r 0-9A-Z_a-z]/y
+  };
+
+  function attemptTokenMatch(str, type, re, lastIndex, tokens) {
+    re.lastIndex = lastIndex;
+    const result = re.exec(str);
+    if (result) {
+      tokens.push({ type, value: result[0] });
+      return re.lastIndex;
+    }
+    return -1;
+  }
+
   function tokenise(str) {
     const tokens = [];
-    const re = {
-      "float": /^-?(([0-9]+\.[0-9]*|[0-9]*\.[0-9]+)([Ee][-+]?[0-9]+)?|[0-9]+[Ee][-+]?[0-9]+)/,
-      "integer": /^-?(0([Xx][0-9A-Fa-f]+|[0-7]*)|[1-9][0-9]*)/,
-      "identifier": /^[A-Z_a-z][0-9A-Z_a-z-]*/,
-      "string": /^"[^"]*"/,
-      "whitespace": /^(?:[\t\n\r ]+|[\t\n\r ]*((\/\/.*|\/\*(.|\n|\r)*?\*\/)[\t\n\r ]*))+/,
-      "other": /^[^\t\n\r 0-9A-Z_a-z]/
-    }
-    const types = ["float", "integer", "identifier", "string", "whitespace", "other"];
-    while (str.length > 0) {
-      let matched = false;
-      for (const type of types) {
-        str = str.replace(re[type], tok => {
-          tokens.push({ type, value: tok });
-          matched = true;
-          return "";
-        });
-        if (matched) break;
+    let lastIndex = 0;
+    while (lastIndex < str.length) {
+      const nextChar = str.charAt(lastIndex);
+      let result = -1;
+      if (/[-0-9.]/.test(nextChar)) {
+        result = attemptTokenMatch(str, "float", tokenRe.float, lastIndex,
+                                   tokens);
+        if (result === -1) {
+          result = attemptTokenMatch(str, "integer", tokenRe.integer, lastIndex,
+                                     tokens);
+        }
+        if (result === -1) {
+          // '-' and '.' can also match "other".
+          result = attemptTokenMatch(str, "other", tokenRe.other,
+                                     lastIndex, tokens);
+        }
+      } else if (/[A-Z_a-z]/.test(nextChar)) {
+        result = attemptTokenMatch(str, "identifier", tokenRe.identifier,
+                                   lastIndex, tokens);
+      } else if (/"/.test(nextChar)) {
+        result = attemptTokenMatch(str, "string", tokenRe.string,
+                                   lastIndex, tokens);
+        if (result === -1) {
+          // '"' can also match "other".
+          result = attemptTokenMatch(str, "other", tokenRe.other,
+                                     lastIndex, tokens);
+        }
+      } else if (/[\t\n\r \/]/.test(nextChar)) {
+        result = attemptTokenMatch(str, "whitespace", tokenRe.whitespace,
+                                   lastIndex, tokens);
+      } else {
+        result = attemptTokenMatch(str, "other", tokenRe.other,
+                                   lastIndex, tokens);
       }
-      if (matched) continue;
-      throw new Error("Token stream not progressing");
+      if (result === -1) {
+        throw new Error("Token stream not progressing");
+      }
+      lastIndex = result;
     }
     return tokens;
   }
@@ -97,7 +137,8 @@
       if (!tokens.length || tokens[0].type !== type) return;
       if (typeof value === "undefined" || tokens[0].value === value) {
         last_token = tokens.shift();
-        if (type === ID) last_token.value = last_token.value.replace(/^_/, "");
+        if (type === ID && last_token.value.charAt(0) === '_')
+          last_token.value = last_token.value.substring(1);
         return last_token;
       }
     }
@@ -106,14 +147,23 @@
       if (!tokens.length) return;
       if (tokens[0].type === "whitespace") {
         const t = tokens.shift();
-        t.value.replace(/\n/g, m => {
-          line++;
-          return m;
-        });
+        let i = 0;
+        while (i !== -1) {
+          i = t.value.indexOf('\n', i);
+          if (i !== -1) {
+            ++line;
+            ++i;
+          }
+        }
         return t;
       }
     }
 
+    const all_ws_re = {
+      "ws": /([\t\n\r ]+)/y,
+      "line-comment": /\/\/(.*)\r?\n?/y,
+      "multiline-comment": /\/\*((?:[^*]|\*[^/])*)\*\//y
+    };
     function all_ws(store, pea) { // pea == post extended attribute, tpea = same for types
       const t = { type: "whitespace", value: "" };
       while (true) {
@@ -124,25 +174,22 @@
       if (t.value.length > 0) {
         if (store) {
           let w = t.value;
-          const re = {
-            "ws": /^([\t\n\r ]+)/,
-            "line-comment": /^\/\/(.*)\r?\n?/,
-            "multiline-comment": /^\/\*((?:.|\n|\r)*?)\*\//
-          };
-          const wsTypes = [];
-          for (const k in re) wsTypes.push(k);
-          while (w.length) {
+          let lastIndex = 0;
+          while (lastIndex < w.length) {
             let matched = false;
-            for (const type of wsTypes) {
-              w = w.replace(re[type], (tok, m1) => {
-                store.push({ type: type + (pea ? ("-" + pea) : ""), value: m1 });
+            for (var type in all_ws_re) {
+              const re = all_ws_re[type];
+              re.lastIndex = lastIndex;
+              const result = re.exec(w);
+              if (result) {
+                store.push({ type: type + (pea ? ("-" + pea) : ""), value: result[1] });
                 matched = true;
-                return "";
-              });
-              if (matched) break;
+                lastIndex = re.lastIndex;
+                break;
+              }
             }
-            if (matched) continue;
-            throw new Error("Surprising white space construct."); // this shouldn't happen
+            if (!matched)
+              throw new Error("Surprising white space construct."); // this shouldn't happen
           }
         }
         return t;
@@ -429,7 +476,11 @@
           return { type: "sequence", value: [] };
         } else {
           const str = consume(STR) || error("No value for default");
-          str.value = str.value.replace(/^"/, "").replace(/"$/, "");
+          if (str.value.charAt(0) !== '"')
+            error(`string '${str.value}' doesn't start with a quote`);
+          if (str.value.charAt(str.value.length - 1) !== '"')
+            error(`string '${str.value}' doesn't end with a quote`);
+          str.value = str.value.substring(1, str.value.length - 1);
           return str;
         }
       }
@@ -917,7 +968,7 @@
           return ret;
         }
         const val = consume(STR) || error("Unexpected value in enum");
-        val.value = val.value.replace(/"/g, "");
+        val.value = val.value.substring(1, val.value.length - 1);
         ret.values.push(val);
         all_ws(store ? vals : null);
         if (consume(OTHER, ",")) {

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -10,7 +10,8 @@
     "integer": /-?(0([Xx][0-9A-Fa-f]+|[0-7]*)|[1-9][0-9]*)/y,
     "identifier": /[A-Z_a-z][0-9A-Z_a-z-]*/y,
     "string": /"[^"]*"/y,
-    "whitespace": /(?:[\t\n\r ]+|(\/(\/.*|\*([^*]|\*[^\/])*\*\/)[\t\n\r ]*)+)/y,
+    "whitespace": /[\t\n\r ]+/y,
+    "comment": /((\/(\/.*|\*([^*]|\*[^\/])*\*\/)[\t\n\r ]*)+)/y,
     "other": /[^\t\n\r 0-9A-Z_a-z]/y
   };
 
@@ -53,9 +54,18 @@
           result = attemptTokenMatch(str, "other", tokenRe.other,
                                      lastIndex, tokens);
         }
-      } else if (/[\t\n\r \/]/.test(nextChar)) {
+      } else if (/[\t\n\r ]/.test(nextChar)) {
         result = attemptTokenMatch(str, "whitespace", tokenRe.whitespace,
                                    lastIndex, tokens);
+      } else if (nextChar === '/') {
+        // The parser expects comments to be labelled as "whitespace".
+        result = attemptTokenMatch(str, "whitespace", tokenRe.comment,
+                                   lastIndex, tokens);
+        if (result === -1) {
+          // '/' can also match "other".
+          result = attemptTokenMatch(str, "other", tokenRe.other,
+                                     lastIndex, tokens);
+        }
       } else {
         result = attemptTokenMatch(str, "other", tokenRe.other,
                                    lastIndex, tokens);

--- a/test/invalid/idl/stray-slash.widl
+++ b/test/invalid/idl/stray-slash.widl
@@ -1,0 +1,2 @@
+// This is a comment.
+/ This is not.

--- a/test/invalid/json/stray-slash.json
+++ b/test/invalid/json/stray-slash.json
@@ -1,0 +1,4 @@
+{
+    "message":  "Got an error before parsing any named definition: Unrecognised tokens"
+,   "line":     2
+}


### PR DESCRIPTION
Tokenisation and whitespace skipping are two major hot spots for the parser.

Optimise by:
1. Using re.exec() instead of str.replace()
2. Using re.lastIndex with sticky expressions to avoid repeatedly trimming the front of the string
3. Using str.indexOf('\n') when counting newlines
5. Using a zero-width lookahead to quickly reject integers in the "float" regexp
6. Tweaking other regexps
7. Peeking at the next character in tokenise() to reduce the number of regular expressions that need to be checked at each position
8. Moving initialisation of re tables out of the hot path

Also optimise the removal of quotation marks from strings by using str.substring() instead of str.replace().

Due to optimisation of the "whitespace" regexp tokenise() now splits "  // foo" into two tokens ("  " and "// foo") rather than one. This makes no difference to the output of the parser. Verified with the test suite and with the w-p-t "idlharness" tests.

With these changes tokenize() is 30% faster and all_ws() is no longer a major contributor to parse time.