### PR TITLE
Always add extAttrs for .idlType

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,13 @@ attached to a field called `idlType`:
 
 ```JS
 {
-  "type": "return-type",
+  "type": "attribute-type",
   "sequence": false,
   "generic": null,
-  "idlType": "void",
+  "idlType": "unsigned short",
   "nullable": false,
   "union": false,
+  "extAttrs": [...]
 }
 ```
 
@@ -115,6 +116,7 @@ Where the fields are as follows:
   description for the type in the sequence, the eventual value of the promise, etc.
 * `nullable`: Boolean indicating whether this is nullable or not.
 * `union`: Boolean indicating whether this is a union type or not.
+* `extAttrs`: A list of [extended attributes](#extended-attributes).
 
 ### Interface
 

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -271,7 +271,7 @@
 
     function single_type(typeName) {
       const prim = primitive_type();
-      const ret = { type: typeName || null, sequence: false, generic: null, nullable: false, union: false };
+      const ret = { type: typeName || null, sequence: false, generic: null, nullable: false, union: false, extAttrs: [] };
       let name;
       let value;
       if (prim) {
@@ -300,9 +300,9 @@
             if (!/^(DOMString|USVString|ByteString)$/.test(types[0].idlType)) {
               error("Record key must be DOMString, USVString, or ByteString");
             }
-            if (types[0].extAttrs) error("Record key cannot have extended attribute");
+            if (types[0].extAttrs.length) error("Record key cannot have extended attribute");
           } else if (value === "Promise") {
-            if (types[0].extAttrs) error("Promise type cannot have extended attribute");
+            if (types[0].extAttrs.length) error("Promise type cannot have extended attribute");
           }
           ret.idlType = types.length === 1 ? types[0] : types;
           all_ws();
@@ -323,7 +323,7 @@
     function union_type(typeName) {
       all_ws();
       if (!consume(OTHER, "(")) return;
-      const ret = { type: typeName || null, sequence: false, generic: null, nullable: false, union: true, idlType: [] };
+      const ret = { type: typeName || null, sequence: false, generic: null, nullable: false, union: true, idlType: [], extAttrs: [] };
       const fst = type_with_extended_attributes() || error("Union type with no content");
       ret.idlType.push(fst);
       while (true) {

--- a/test/syntax/json/allowany.json
+++ b/test/syntax/json/allowany.json
@@ -17,7 +17,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "g",
                 "arguments": [],
@@ -36,7 +37,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "g",
                 "arguments": [
@@ -50,7 +52,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "B"
+                            "idlType": "B",
+                            "extAttrs": []
                         },
                         "name": "b"
                     }
@@ -70,7 +73,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "g",
                 "arguments": [
@@ -91,7 +95,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "DOMString"
+                            "idlType": "DOMString",
+                            "extAttrs": []
                         },
                         "name": "s"
                     }

--- a/test/syntax/json/attributes.json
+++ b/test/syntax/json/attributes.json
@@ -16,7 +16,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned short"
+                    "idlType": "unsigned short",
+                    "extAttrs": []
                 },
                 "name": "age",
                 "extAttrs": []

--- a/test/syntax/json/callback.json
+++ b/test/syntax/json/callback.json
@@ -8,7 +8,8 @@
             "generic": null,
             "nullable": false,
             "union": false,
-            "idlType": "void"
+            "idlType": "void",
+            "extAttrs": []
         },
         "arguments": [
             {
@@ -21,7 +22,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString"
+                    "idlType": "DOMString",
+                    "extAttrs": []
                 },
                 "name": "status"
             }
@@ -46,7 +48,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "eventOccurred",
                 "arguments": [
@@ -60,7 +63,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "DOMString"
+                            "idlType": "DOMString",
+                            "extAttrs": []
                         },
                         "name": "details"
                     }
@@ -80,7 +84,8 @@
             "generic": null,
             "nullable": false,
             "union": false,
-            "idlType": "boolean"
+            "idlType": "boolean",
+            "extAttrs": []
         },
         "arguments": [
             {
@@ -93,7 +98,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "any"
+                    "idlType": "any",
+                    "extAttrs": []
                 },
                 "name": "a"
             },
@@ -107,7 +113,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "any"
+                    "idlType": "any",
+                    "extAttrs": []
                 },
                 "name": "b"
             }

--- a/test/syntax/json/constructor.json
+++ b/test/syntax/json/constructor.json
@@ -16,7 +16,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "float"
+                    "idlType": "float",
+                    "extAttrs": []
                 },
                 "name": "r",
                 "extAttrs": []
@@ -33,7 +34,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "float"
+                    "idlType": "float",
+                    "extAttrs": []
                 },
                 "name": "cx",
                 "extAttrs": []
@@ -50,7 +52,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "float"
+                    "idlType": "float",
+                    "extAttrs": []
                 },
                 "name": "cy",
                 "extAttrs": []
@@ -67,7 +70,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "float"
+                    "idlType": "float",
+                    "extAttrs": []
                 },
                 "name": "circumference",
                 "extAttrs": []
@@ -94,7 +98,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "float"
+                            "idlType": "float",
+                            "extAttrs": []
                         },
                         "name": "radius"
                     }

--- a/test/syntax/json/dictionary-inherits.json
+++ b/test/syntax/json/dictionary-inherits.json
@@ -14,7 +14,8 @@
                     "generic": null,
                     "nullable": true,
                     "union": false,
-                    "idlType": "DOMString"
+                    "idlType": "DOMString",
+                    "extAttrs": []
                 },
                 "extAttrs": [],
                 "default": {
@@ -32,7 +33,8 @@
                     "generic": null,
                     "nullable": true,
                     "union": false,
-                    "idlType": "DOMString"
+                    "idlType": "DOMString",
+                    "extAttrs": []
                 },
                 "extAttrs": [],
                 "default": {
@@ -49,7 +51,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "Point"
+                    "idlType": "Point",
+                    "extAttrs": []
                 },
                 "extAttrs": []
             }
@@ -72,7 +75,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "float"
+                    "idlType": "float",
+                    "extAttrs": []
                 },
                 "extAttrs": []
             }

--- a/test/syntax/json/dictionary.json
+++ b/test/syntax/json/dictionary.json
@@ -14,7 +14,8 @@
                     "generic": null,
                     "nullable": true,
                     "union": false,
