### PR TITLE
const-type as full IDL Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,8 @@ A callback looks like this:
     "generic": null,
     "nullable": false,
     "union": false,
-    "idlType": "void"
+    "idlType": "void",
+    "extAttrs": []
   },
   "arguments": [...],
   "extAttrs": []
@@ -254,7 +255,8 @@ A dictionary looks like this:
       "generic": null,
       "nullable": true,
       "union": false,
-      "idlType": "DOMString"
+      "idlType": "DOMString",
+      "extAttrs": [...]
     },
     "extAttrs": [],
     "default": {
@@ -328,8 +330,10 @@ A typedef looks like this:
       "generic": null,
       "nullable": false,
       "union": false,
-      "idlType": "Point"
-    }
+      "idlType": "Point",
+      "extAttrs": [...]
+    },
+    "extAttrs": [...]
   },
   "name": "PointSequence",
   "extAttrs": []
@@ -401,7 +405,8 @@ An operation looks like this:
     "generic": null,
     "nullable": false,
     "union": false,
-    "idlType": "void"
+    "idlType": "void",
+    "extAttrs": []
   },
   "name": "intersection",
   "arguments": [{
@@ -414,7 +419,8 @@ An operation looks like this:
       "generic": null,
       "nullable": false,
       "union": false,
-      "idlType": "long"
+      "idlType": "long",
+      "extAttrs": [...]
     },
     "name": "ints"
   }],
@@ -452,7 +458,8 @@ An attribute member looks like this:
     "generic": null,
     "nullable": false,
     "union": false,
-    "idlType": "RegExp"
+    "idlType": "RegExp",
+    "extAttrs": [...]
   },
   "name": "regexp",
   "extAttrs": []
@@ -480,7 +487,12 @@ A constant member looks like this:
   "nullable": false,
   "idlType": {
     "type": "const-type",
+    "sequence": false,
+    "generic": null,
+    "nullable": false,
+    "union": false,
     "idlType": "boolean"
+    "extAttrs": []
   },
   "name": "DEBUG",
   "value": {
@@ -516,7 +528,8 @@ The arguments (e.g. for an operation) look like this:
       "generic": null,
       "nullable": false,
       "union": false,
-      "idlType": "long"
+      "idlType": "long",
+      "extAttrs": [...]
     },
     "name": "ints"
   }]

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -129,7 +129,7 @@
         tok += tokens[numTokens].value;
         numTokens++;
       }
