### PR TITLE
refactor: one-to-one match for token matcher

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -15,7 +15,8 @@
     "other": /[^\t\n\r 0-9A-Z_a-z]/y
   };
 
-  function attemptTokenMatch(str, type, re, lastIndex, tokens) {
+  function attemptTokenMatch(str, type, lastIndex, tokens) {
+    const re = tokenRe[type];
     re.lastIndex = lastIndex;
     const result = re.exec(str);
     if (result) {
@@ -32,43 +33,32 @@
       const nextChar = str.charAt(lastIndex);
       let result = -1;
       if (/[-0-9.]/.test(nextChar)) {
-        result = attemptTokenMatch(str, "float", tokenRe.float, lastIndex,
-                                   tokens);
+        result = attemptTokenMatch(str, "float", lastIndex, tokens);
         if (result === -1) {
-          result = attemptTokenMatch(str, "integer", tokenRe.integer, lastIndex,
-                                     tokens);
+          result = attemptTokenMatch(str, "integer", lastIndex, tokens);
         }
         if (result === -1) {
           // '-' and '.' can also match "other".
-          result = attemptTokenMatch(str, "other", tokenRe.other,
-                                     lastIndex, tokens);
+          result = attemptTokenMatch(str, "other", lastIndex, tokens);
         }
       } else if (/[A-Z_a-z]/.test(nextChar)) {
-        result = attemptTokenMatch(str, "identifier", tokenRe.identifier,
-                                   lastIndex, tokens);
+        result = attemptTokenMatch(str, "identifier", lastIndex, tokens);
       } else if (nextChar === '"') {
-        result = attemptTokenMatch(str, "string", tokenRe.string,
-                                   lastIndex, tokens);
+        result = attemptTokenMatch(str, "string", lastIndex, tokens);
         if (result === -1) {
           // '"' can also match "other".
-          result = attemptTokenMatch(str, "other", tokenRe.other,
-                                     lastIndex, tokens);
+          result = attemptTokenMatch(str, "other", lastIndex, tokens);
         }
       } else if (/[\t\n\r ]/.test(nextChar)) {
-        result = attemptTokenMatch(str, "whitespace", tokenRe.whitespace,
-                                   lastIndex, tokens);
+        result = attemptTokenMatch(str, "whitespace", lastIndex, tokens);
       } else if (nextChar === '/') {
-        // The parser expects comments to be labelled as "whitespace".
-        result = attemptTokenMatch(str, "whitespace", tokenRe.comment,
-                                   lastIndex, tokens);
+        result = attemptTokenMatch(str, "comment", lastIndex, tokens);
         if (result === -1) {
           // '/' can also match "other".
-          result = attemptTokenMatch(str, "other", tokenRe.other,
-                                     lastIndex, tokens);
+          result = attemptTokenMatch(str, "other", lastIndex, tokens);
         }
       } else {
-        result = attemptTokenMatch(str, "other", tokenRe.other,
-                                   lastIndex, tokens);
+        result = attemptTokenMatch(str, "other", lastIndex, tokens);
       }
       if (result === -1) {
         throw new Error("Token stream not progressing");
@@ -172,7 +162,7 @@
 
     function ws() {
       if (!tokens.length) return;
-      if (tokens[0].type === "whitespace") {
+      if (tokens[0].type === "whitespace" || tokens[0].type === "comment") {
         const t = tokens.shift();
         line += count(t.value, '\n');
         return t;


### PR DESCRIPTION
This removes the need for the third argument `re`.