-                    "idlType": "DOMString"
+                    "idlType": "DOMString",
+                    "extAttrs": []
                 },
                 "extAttrs": [],
                 "default": {
@@ -32,7 +33,8 @@
                     "generic": null,
                     "nullable": true,
                     "union": false,
-                    "idlType": "DOMString"
+                    "idlType": "DOMString",
+                    "extAttrs": []
                 },
                 "extAttrs": [],
                 "default": {
@@ -49,7 +51,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "Point"
+                    "idlType": "Point",
+                    "extAttrs": []
                 },
                 "extAttrs": []
             },
@@ -69,8 +72,10 @@
                         "generic": null,
                         "nullable": false,
                         "union": false,
-                        "idlType": "long"
-                    }
+                        "idlType": "long",
+                        "extAttrs": []
+                    },
+                    "extAttrs": []
                 },
                 "extAttrs": [],
                 "default": {
@@ -88,7 +93,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "long"
+                    "idlType": "long",
+                    "extAttrs": []
                 },
                 "extAttrs": []
             }
@@ -111,7 +117,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "long"
+                    "idlType": "long",
+                    "extAttrs": []
                 },
                 "extAttrs": []
             },
@@ -125,7 +132,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "long"
+                    "idlType": "long",
+                    "extAttrs": []
                 },
                 "extAttrs": []
             }

--- a/test/syntax/json/enum.json
+++ b/test/syntax/json/enum.json
@@ -35,7 +35,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "MealType"
+                    "idlType": "MealType",
+                    "extAttrs": []
                 },
                 "name": "type",
                 "extAttrs": []
@@ -52,7 +53,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "float"
+                    "idlType": "float",
+                    "extAttrs": []
                 },
                 "name": "size",
                 "extAttrs": []
@@ -70,7 +72,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "initialize",
                 "arguments": [
@@ -84,7 +87,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "MealType"
+                            "idlType": "MealType",
+                            "extAttrs": []
                         },
                         "name": "type"
                     },
@@ -98,7 +102,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "float"
+                            "idlType": "float",
+                            "extAttrs": []
                         },
                         "name": "size"
                     }

--- a/test/syntax/json/equivalent-decl.json
+++ b/test/syntax/json/equivalent-decl.json
@@ -16,7 +16,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned long"
+                    "idlType": "unsigned long",
+                    "extAttrs": []
                 },
                 "name": "propertyCount",
                 "extAttrs": []
@@ -34,7 +35,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "float"
+                    "idlType": "float",
+                    "extAttrs": []
                 },
                 "name": "getProperty",
                 "arguments": [
@@ -48,7 +50,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "DOMString"
+                            "idlType": "DOMString",
+                            "extAttrs": []
                         },
                         "name": "propertyName"
                     }
@@ -68,7 +71,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "setProperty",
                 "arguments": [
@@ -82,7 +86,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "DOMString"
+                            "idlType": "DOMString",
+                            "extAttrs": []
                         },
                         "name": "propertyName"
                     },
@@ -96,7 +101,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "float"
+                            "idlType": "float",
+                            "extAttrs": []
                         },
                         "name": "propertyValue"
                     }
@@ -124,7 +130,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned long"
+                    "idlType": "unsigned long",
+                    "extAttrs": []
                 },
                 "name": "propertyCount",
                 "extAttrs": []
@@ -142,7 +149,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "float"
+                    "idlType": "float",
+                    "extAttrs": []
                 },
                 "name": "getProperty",
                 "arguments": [
@@ -156,7 +164,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "DOMString"
+                            "idlType": "DOMString",
+                            "extAttrs": []
                         },
                         "name": "propertyName"
                     }
@@ -176,7 +185,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "setProperty",
                 "arguments": [
@@ -190,7 +200,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "DOMString"
+                            "idlType": "DOMString",
+                            "extAttrs": []
                         },
                         "name": "propertyName"
                     },
@@ -204,7 +215,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "float"
+                            "idlType": "float",
+                            "extAttrs": []
                         },
                         "name": "propertyValue"
                     }
@@ -224,7 +236,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "float"
+                    "idlType": "float",
+                    "extAttrs": []
                 },
                 "name": null,
                 "arguments": [
@@ -238,7 +251,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "DOMString"
+                            "idlType": "DOMString",
+                            "extAttrs": []
                         },
                         "name": "propertyName"
                     }
@@ -258,7 +272,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": null,
                 "arguments": [
@@ -272,7 +287,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "DOMString"
+                            "idlType": "DOMString",
+                            "extAttrs": []
                         },
                         "name": "propertyName"
                     },
@@ -286,7 +302,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "float"
+                            "idlType": "float",
+                            "extAttrs": []
                         },
                         "name": "propertyValue"
                     }

--- a/test/syntax/json/extended-attributes.json
+++ b/test/syntax/json/extended-attributes.json
@@ -82,7 +82,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "double"
+                    "idlType": "double",
+                    "extAttrs": []
                 },
                 "name": "r",
                 "extAttrs": []
@@ -99,7 +100,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "double"
+                    "idlType": "double",
+                    "extAttrs": []
                 },
                 "name": "cx",
                 "extAttrs": []
@@ -116,7 +118,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "double"
+                    "idlType": "double",
+                    "extAttrs": []
                 },
                 "name": "cy",
                 "extAttrs": []
@@ -133,7 +136,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "double"
+                    "idlType": "double",
+                    "extAttrs": []
                 },
                 "name": "circumference",
                 "extAttrs": []
@@ -160,7 +164,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "double"
+                            "idlType": "double",
+                            "extAttrs": []
                         },
                         "name": "radius"
                     }
@@ -194,7 +199,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "long"
+                            "idlType": "long",
+                            "extAttrs": []
                         },
                         {
                             "type": null,
@@ -202,7 +208,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "Node"
+                            "idlType": "Node",
+                            "extAttrs": []
                         }
                     ],
                     "extAttrs": [

--- a/test/syntax/json/generic.json
+++ b/test/syntax/json/generic.json
@@ -35,10 +35,14 @@
                                 "generic": null,
                                 "nullable": true,
                                 "union": false,
-                                "idlType": "DOMString"
-                            }
-                        }
-                    }
+                                "idlType": "DOMString",
+                                "extAttrs": []
+                            },
+                            "extAttrs": []
+                        },
+                        "extAttrs": []
+                    },
+                    "extAttrs": []
                 },
                 "name": "bar",
                 "arguments": [],
@@ -62,8 +66,10 @@
                         "generic": null,
                         "nullable": false,
                         "union": false,
