### PR TITLE
refactor: remove eas.length check

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -466,11 +466,7 @@
       eas[0] = simple_extended_attr(store) || error("Extended attribute with not content");
       all_ws();
       while (consume(OTHER, ",")) {
-        if (eas.length) {
-          eas.push(simple_extended_attr(store));
-        } else {
-          eas.push(simple_extended_attr(store) || error("Trailing comma in extended attribute"));
-        }
+        eas.push(simple_extended_attr(store) || error("Trailing comma in extended attribute"));
       }
       all_ws();
       consume(OTHER, "]") || error("No end of extended attribute");


### PR DESCRIPTION
Because it's always >= 1.