-      
+
       let message;
       if (current) {
         message = `Got an error during or right after parsing \`${current.partial ? "partial " : ""}${current.type} ${current.name}\`: ${str}`
@@ -280,7 +280,7 @@
 
     function single_type(typeName) {
       const prim = primitive_type();
-      const ret = { type: typeName || null, ...EMPTY_IDLTYPE };
+      const ret = Object.assign({ type: typeName || null }, EMPTY_IDLTYPE);
       let name;
       let value;
       if (prim) {
@@ -332,7 +332,7 @@
     function union_type(typeName) {
       all_ws();
       if (!consume(OTHER, "(")) return;
-      const ret = { type: typeName || null, ...EMPTY_IDLTYPE, union: true, idlType: [] };
+      const ret = Object.assign({ type: typeName || null }, EMPTY_IDLTYPE, { union: true, idlType: [] });
       const fst = type_with_extended_attributes() || error("Union type with no content");
       ret.idlType.push(fst);
       while (true) {
@@ -515,7 +515,7 @@
         typ = consume(ID) || error("No type for const");
         typ = typ.value;
       }
-      ret.idlType = { type: "const-type", ...EMPTY_IDLTYPE, idlType: typ };
+      ret.idlType = Object.assign({ type: "const-type" }, EMPTY_IDLTYPE, { idlType: typ });
       all_ws();
       if (consume(OTHER, "?")) {
         ret.nullable = true;

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -112,6 +112,15 @@
       stringifier: false
     });
 
+    const EMPTY_IDLTYPE = Object.freeze({
+      sequence: false,
+      generic: null,
+      nullable: false,
+      union: false,
+      idlType: null,
+      extAttrs: []
+    });
+
     function error(str) {
       let tok = "";
       let numTokens = 0;
@@ -271,7 +280,7 @@
 
     function single_type(typeName) {
       const prim = primitive_type();
-      const ret = { type: typeName || null, sequence: false, generic: null, nullable: false, union: false, extAttrs: [] };
+      const ret = { type: typeName || null, ...EMPTY_IDLTYPE };
       let name;
       let value;
       if (prim) {
@@ -323,7 +332,7 @@
     function union_type(typeName) {
       all_ws();
       if (!consume(OTHER, "(")) return;
-      const ret = { type: typeName || null, sequence: false, generic: null, nullable: false, union: true, idlType: [], extAttrs: [] };
+      const ret = { type: typeName || null, ...EMPTY_IDLTYPE, union: true, idlType: [] };
       const fst = type_with_extended_attributes() || error("Union type with no content");
       ret.idlType.push(fst);
       while (true) {
@@ -506,7 +515,7 @@
         typ = consume(ID) || error("No type for const");
         typ = typ.value;
       }
-      ret.idlType = { type: "const-type", idlType: typ };
+      ret.idlType = { type: "const-type", ...EMPTY_IDLTYPE, idlType: typ };
       all_ws();
       if (consume(OTHER, "?")) {
         ret.nullable = true;

--- a/test/syntax/json/constants.json
+++ b/test/syntax/json/constants.json
@@ -9,7 +9,12 @@
                 "nullable": false,
                 "idlType": {
                     "type": "const-type",
-                    "idlType": "boolean"
+                    "sequence": false,
+                    "generic": null,
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "boolean",
+                    "extAttrs": []
                 },
                 "name": "DEBUG",
                 "value": {
@@ -23,7 +28,12 @@
                 "nullable": false,
                 "idlType": {
                     "type": "const-type",
-                    "idlType": "short"
+                    "sequence": false,
+                    "generic": null,
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "short",
+                    "extAttrs": []
                 },
                 "name": "negative",
                 "value": {
@@ -37,7 +47,12 @@
                 "nullable": false,
                 "idlType": {
                     "type": "const-type",
-                    "idlType": "octet"
+                    "sequence": false,
+                    "generic": null,
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "octet",
+                    "extAttrs": []
                 },
                 "name": "LF",
                 "value": {
@@ -51,7 +66,12 @@
                 "nullable": false,
                 "idlType": {
                     "type": "const-type",
-                    "idlType": "unsigned long"
+                    "sequence": false,
+                    "generic": null,
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "unsigned long",
+                    "extAttrs": []
                 },
                 "name": "BIT_MASK",
                 "value": {
@@ -65,7 +85,12 @@
                 "nullable": false,
                 "idlType": {
                     "type": "const-type",
-                    "idlType": "float"
+                    "sequence": false,
+                    "generic": null,
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "float",
+                    "extAttrs": []
                 },
                 "name": "AVOGADRO",
                 "value": {
@@ -79,7 +104,12 @@
                 "nullable": false,
                 "idlType": {
                     "type": "const-type",
-                    "idlType": "unrestricted float"
+                    "sequence": false,
+                    "generic": null,
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "unrestricted float",
+                    "extAttrs": []
                 },
                 "name": "sobig",
                 "value": {
@@ -93,7 +123,12 @@
                 "nullable": false,
                 "idlType": {
                     "type": "const-type",
-                    "idlType": "unrestricted double"
+                    "sequence": false,
+                    "generic": null,
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "unrestricted double",
+                    "extAttrs": []
                 },
                 "name": "minusonedividedbyzero",
                 "value": {
@@ -107,7 +142,12 @@
                 "nullable": false,
                 "idlType": {
                     "type": "const-type",
-                    "idlType": "short"
+                    "sequence": false,
+                    "generic": null,
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "short",
+                    "extAttrs": []
                 },
                 "name": "notanumber",
                 "value": {

--- a/test/syntax/json/nullable.json
+++ b/test/syntax/json/nullable.json
@@ -9,7 +9,12 @@
                 "nullable": true,
                 "idlType": {
                     "type": "const-type",
-                    "idlType": "boolean"
+                    "sequence": false,
+                    "generic": null,
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "boolean",
+                    "extAttrs": []
                 },
                 "name": "ARE_WE_THERE_YET",
                 "value": {


### PR DESCRIPTION
#141 didn't cover `const-type` so this PR adds full IDL type members to it. Those will always have the same values but it's better than forcing existence check.