-                        "idlType": "DOMString"
-                    }
+                        "idlType": "DOMString",
+                        "extAttrs": []
+                    },
+                    "extAttrs": []
                 },
                 "name": "baz",
                 "extAttrs": []
@@ -96,8 +102,10 @@
                         "generic": null,
                         "nullable": true,
                         "union": false,
-                        "idlType": "Client"
-                    }
+                        "idlType": "Client",
+                        "extAttrs": []
+                    },
+                    "extAttrs": []
                 },
                 "name": "getServiced",
                 "arguments": [],
@@ -122,8 +130,10 @@
                         "generic": null,
                         "nullable": false,
                         "union": false,
-                        "idlType": "any"
-                    }
+                        "idlType": "any",
+                        "extAttrs": []
+                    },
+                    "extAttrs": []
                 },
                 "name": "reloadAll",
                 "arguments": [],
@@ -157,8 +167,10 @@
                         "generic": null,
                         "nullable": false,
                         "union": false,
-                        "idlType": "any"
-                    }
+                        "idlType": "any",
+                        "extAttrs": []
+                    },
+                    "extAttrs": []
                 },
                 "name": "default",
                 "arguments": [],

--- a/test/syntax/json/getter-setter.json
+++ b/test/syntax/json/getter-setter.json
@@ -16,7 +16,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned long"
+                    "idlType": "unsigned long",
+                    "extAttrs": []
                 },
                 "name": "propertyCount",
                 "extAttrs": []
@@ -34,7 +35,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "float"
+                    "idlType": "float",
+                    "extAttrs": []
                 },
                 "name": null,
                 "arguments": [
@@ -48,7 +50,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "DOMString"
+                            "idlType": "DOMString",
+                            "extAttrs": []
                         },
                         "name": "propertyName"
                     }
@@ -68,7 +71,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": null,
                 "arguments": [
@@ -82,7 +86,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "DOMString"
+                            "idlType": "DOMString",
+                            "extAttrs": []
                         },
                         "name": "propertyName"
                     },
@@ -96,7 +101,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "float"
+                            "idlType": "float",
+                            "extAttrs": []
                         },
                         "name": "propertyValue"
                     }

--- a/test/syntax/json/identifier-qualified-names.json
+++ b/test/syntax/json/identifier-qualified-names.json
@@ -7,7 +7,8 @@
             "generic": null,
             "nullable": false,
             "union": false,
-            "idlType": "float"
+            "idlType": "float",
+            "extAttrs": []
         },
         "name": "number",
         "extAttrs": []
@@ -30,7 +31,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "object"
+                    "idlType": "object",
+                    "extAttrs": []
                 },
                 "name": "createObject",
                 "arguments": [
@@ -44,7 +46,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "DOMString"
+                            "idlType": "DOMString",
+                            "extAttrs": []
                         },
                         "name": "interface"
                     }
@@ -64,7 +67,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString"
+                    "idlType": "DOMString",
+                    "extAttrs": []
                 },
                 "name": null,
                 "arguments": [
@@ -78,7 +82,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "DOMString"
+                            "idlType": "DOMString",
+                            "extAttrs": []
                         },
                         "name": "keyName"
                     }
@@ -106,7 +111,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "boolean"
+                    "idlType": "boolean",
+                    "extAttrs": []
                 },
                 "name": "const",
                 "extAttrs": []
@@ -123,7 +129,8 @@
                     "generic": null,
                     "nullable": true,
                     "union": false,
-                    "idlType": "DOMString"
+                    "idlType": "DOMString",
+                    "extAttrs": []
                 },
                 "name": "value",
                 "extAttrs": []
@@ -150,7 +157,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "op",
                 "arguments": [
@@ -164,7 +172,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "object"
+                            "idlType": "object",
+                            "extAttrs": []
                         },
                         "name": "interface"
                     }

--- a/test/syntax/json/implements.json
+++ b/test/syntax/json/implements.json
@@ -16,7 +16,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned short"
+                    "idlType": "unsigned short",
+                    "extAttrs": []
                 },
                 "name": "nodeType",
                 "extAttrs": []
@@ -43,7 +44,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "addEventListener",
                 "arguments": [
@@ -57,7 +59,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "DOMString"
+                            "idlType": "DOMString",
+                            "extAttrs": []
                         },
                         "name": "type"
                     },
@@ -71,7 +74,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "EventListener"
+                            "idlType": "EventListener",
+                            "extAttrs": []
                         },
                         "name": "listener"
                     },
@@ -85,7 +89,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "boolean"
+                            "idlType": "boolean",
+                            "extAttrs": []
                         },
                         "name": "useCapture"
                     }

--- a/test/syntax/json/indexed-properties.json
+++ b/test/syntax/json/indexed-properties.json
@@ -16,7 +16,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned long"
+                    "idlType": "unsigned long",
+                    "extAttrs": []
                 },
                 "name": "size",
                 "extAttrs": []
@@ -34,7 +35,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "any"
+                    "idlType": "any",
+                    "extAttrs": []
                 },
                 "name": "getByIndex",
                 "arguments": [
@@ -48,7 +50,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "unsigned long"
+                            "idlType": "unsigned long",
+                            "extAttrs": []
                         },
                         "name": "index"
                     }
@@ -68,7 +71,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "setByIndex",
                 "arguments": [
@@ -82,7 +86,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "unsigned long"
+                            "idlType": "unsigned long",
+                            "extAttrs": []
                         },
                         "name": "index"
                     },
@@ -96,7 +101,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "any"
+                            "idlType": "any",
+                            "extAttrs": []
                         },
                         "name": "value"
                     }
@@ -116,7 +122,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "removeByIndex",
                 "arguments": [
@@ -130,7 +137,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "unsigned long"
+                            "idlType": "unsigned long",
+                            "extAttrs": []
                         },
                         "name": "index"
                     }
@@ -150,7 +158,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "any"
+                    "idlType": "any",
+                    "extAttrs": []
                 },
                 "name": "get",
                 "arguments": [
@@ -164,7 +173,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "DOMString"
+                            "idlType": "DOMString",
+                            "extAttrs": []
                         },
                         "name": "name"
                     }
@@ -184,7 +194,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "set",
                 "arguments": [
@@ -198,7 +209,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "DOMString"
+                            "idlType": "DOMString",
+                            "extAttrs": []
                         },
                         "name": "name"
                     },
