### PR TITLE
Refactor simple_extended_attr();

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -424,7 +424,10 @@
           consume(FLOAT) ||
           consume(INT) ||
           consume(STR);
-        if (!ret.rhs && consume(OTHER, "(")) {
+      }
+      all_ws();
+      if (consume(OTHER, "(")) {
+        if (eq && !ret.rhs) {
           // [Exposed=(Window,Worker)]
           const rhs_list = [];
           const id = consume(ID);
@@ -432,28 +435,19 @@
             rhs_list.push(id.value);
           }
           identifiers(rhs_list);
-          consume(OTHER, ")") || error("Unexpected token in extended attribute argument list or type pair");
           ret.rhs = {
             type: "identifier-list",
             value: rhs_list
           };
         }
-        if (!ret.rhs) return error("No right hand side to extended attribute assignment");
-      }
-      all_ws();
-      if (consume(OTHER, "(")) {
-        let args, pair;
-        // [Constructor(DOMString str)]
-        if (args = argument_list(store)) {
-          ret["arguments"] = args;
-        }
-        // [Constructor()]
         else {
-          ret["arguments"] = [];
+          // [NamedConstructor=Audio(DOMString src)] or [Constructor(DOMString str)]
+          ret["arguments"] = argument_list(store) || [];
         }
         all_ws();
         consume(OTHER, ")") || error("Unexpected token in extended attribute argument list");
       }
+      if (eq && !ret.rhs) error("No right hand side to extended attribute assignment");
       return ret;
     }
 

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -429,12 +429,7 @@
       if (consume(OTHER, "(")) {
         if (eq && !ret.rhs) {
           // [Exposed=(Window,Worker)]
-          const rhs_list = [];
-          const id = consume(ID);
-          if (id) {
-            rhs_list.push(id.value);
-          }
-          identifiers(rhs_list);
+          const rhs_list = [...identifiers()];
           ret.rhs = {
             type: "identifier-list",
             value: rhs_list
@@ -665,13 +660,18 @@
         error("Unterminated stringifier");
     }
 
-    function identifiers(arr) {
+    function* identifiers() {
+      const id = consume(ID);
+      if (id) {
+        yield id.value;
+      }
+      else error("Expected identifiers but not found");
       while (true) {
         all_ws();
         if (consume(OTHER, ",")) {
           all_ws();
           const name = consume(ID) || error("Trailing comma in identifiers list");
-          arr.push(name.value);
+          yield name.value;
         } else break;
       }
     }

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -429,10 +429,9 @@
       if (consume(OTHER, "(")) {
         if (eq && !ret.rhs) {
           // [Exposed=(Window,Worker)]
-          const rhs_list = [...identifiers()];
           ret.rhs = {
             type: "identifier-list",
-            value: rhs_list
+            value: identifiers()
           };
         }
         else {
@@ -660,10 +659,11 @@
         error("Unterminated stringifier");
     }
 
-    function* identifiers() {
+    function identifiers() {
+      const arr = [];
       const id = consume(ID);
       if (id) {
-        yield id.value;
+        arr.push(id.value);
       }
       else error("Expected identifiers but not found");
       while (true) {
@@ -671,9 +671,10 @@
         if (consume(OTHER, ",")) {
           all_ws();
           const name = consume(ID) || error("Trailing comma in identifiers list");
-          yield name.value;
+          arr.push(name.value);
         } else break;
       }
+      return arr;
     }
 
     function iterable_type() {

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -396,7 +396,7 @@
     function argument_list(store) {
       const ret = [];
       const arg = argument(store ? ret : null);
-      if (!arg) return;
+      if (!arg) return ret;
       ret.push(arg);
       while (true) {
         all_ws(store ? ret : null);
@@ -412,7 +412,7 @@
       if (!name) return;
       const ret = {
         name: name.value,
-        "arguments": null,
+        arguments: null,
         type: "extended-attribute",
         rhs: null
       };
@@ -436,7 +436,7 @@
         }
         else {
           // [NamedConstructor=Audio(DOMString src)] or [Constructor(DOMString str)]
-          ret["arguments"] = argument_list(store) || [];
+          ret.arguments = argument_list(store);
         }
         all_ws();
         consume(OTHER, ")") || error("Unexpected token in extended attribute argument list");
@@ -524,7 +524,7 @@
       ret.name = name ? name.value : null;
       all_ws();
       consume(OTHER, "(") || error("Invalid operation");
-      ret["arguments"] = argument_list(store) || [];
+      ret.arguments = argument_list(store);
       all_ws();
       consume(OTHER, ")") || error("Unterminated operation");
       all_ws();
@@ -550,7 +550,7 @@
       ret.idlType = return_type();
       all_ws();
       consume(OTHER, "(") || error("No arguments in callback");
-      ret["arguments"] = argument_list(store) || [];
+      ret.arguments = argument_list(store);
       all_ws();
       consume(OTHER, ")") || error("Unterminated callback");
       all_ws();

--- a/test/invalid/idl/extattr-empty-ids.widl
+++ b/test/invalid/idl/extattr-empty-ids.widl
@@ -1,0 +1,2 @@
+[Exposed=()]
+interface Unexposed {};

--- a/test/invalid/json/extattr-empty-ids.json
+++ b/test/invalid/json/extattr-empty-ids.json
@@ -1,0 +1,4 @@
+{
+    "message": "Got an error before parsing any named definition: Expected identifiers but not found",
+    "line": 1
+}


### PR DESCRIPTION
This PR:

1. avoids checking `(` twice in different if-branches
2. removes old MapClass related variable and comment
3. throws if an identifier list is empty