### PR TITLE
Fix whitespace handling of implements and includes.

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -1021,7 +1021,8 @@
         return ret;
       } else {
         // rollback
-        tokens.unshift(w);
+        if (w)
+          tokens.unshift(w);
         tokens.unshift(target);
       }
     }
@@ -1044,7 +1045,8 @@
         return ret;
       } else {
         // rollback
-        tokens.unshift(w);
+        if (w)
+          tokens.unshift(w);
         tokens.unshift(target);
       }
     }

--- a/test/invalid/idl/implements_and_includes_ws.widl
+++ b/test/invalid/idl/implements_and_includes_ws.widl
@@ -1,0 +1,4 @@
+// This hits the unshifting of whitespace in the "implements" and
+// "includes" productions. If there is a bug in that whitespace
+// rollback, the wrong exception will be produced.
+foobar;

--- a/test/invalid/json/implements_and_includes_ws.json
+++ b/test/invalid/json/implements_and_includes_ws.json
@@ -1,0 +1,4 @@
+{
+    "message": "Got an error before parsing any named definition: Unrecognised tokens",
+    "line": 4
+}


### PR DESCRIPTION
The all_ws() production here might return undefined for certain badly
formed WebIDL (for example, the simple text "foobar;"). Be careful not
to unshift an undefined value onto the tokens array.