@@ -212,7 +224,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "any"
+                            "idlType": "any",
+                            "extAttrs": []
                         },
                         "name": "value"
                     }
@@ -232,7 +245,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "remove",
                 "arguments": [
@@ -246,7 +260,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "DOMString"
+                            "idlType": "DOMString",
+                            "extAttrs": []
                         },
                         "name": "name"
                     }

--- a/test/syntax/json/inherits-getter.json
+++ b/test/syntax/json/inherits-getter.json
@@ -16,7 +16,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString"
+                    "idlType": "DOMString",
+                    "extAttrs": []
                 },
                 "name": "name",
                 "extAttrs": []
@@ -42,7 +43,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned short"
+                    "idlType": "unsigned short",
+                    "extAttrs": []
                 },
                 "name": "age",
                 "extAttrs": []
@@ -59,7 +61,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString"
+                    "idlType": "DOMString",
+                    "extAttrs": []
                 },
                 "name": "name",
                 "extAttrs": []

--- a/test/syntax/json/interface-inherits.json
+++ b/test/syntax/json/interface-inherits.json
@@ -16,7 +16,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString"
+                    "idlType": "DOMString",
+                    "extAttrs": []
                 },
                 "name": "name",
                 "extAttrs": []
@@ -42,7 +43,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "Dog"
+                    "idlType": "Dog",
+                    "extAttrs": []
                 },
                 "name": "pet",
                 "extAttrs": []
@@ -68,7 +70,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "Human"
+                    "idlType": "Human",
+                    "extAttrs": []
                 },
                 "name": "owner",
                 "extAttrs": []

--- a/test/syntax/json/iterable.json
+++ b/test/syntax/json/iterable.json
@@ -13,7 +13,8 @@
                         "generic": null,
                         "nullable": false,
                         "union": false,
-                        "idlType": "long"
+                        "idlType": "long",
+                        "extAttrs": []
                     }
                 ],
                 "extAttrs": []
@@ -36,7 +37,8 @@
                         "generic": null,
                         "nullable": false,
                         "union": false,
-                        "idlType": "short"
+                        "idlType": "short",
+                        "extAttrs": []
                     },
                     {
                         "type": null,
@@ -44,7 +46,8 @@
                         "generic": null,
                         "nullable": true,
                         "union": false,
-                        "idlType": "double"
+                        "idlType": "double",
+                        "extAttrs": []
                     }
                 ],
                 "extAttrs": []

--- a/test/syntax/json/legacyiterable.json
+++ b/test/syntax/json/legacyiterable.json
@@ -13,7 +13,8 @@
                         "generic": null,
                         "nullable": false,
                         "union": false,
-                        "idlType": "long"
+                        "idlType": "long",
+                        "extAttrs": []
                     }
                 ],
                 "extAttrs": []

--- a/test/syntax/json/maplike.json
+++ b/test/syntax/json/maplike.json
@@ -13,7 +13,8 @@
                         "generic": null,
                         "nullable": false,
                         "union": false,
-                        "idlType": "long"
+                        "idlType": "long",
+                        "extAttrs": []
                     },
                     {
                         "type": null,
@@ -21,7 +22,8 @@
                         "generic": null,
                         "nullable": false,
                         "union": false,
-                        "idlType": "float"
+                        "idlType": "float",
+                        "extAttrs": []
                     }
                 ],
                 "readonly": false,
@@ -45,7 +47,8 @@
                         "generic": null,
                         "nullable": false,
                         "union": false,
-                        "idlType": "long"
+                        "idlType": "long",
+                        "extAttrs": []
                     },
                     {
                         "type": null,
@@ -53,7 +56,8 @@
                         "generic": null,
                         "nullable": false,
                         "union": false,
-                        "idlType": "float"
+                        "idlType": "float",
+                        "extAttrs": []
                     }
                 ],
                 "readonly": true,

--- a/test/syntax/json/mixin.json
+++ b/test/syntax/json/mixin.json
@@ -16,7 +16,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "Crypto"
+                    "idlType": "Crypto",
+                    "extAttrs": []
                 },
                 "name": "crypto",
                 "extAttrs": []
@@ -53,7 +54,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "Crypto"
+                    "idlType": "Crypto",
+                    "extAttrs": []
                 },
                 "name": "crypto",
                 "extAttrs": []

--- a/test/syntax/json/namedconstructor.json
+++ b/test/syntax/json/namedconstructor.json
@@ -28,7 +28,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "DOMString"
+                            "idlType": "DOMString",
+                            "extAttrs": []
                         },
                         "name": "src"
                     }

--- a/test/syntax/json/namespace.json
+++ b/test/syntax/json/namespace.json
@@ -16,7 +16,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "Vector"
+                    "idlType": "Vector",
+                    "extAttrs": []
                 },
                 "name": "unit",
                 "extAttrs": []
@@ -34,7 +35,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "double"
+                    "idlType": "double",
+                    "extAttrs": []
                 },
                 "name": "dotProduct",
                 "arguments": [
@@ -48,7 +50,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "Vector"
+                            "idlType": "Vector",
+                            "extAttrs": []
                         },
                         "name": "x"
                     },
@@ -62,7 +65,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "Vector"
+                            "idlType": "Vector",
+                            "extAttrs": []
                         },
                         "name": "y"
                     }
@@ -82,7 +86,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "Vector"
+                    "idlType": "Vector",
+                    "extAttrs": []
                 },
                 "name": "crossProduct",
                 "arguments": [
@@ -96,7 +101,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "Vector"
+                            "idlType": "Vector",
+                            "extAttrs": []
                         },
                         "name": "x"
                     },
@@ -110,7 +116,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "Vector"
+                            "idlType": "Vector",
+                            "extAttrs": []
                         },
                         "name": "y"
                     }

--- a/test/syntax/json/nointerfaceobject.json
+++ b/test/syntax/json/nointerfaceobject.json
@@ -17,7 +17,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "any"
+                    "idlType": "any",
+                    "extAttrs": []
                 },
                 "name": "lookupEntry",
                 "arguments": [
@@ -31,7 +32,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "unsigned long"
+                            "idlType": "unsigned long",
+                            "extAttrs": []
                         },
                         "name": "key"
                     }

--- a/test/syntax/json/nullable.json
+++ b/test/syntax/json/nullable.json
@@ -39,7 +39,8 @@
                     "generic": null,
                     "nullable": true,
                     "union": false,
-                    "idlType": "DOMString"
+                    "idlType": "DOMString",
+                    "extAttrs": []
                 },
                 "name": "namespaceURI",
                 "extAttrs": []

--- a/test/syntax/json/nullableobjects.json
+++ b/test/syntax/json/nullableobjects.json
@@ -33,7 +33,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "f",
                 "arguments": [
@@ -47,7 +48,8 @@
                             "generic": null,
                             "nullable": true,
                             "union": false,
-                            "idlType": "A"
+                            "idlType": "A",
+                            "extAttrs": []
                         },
                         "name": "x"
                     }
@@ -67,7 +69,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "f",
                 "arguments": [
@@ -81,7 +84,8 @@
                             "generic": null,
                             "nullable": true,
                             "union": false,
-                            "idlType": "B"
+                            "idlType": "B",
+                            "extAttrs": []
                         },
                         "name": "x"
                     }

--- a/test/syntax/json/operation-optional-arg.json
+++ b/test/syntax/json/operation-optional-arg.json
@@ -17,7 +17,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "object"
+                    "idlType": "object",
+                    "extAttrs": []
                 },
                 "name": "createColor",
                 "arguments": [
@@ -31,7 +32,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "float"
+                            "idlType": "float",
+                            "extAttrs": []
                         },
                         "name": "v1"
                     },
@@ -45,7 +47,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "float"
+                            "idlType": "float",
+                            "extAttrs": []
                         },
                         "name": "v2"
                     },
@@ -59,7 +62,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "float"
+                            "idlType": "float",
+                            "extAttrs": []
                         },
                         "name": "v3"
                     },
@@ -73,7 +77,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "float"
+                            "idlType": "float",
+                            "extAttrs": []
                         },
                         "name": "alpha",
                         "default": {

--- a/test/syntax/json/overloading.json
+++ b/test/syntax/json/overloading.json
@@ -33,7 +33,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "f",
                 "arguments": [
@@ -47,7 +48,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "A"
+                            "idlType": "A",
+                            "extAttrs": []
                         },
                         "name": "x"
                     }
@@ -67,7 +69,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "f",
                 "arguments": [
@@ -81,7 +84,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "B"
+                            "idlType": "B",
+                            "extAttrs": []
                         },
                         "name": "x"
                     }
@@ -110,7 +114,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "f",
                 "arguments": [
@@ -124,7 +129,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "DOMString"
+                            "idlType": "DOMString",
+                            "extAttrs": []
                         },
                         "name": "a"
                     }
@@ -144,7 +150,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "f",
                 "arguments": [
@@ -165,7 +172,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "DOMString"
+                            "idlType": "DOMString",
+                            "extAttrs": []
                         },
                         "name": "a"
                     },
@@ -179,7 +187,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "DOMString"
+                            "idlType": "DOMString",
+                            "extAttrs": []
                         },
                         "name": "b"
                     },
@@ -193,7 +202,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "float"
+                            "idlType": "float",
+                            "extAttrs": []
                         },
                         "name": "c"
                     }
@@ -213,7 +223,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "f",
                 "arguments": [],
@@ -232,7 +243,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "f",
                 "arguments": [
@@ -246,7 +258,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "long"
+                            "idlType": "long",
+                            "extAttrs": []
                         },
                         "name": "a"
                     },
@@ -260,7 +273,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "DOMString"
+                            "idlType": "DOMString",
+                            "extAttrs": []
                         },
                         "name": "b"
                     },
@@ -274,7 +288,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "DOMString"
+                            "idlType": "DOMString",
+                            "extAttrs": []
                         },
                         "name": "c"
                     },
@@ -288,7 +303,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "float"
+                            "idlType": "float",
+                            "extAttrs": []
                         },
                         "name": "d"
                     }

--- a/test/syntax/json/overridebuiltins.json
+++ b/test/syntax/json/overridebuiltins.json
@@ -16,7 +16,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned long"
+                    "idlType": "unsigned long",
+                    "extAttrs": []
                 },
                 "name": "length",
                 "extAttrs": []
@@ -34,7 +35,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString"
+                    "idlType": "DOMString",
+                    "extAttrs": []
                 },
                 "name": "lookup",
                 "arguments": [
@@ -48,7 +50,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "DOMString"
+                            "idlType": "DOMString",
+                            "extAttrs": []
                         },
                         "name": "key"
                     }

--- a/test/syntax/json/partial-interface.json
+++ b/test/syntax/json/partial-interface.json
@@ -16,7 +16,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString"
+                    "idlType": "DOMString",
+                    "extAttrs": []
                 },
                 "name": "bar",
                 "extAttrs": []
@@ -42,7 +43,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString"
+                    "idlType": "DOMString",
+                    "extAttrs": []
                 },
                 "name": "quux",
                 "extAttrs": []

--- a/test/syntax/json/primitives.json
+++ b/test/syntax/json/primitives.json
@@ -16,7 +16,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "boolean"
+                    "idlType": "boolean",
+                    "extAttrs": []
                 },
                 "name": "truth",
                 "extAttrs": []
@@ -33,7 +34,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "byte"
+                    "idlType": "byte",
+                    "extAttrs": []
                 },
                 "name": "character",
                 "extAttrs": []
@@ -50,7 +52,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "octet"
+                    "idlType": "octet",
+                    "extAttrs": []
                 },
                 "name": "value",
                 "extAttrs": []
@@ -67,7 +70,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "short"
+                    "idlType": "short",
+                    "extAttrs": []
                 },
                 "name": "number",
                 "extAttrs": []
@@ -84,7 +88,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned short"
+                    "idlType": "unsigned short",
+                    "extAttrs": []
                 },
                 "name": "positive",
                 "extAttrs": []
@@ -101,7 +106,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "long"
+                    "idlType": "long",
+                    "extAttrs": []
                 },
                 "name": "big",
                 "extAttrs": []
@@ -118,7 +124,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned long"
+                    "idlType": "unsigned long",
+                    "extAttrs": []
                 },
                 "name": "bigpositive",
                 "extAttrs": []
@@ -135,7 +142,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "long long"
+                    "idlType": "long long",
+                    "extAttrs": []
                 },
                 "name": "bigbig",
                 "extAttrs": []
@@ -152,7 +160,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned long long"
+                    "idlType": "unsigned long long",
+                    "extAttrs": []
                 },
                 "name": "bigbigpositive",
                 "extAttrs": []
@@ -169,7 +178,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "float"
+                    "idlType": "float",
+                    "extAttrs": []
                 },
                 "name": "real",
                 "extAttrs": []
@@ -186,7 +196,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "double"
+                    "idlType": "double",
+                    "extAttrs": []
                 },
                 "name": "bigreal",
                 "extAttrs": []
@@ -203,7 +214,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "unrestricted float"
+                    "idlType": "unrestricted float",
+                    "extAttrs": []
                 },
                 "name": "realwithinfinity",
                 "extAttrs": []
@@ -220,7 +232,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "unrestricted double"
+                    "idlType": "unrestricted double",
+                    "extAttrs": []
                 },
                 "name": "bigrealwithinfinity",
                 "extAttrs": []
@@ -237,7 +250,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString"
+                    "idlType": "DOMString",
+                    "extAttrs": []
                 },
                 "name": "string",
                 "extAttrs": []
@@ -254,7 +268,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "ByteString"
+                    "idlType": "ByteString",
+                    "extAttrs": []
                 },
                 "name": "bytes",
                 "extAttrs": []
@@ -271,7 +286,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "Date"
+                    "idlType": "Date",
+                    "extAttrs": []
                 },
                 "name": "date",
                 "extAttrs": []
@@ -288,7 +304,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "RegExp"
+                    "idlType": "RegExp",
+                    "extAttrs": []
                 },
                 "name": "regexp",
                 "extAttrs": []

--- a/test/syntax/json/prototyperoot.json
+++ b/test/syntax/json/prototyperoot.json
@@ -16,7 +16,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned short"
+                    "idlType": "unsigned short",
+                    "extAttrs": []
                 },
                 "name": "nodeType",
                 "extAttrs": []

--- a/test/syntax/json/putforwards.json
+++ b/test/syntax/json/putforwards.json
@@ -16,7 +16,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "Name"
+                    "idlType": "Name",
+                    "extAttrs": []
                 },
                 "name": "name",
                 "extAttrs": [
@@ -43,7 +44,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned short"
+                    "idlType": "unsigned short",
+                    "extAttrs": []
                 },
                 "name": "age",
                 "extAttrs": []

--- a/test/syntax/json/record.json
+++ b/test/syntax/json/record.json
@@ -17,7 +17,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "foo",
                 "arguments": [
@@ -44,7 +45,8 @@
                                         "generic": null,
                                         "nullable": false,
                                         "union": false,
-                                        "idlType": "ByteString"
+                                        "idlType": "ByteString",
+                                        "extAttrs": []
                                     },
                                     {
                                         "type": "argument-type",
@@ -52,10 +54,13 @@
                                         "generic": null,
                                         "nullable": false,
                                         "union": false,
-                                        "idlType": "any"
+                                        "idlType": "any",
+                                        "extAttrs": []
                                     }
-                                ]
-                            }
+                                ],
+                                "extAttrs": []
+                            },
+                            "extAttrs": []
                         },
                         "name": "param"
                     }
@@ -82,7 +87,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "DOMString"
+                            "idlType": "DOMString",
+                            "extAttrs": []
                         },
                         {
                             "type": "return-type",
@@ -97,7 +103,8 @@
                                     "generic": null,
                                     "nullable": false,
                                     "union": false,
-                                    "idlType": "float"
+                                    "idlType": "float",
+                                    "extAttrs": []
                                 },
                                 {
                                     "type": null,
@@ -105,11 +112,14 @@
                                     "generic": null,
                                     "nullable": false,
                                     "union": false,
-                                    "idlType": "DOMString"
+                                    "idlType": "DOMString",
+                                    "extAttrs": []
                                 }
-                            ]
+                            ],
+                            "extAttrs": []
                         }
-                    ]
+                    ],
+                    "extAttrs": []
                 },
                 "name": "bar",
                 "arguments": [],
@@ -128,7 +138,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "record"
+                    "idlType": "record",
+                    "extAttrs": []
                 },
                 "name": "baz",
                 "arguments": [],
@@ -157,7 +168,8 @@
                                     "generic": null,
                                     "nullable": false,
                                     "union": false,
-                                    "idlType": "USVString"
+                                    "idlType": "USVString",
+                                    "extAttrs": []
                                 },
                                 {
                                     "type": "argument-type",
@@ -165,9 +177,11 @@
                                     "generic": null,
                                     "nullable": false,
                                     "union": false,
-                                    "idlType": "USVString"
+                                    "idlType": "USVString",
+                                    "extAttrs": []
                                 }
-                            ]
+                            ],
+                            "extAttrs": []
                         },
                         "name": "init"
                     }
@@ -202,7 +216,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "DOMString"
+                            "idlType": "DOMString",
+                            "extAttrs": []
                         },
                         {
                             "type": "return-type",
@@ -220,7 +235,8 @@
                                 }
                             ]
                         }
-                    ]
+                    ],
+                    "extAttrs": []
                 },
                 "name": "bar",
                 "arguments": [],

--- a/test/syntax/json/reg-operations.json
+++ b/test/syntax/json/reg-operations.json
@@ -16,7 +16,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned long"
+                    "idlType": "unsigned long",
+                    "extAttrs": []
                 },
                 "name": "width",
                 "extAttrs": []
@@ -33,7 +34,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned long"
+                    "idlType": "unsigned long",
+                    "extAttrs": []
                 },
                 "name": "height",
                 "extAttrs": []
@@ -60,7 +62,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "boolean"
+                    "idlType": "boolean",
+                    "extAttrs": []
                 },
                 "name": "isMouseOver",
                 "arguments": [],
@@ -79,7 +82,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "setDimensions",
                 "arguments": [
@@ -93,7 +97,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "Dimensions"
+                            "idlType": "Dimensions",
+                            "extAttrs": []
                         },
                         "name": "size"
                     }
@@ -113,7 +118,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "setDimensions",
                 "arguments": [
@@ -127,7 +133,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "unsigned long"
+                            "idlType": "unsigned long",
+                            "extAttrs": []
                         },
                         "name": "width"
                     },
@@ -141,7 +148,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "unsigned long"
+                            "idlType": "unsigned long",
+                            "extAttrs": []
                         },
                         "name": "height"
                     }

--- a/test/syntax/json/replaceable.json
+++ b/test/syntax/json/replaceable.json
@@ -16,7 +16,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned long"
+                    "idlType": "unsigned long",
+                    "extAttrs": []
                 },
                 "name": "value",
                 "extAttrs": [
@@ -41,7 +42,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "increment",
                 "arguments": [],

--- a/test/syntax/json/sequence.json
+++ b/test/syntax/json/sequence.json
@@ -17,7 +17,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "drawPolygon",
                 "arguments": [
@@ -37,8 +38,10 @@
                                 "generic": null,
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "float"
-                            }
+                                "idlType": "float",
+                                "extAttrs": []
+                            },
+                            "extAttrs": []
                         },
                         "name": "coordinates"
                     }
@@ -64,8 +67,10 @@
                         "generic": null,
                         "nullable": false,
                         "union": false,
-                        "idlType": "float"
-                    }
+                        "idlType": "float",
+                        "extAttrs": []
+                    },
+                    "extAttrs": []
                 },
                 "name": "getInflectionPoints",
                 "arguments": [],
@@ -93,7 +98,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "sequence"
+                    "idlType": "sequence",
+                    "extAttrs": []
                 },
                 "name": "bar",
                 "arguments": [],
@@ -121,7 +127,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "f1",
                 "arguments": [
@@ -150,7 +157,8 @@
                                         "rhs": null
                                     }
                                 ]
-                            }
+                            },
+                            "extAttrs": []
                         },
                         "name": "arg"
                     }

--- a/test/syntax/json/setlike.json
+++ b/test/syntax/json/setlike.json
@@ -13,7 +13,8 @@
                         "generic": null,
                         "nullable": false,
                         "union": false,
-                        "idlType": "long"
+                        "idlType": "long",
+                        "extAttrs": []
                     }
                 ],
                 "readonly": false,
@@ -37,7 +38,8 @@
                         "generic": null,
                         "nullable": false,
                         "union": false,
-                        "idlType": "long"
+                        "idlType": "long",
+                        "extAttrs": []
                     }
                 ],
                 "readonly": true,

--- a/test/syntax/json/static.json
+++ b/test/syntax/json/static.json
@@ -24,7 +24,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "float"
+                    "idlType": "float",
+                    "extAttrs": []
                 },
                 "name": "cx",
                 "extAttrs": []
@@ -41,7 +42,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "float"
+                    "idlType": "float",
+                    "extAttrs": []
                 },
                 "name": "cy",
                 "extAttrs": []
@@ -58,7 +60,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "float"
+                    "idlType": "float",
+                    "extAttrs": []
                 },
                 "name": "radius",
                 "extAttrs": []
@@ -75,7 +78,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "long"
+                    "idlType": "long",
+                    "extAttrs": []
                 },
                 "name": "triangulationCount",
                 "extAttrs": []
@@ -93,7 +97,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "Point"
+                    "idlType": "Point",
+                    "extAttrs": []
                 },
                 "name": "triangulate",
                 "arguments": [
@@ -107,7 +112,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "Circle"
+                            "idlType": "Circle",
+                            "extAttrs": []
                         },
                         "name": "c1"
                     },
@@ -121,7 +127,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "Circle"
+                            "idlType": "Circle",
+                            "extAttrs": []
                         },
                         "name": "c2"
                     },
@@ -135,7 +142,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "Circle"
+                            "idlType": "Circle",
+                            "extAttrs": []
                         },
                         "name": "c3"
                     }

--- a/test/syntax/json/stringifier-attribute.json
+++ b/test/syntax/json/stringifier-attribute.json
@@ -16,7 +16,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned long"
+                    "idlType": "unsigned long",
+                    "extAttrs": []
                 },
                 "name": "id",
                 "extAttrs": []
@@ -33,7 +34,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString"
+                    "idlType": "DOMString",
+                    "extAttrs": []
                 },
                 "name": "name",
                 "extAttrs": []

--- a/test/syntax/json/stringifier-custom.json
+++ b/test/syntax/json/stringifier-custom.json
@@ -16,7 +16,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned long"
+                    "idlType": "unsigned long",
+                    "extAttrs": []
                 },
                 "name": "id",
                 "extAttrs": []
@@ -33,7 +34,8 @@
                     "generic": null,
                     "nullable": true,
                     "union": false,
-                    "idlType": "DOMString"
+                    "idlType": "DOMString",
+                    "extAttrs": []
                 },
                 "name": "familyName",
                 "extAttrs": []
@@ -50,7 +52,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString"
+                    "idlType": "DOMString",
+                    "extAttrs": []
                 },
                 "name": "givenName",
                 "extAttrs": []
@@ -68,7 +71,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString"
+                    "idlType": "DOMString",
+                    "extAttrs": []
                 },
                 "name": null,
                 "arguments": [],

--- a/test/syntax/json/stringifier.json
+++ b/test/syntax/json/stringifier.json
@@ -17,7 +17,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString"
+                    "idlType": "DOMString",
+                    "extAttrs": []
                 },
                 "name": null,
                 "arguments": [],

--- a/test/syntax/json/treatasnull.json
+++ b/test/syntax/json/treatasnull.json
@@ -16,7 +16,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString"
+                    "idlType": "DOMString",
+                    "extAttrs": []
                 },
                 "name": "name",
                 "extAttrs": []
@@ -33,7 +34,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString"
+                    "idlType": "DOMString",
+                    "extAttrs": []
                 },
                 "name": "owner",
                 "extAttrs": []
@@ -51,7 +53,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "boolean"
+                    "idlType": "boolean",
+                    "extAttrs": []
                 },
                 "name": "isMemberOfBreed",
                 "arguments": [
@@ -75,7 +78,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "DOMString"
+                            "idlType": "DOMString",
+                            "extAttrs": []
                         },
                         "name": "breedName"
                     }

--- a/test/syntax/json/treatasundefined.json
+++ b/test/syntax/json/treatasundefined.json
@@ -16,7 +16,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString"
+                    "idlType": "DOMString",
+                    "extAttrs": []
                 },
                 "name": "name",
                 "extAttrs": []
@@ -33,7 +34,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString"
+                    "idlType": "DOMString",
+                    "extAttrs": []
                 },
                 "name": "owner",
                 "extAttrs": []
@@ -51,7 +53,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "boolean"
+                    "idlType": "boolean",
+                    "extAttrs": []
                 },
                 "name": "isMemberOfBreed",
                 "arguments": [
@@ -75,7 +78,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "DOMString"
+                            "idlType": "DOMString",
+                            "extAttrs": []
                         },
                         "name": "breedName"
                     }

--- a/test/syntax/json/typedef-union.json
+++ b/test/syntax/json/typedef-union.json
@@ -14,7 +14,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "ImageData"
+                    "idlType": "ImageData",
+                    "extAttrs": []
                 },
                 {
                     "type": null,
@@ -22,7 +23,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "HTMLImageElement"
+                    "idlType": "HTMLImageElement",
+                    "extAttrs": []
                 },
                 {
                     "type": null,
@@ -30,7 +32,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "HTMLCanvasElement"
+                    "idlType": "HTMLCanvasElement",
+                    "extAttrs": []
                 },
                 {
                     "type": null,
@@ -38,9 +41,11 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "HTMLVideoElement"
+                    "idlType": "HTMLVideoElement",
+                    "extAttrs": []
                 }
-            ]
+            ],
+            "extAttrs": []
         },
         "name": "TexImageSource",
         "extAttrs": []

--- a/test/syntax/json/typedef.json
+++ b/test/syntax/json/typedef.json
@@ -16,7 +16,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "float"
+                    "idlType": "float",
+                    "extAttrs": []
                 },
                 "name": "x",
                 "extAttrs": []
@@ -33,7 +34,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "float"
+                    "idlType": "float",
+                    "extAttrs": []
                 },
                 "name": "y",
                 "extAttrs": []
@@ -56,8 +58,10 @@
                 "generic": null,
                 "nullable": false,
                 "union": false,
-                "idlType": "Point"
-            }
+                "idlType": "Point",
+                "extAttrs": []
+            },
+            "extAttrs": []
         },
         "name": "PointSequence",
         "extAttrs": []
@@ -79,7 +83,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "Point"
+                    "idlType": "Point",
+                    "extAttrs": []
                 },
                 "name": "topleft",
                 "extAttrs": []
@@ -96,7 +101,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "Point"
+                    "idlType": "Point",
+                    "extAttrs": []
                 },
                 "name": "bottomright",
                 "extAttrs": []
@@ -122,7 +128,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "Rect"
+                    "idlType": "Rect",
+                    "extAttrs": []
                 },
                 "name": "bounds",
                 "extAttrs": []
@@ -140,7 +147,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "boolean"
+                    "idlType": "boolean",
+                    "extAttrs": []
                 },
                 "name": "pointWithinBounds",
                 "arguments": [
@@ -154,7 +162,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "Point"
+                            "idlType": "Point",
+                            "extAttrs": []
                         },
                         "name": "p"
                     }
@@ -174,7 +183,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "boolean"
+                    "idlType": "boolean",
+                    "extAttrs": []
                 },
                 "name": "allPointsWithinBounds",
                 "arguments": [
@@ -188,7 +198,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "PointSequence"
+                            "idlType": "PointSequence",
+                            "extAttrs": []
                         },
                         "name": "ps"
                     }

--- a/test/syntax/json/typesuffixes.json
+++ b/test/syntax/json/typesuffixes.json
@@ -17,7 +17,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "test",
                 "arguments": [
@@ -37,8 +38,10 @@
                                 "generic": null,
                                 "nullable": true,
                                 "union": false,
-                                "idlType": "DOMString"
-                            }
+                                "idlType": "DOMString",
+                                "extAttrs": []
+                            },
+                            "extAttrs": []
                         },
                         "name": "foo"
                     }

--- a/test/syntax/json/uniontype.json
+++ b/test/syntax/json/uniontype.json
@@ -23,7 +23,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "float"
+                            "idlType": "float",
+                            "extAttrs": []
                         },
                         {
                             "type": null,
@@ -38,7 +39,8 @@
                                     "generic": null,
                                     "nullable": false,
                                     "union": false,
-                                    "idlType": "Date"
+                                    "idlType": "Date",
+                                    "extAttrs": []
                                 },
                                 {
                                     "type": null,
@@ -46,9 +48,11 @@
                                     "generic": null,
                                     "nullable": false,
                                     "union": false,
-                                    "idlType": "Event"
+                                    "idlType": "Event",
+                                    "extAttrs": []
                                 }
-                            ]
+                            ],
+                            "extAttrs": []
                         },
                         {
                             "type": null,
@@ -63,7 +67,8 @@
                                     "generic": null,
                                     "nullable": false,
                                     "union": false,
-                                    "idlType": "Node"
+                                    "idlType": "Node",
+                                    "extAttrs": []
                                 },
                                 {
                                     "type": null,
@@ -71,11 +76,14 @@
                                     "generic": null,
                                     "nullable": false,
                                     "union": false,
-                                    "idlType": "DOMString"
+                                    "idlType": "DOMString",
+                                    "extAttrs": []
                                 }
-                            ]
+                            ],
+                            "extAttrs": []
                         }
-                    ]
+                    ],
+                    "extAttrs": []
                 },
                 "name": "test",
                 "extAttrs": []
@@ -115,9 +123,11 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "Date"
+                            "idlType": "Date",
+                            "extAttrs": []
                         }
-                    ]
+                    ],
+                    "extAttrs": []
                 },
                 "name": "test2",
                 "extAttrs": []

--- a/test/syntax/json/variadic-operations.json
+++ b/test/syntax/json/variadic-operations.json
@@ -16,7 +16,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned long"
+                    "idlType": "unsigned long",
+                    "extAttrs": []
                 },
                 "name": "cardinality",
                 "extAttrs": []
@@ -34,7 +35,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "union",
                 "arguments": [
@@ -48,7 +50,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "long"
+                            "idlType": "long",
+                            "extAttrs": []
                         },
                         "name": "ints"
                     }
@@ -68,7 +71,8 @@
                     "generic": null,
                     "nullable": false,
                     "union": false,
-                    "idlType": "void"
+                    "idlType": "void",
+                    "extAttrs": []
                 },
                 "name": "intersection",
                 "arguments": [
@@ -82,7 +86,8 @@
                             "generic": null,
                             "nullable": false,
                             "union": false,
-                            "idlType": "long"
+                            "idlType": "long",
+                            "extAttrs": []
                         },
                         "name": "ints"
                     }


### PR DESCRIPTION
1. An IDL Type can have extended attributes except when it's a return type, but currently it's not in the documentation.
2. `extAttrs` property for IDL types is not defined for types that don't have any extended attributes, and this is inconsistent with behaviors in e.g. arguments.

Thus this PR always adds `extAttrs` so that users don't have to check its existence.