### PR TITLE
Remove all_ws() and gather trivia implicitly

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -175,36 +175,12 @@
       return total;
     }
 
-    function ws() {
-      if (!tokens.length) return;
-      if (tokens[0].type === "whitespace" || tokens[0].type === "comment") {
-        const t = tokens.shift();
-        line += count(t.value, '\n');
-        return t;
-      }
-    }
-
-    function all_ws() {
-      const t = { type: "whitespace", value: "" };
-      while (true) {
-        const w = ws();
-        if (!w) break;
-        t.value += w.value;
-      }
-      if (t.value.length > 0) {
-        return t;
-      }
-    }
-
     function integer_type() {
       let ret = "";
-      all_ws();
       if (consume(ID, "unsigned")) ret = "unsigned ";
-      all_ws();
       if (consume(ID, "short")) return ret + "short";
       if (consume(ID, "long")) {
         ret += "long";
-        all_ws();
         if (consume(ID, "long")) return ret + " long";
         return ret;
       }
@@ -213,9 +189,7 @@
 
     function float_type() {
       let ret = "";
-      all_ws();
       if (consume(ID, "unrestricted")) ret = "unrestricted ";
-      all_ws();
       if (consume(ID, "float")) return ret + "float";
       if (consume(ID, "double")) return ret + "double";
       if (ret) error("Failed to parse float type");
@@ -224,7 +198,6 @@
     function primitive_type() {
       const num_type = integer_type() || float_type();
       if (num_type) return num_type;
-      all_ws();
       if (consume(ID, "boolean")) return "boolean";
       if (consume(ID, "byte")) return "byte";
       if (consume(ID, "octet")) return "octet";
@@ -247,7 +220,6 @@
 
     function type_suffix(obj) {
       while (true) {
-        all_ws();
         if (consume(OTHER, "?")) {
           if (obj.nullable) error("Can't nullable more than once");
           obj.nullable = true;
@@ -264,7 +236,6 @@
         ret.idlType = prim;
       } else if (name = consume(ID)) {
         value = name.value;
-        all_ws();
         // Generic types
         if (consume(OTHER, "<")) {
           // backwards compat
@@ -274,9 +245,7 @@
           ret.generic = value;
           const types = [];
           do {
-            all_ws();
             types.push(type_with_extended_attributes(typeName) || error("Error parsing generic type " + value));
-            all_ws();
           }
           while (consume(OTHER, ","));
           if (value === "sequence") {
@@ -291,7 +260,6 @@
             if (types[0].extAttrs.length) error("Promise type cannot have extended attribute");
           }
           ret.idlType = types.length === 1 ? types[0] : types;
-          all_ws();
           if (!consume(OTHER, ">")) error("Unterminated generic type " + value);
           type_suffix(ret);
           return ret;
@@ -307,13 +275,11 @@
     }
 
     function union_type(typeName) {
-      all_ws();
       if (!consume(OTHER, "(")) return;
       const ret = Object.assign({ type: typeName || null }, EMPTY_IDLTYPE, { union: true, idlType: [] });
       const fst = type_with_extended_attributes() || error("Union type with no content");
       ret.idlType.push(fst);
       while (true) {
-        all_ws();
         if (!consume(ID, "or")) break;
         const typ = type_with_extended_attributes() || error("No type after 'or' in union type");
         ret.idlType.push(typ);
@@ -337,11 +303,9 @@
     function argument() {
       const ret = { optional: false, variadic: false };
       ret.extAttrs = extended_attrs();
-      all_ws();
       const opt_token = consume(ID, "optional");
       if (opt_token) {
         ret.optional = true;
-        all_ws();
       }
       ret.idlType = type_with_extended_attributes("argument-type");
       if (!ret.idlType) {
@@ -350,7 +314,6 @@
       }
       const type_token = last_token;
       if (!ret.optional) {
-        all_ws();
         if (tokens.length >= 3 &&
           tokens[0].type === "other" && tokens[0].value === "." &&
           tokens[1].type === "other" && tokens[1].value === "." &&
@@ -362,7 +325,6 @@
           ret.variadic = true;
         }
       }
-      all_ws();
       const name = consume(ID);
       if (!name) {
         if (opt_token) unconsume(opt_token);
@@ -371,7 +333,6 @@
       }
       ret.name = name.value;
       if (ret.optional) {
-        all_ws();
         const dflt = default_();
         if (typeof dflt !== "undefined") {
           ret["default"] = dflt;
@@ -386,7 +347,6 @@
       if (!arg) return ret;
       ret.push(arg);
       while (true) {
-        all_ws();
         if (!consume(OTHER, ",")) return ret;
         const nxt = argument() || error("Trailing comma in arguments list");
         ret.push(nxt);
@@ -394,7 +354,6 @@
     }
 
     function simple_extended_attr() {
-      all_ws();
       const name = consume(ID);
       if (!name) return;
       const ret = {
@@ -403,10 +362,8 @@
         type: "extended-attribute",
         rhs: null
       };
-      all_ws();
       const eq = consume(OTHER, "=");
       if (eq) {
-        all_ws();
         ret.rhs = consume(ID) ||
           consume(FLOAT) ||
           consume(INT) ||
@@ -416,7 +373,6 @@
           ret.rhs.trivia = undefined;
         }
       }
-      all_ws();
       if (consume(OTHER, "(")) {
         if (eq && !ret.rhs) {
           // [Exposed=(Window,Worker)]
@@ -429,7 +385,6 @@
           // [NamedConstructor=Audio(DOMString src)] or [Constructor(DOMString str)]
           ret.arguments = argument_list();
         }
-        all_ws();
         consume(OTHER, ")") || error("Unexpected token in extended attribute argument list");
       }
       if (eq && !ret.rhs) error("No right hand side to extended attribute assignment");
@@ -440,22 +395,17 @@
     // seems to be used
     function extended_attrs() {
       const eas = [];
-      all_ws();
       if (!consume(OTHER, "[")) return eas;
       eas[0] = simple_extended_attr() || error("Extended attribute with not content");
-      all_ws();
       while (consume(OTHER, ",")) {
         eas.push(simple_extended_attr() || error("Trailing comma in extended attribute"));
       }
-      all_ws();
       consume(OTHER, "]") || error("No end of extended attribute");
       return eas;
     }
 
     function default_() {
-      all_ws();
       if (consume(OTHER, "=")) {
-        all_ws();
         const def = const_value();
         if (def) {
           return def;
@@ -473,63 +423,48 @@
     }
 
     function const_() {
-      all_ws();
       if (!consume(ID, "const")) return;
       const ret = { type: "const", nullable: false };
-      all_ws();
       let typ = primitive_type();
       if (!typ) {
         typ = consume(ID) || error("No type for const");
         typ = typ.value;
       }
       ret.idlType = Object.assign({ type: "const-type" }, EMPTY_IDLTYPE, { idlType: typ });
-      all_ws();
       if (consume(OTHER, "?")) {
         ret.nullable = true;
-        all_ws();
       }
       const name = consume(ID) || error("No name for const");
       ret.name = name.value;
-      all_ws();
       consume(OTHER, "=") || error("No value assignment for const");
-      all_ws();
       const cnt = const_value();
       if (cnt) ret.value = cnt;
       else error("No value for const");
-      all_ws();
       consume(OTHER, ";") || error("Unterminated const");
       return ret;
     }
 
     function inheritance() {
-      all_ws();
       if (consume(OTHER, ":")) {
-        all_ws();
         const inh = consume(ID) || error("No type in inheritance");
         return inh.value;
       }
     }
 
     function operation_rest(ret) {
-      all_ws();
       if (!ret) ret = {};
       const name = consume(ID);
       ret.name = name ? name.value : null;
-      all_ws();
       consume(OTHER, "(") || error("Invalid operation");
       ret.arguments = argument_list();
-      all_ws();
       consume(OTHER, ")") || error("Unterminated operation");
-      all_ws();
       consume(OTHER, ";") || error("Unterminated operation");
       return ret;
     }
 
     function callback() {
-      all_ws();
       let ret;
       if (!consume(ID, "callback")) return;
-      all_ws();
       const tok = consume(ID, "interface");
       if (tok) {
         ret = interface_rest(false, "callback interface");
@@ -537,22 +472,16 @@
       }
       const name = consume(ID) || error("No name for callback");
       ret = current = { type: "callback", name: sanitize_name(name.value, "callback") };
-      all_ws();
       consume(OTHER, "=") || error("No assignment in callback");
-      all_ws();
       ret.idlType = return_type();
-      all_ws();
       consume(OTHER, "(") || error("No arguments in callback");
       ret.arguments = argument_list();
-      all_ws();
       consume(OTHER, ")") || error("Unterminated callback");
-      all_ws();
       consume(OTHER, ";") || error("Unterminated callback");
       return ret;
     }
 
     function attribute() {
-      all_ws();
       const grabbed = [];
       const ret = {
         type: "attribute",
@@ -561,20 +490,14 @@
         inherit: false,
         readonly: false
       };
-      const w = all_ws();
-      if (w) grabbed.push(w);
       if (consume(ID, "inherit")) {
         if (ret.static || ret.stringifier) error("Cannot have a static or stringifier inherit");
         ret.inherit = true;
         grabbed.push(last_token);
-        const w = all_ws();
-        if (w) grabbed.push(w);
       }
       if (consume(ID, "readonly")) {
         ret.readonly = true;
         grabbed.push(last_token);
-        const w = all_ws();
-        if (w) grabbed.push(w);
       }
       const rest = attribute_rest(ret);
       if (!rest) {
@@ -587,14 +510,11 @@
       if (!consume(ID, "attribute")) {
         return;
       }
-      all_ws();
       ret.idlType = type_with_extended_attributes("attribute-type") || error("No type in attribute");
       if (ret.idlType.sequence) error("Attributes cannot accept sequence types");
       if (ret.idlType.generic === "record") error("Attributes cannot accept record types");
-      all_ws();
       const name = consume(ID) || error("No name in attribute");
       ret.name = name.value;
-      all_ws();
       consume(OTHER, ";") || error("Unterminated attribute");
       return ret;
     }
@@ -610,40 +530,32 @@
     }
 
     function operation() {
-      all_ws();
       const ret = Object.assign({}, EMPTY_OPERATION);
       while (true) {
-        all_ws();
         if (consume(ID, "getter")) ret.getter = true;
         else if (consume(ID, "setter")) ret.setter = true;
         else if (consume(ID, "deleter")) ret.deleter = true;
         else break;
       }
       if (ret.getter || ret.setter || ret.deleter) {
-        all_ws();
         ret.idlType = return_type();
         operation_rest(ret);
         return ret;
       }
       ret.idlType = return_type();
-      all_ws();
       operation_rest(ret);
       return ret;
     }
 
     function static_member() {
-      all_ws();
       if (!consume(ID, "static")) return;
-      all_ws();
       return noninherited_attribute("static") ||
         regular_operation("static") ||
         error("No body in static member");
     }
 
     function stringifier() {
-      all_ws();
       if (!consume(ID, "stringifier")) return;
-      all_ws();
       if (consume(OTHER, ";")) {
         return Object.assign({}, EMPTY_OPERATION, { stringifier: true });
       }
@@ -660,9 +572,7 @@
       }
       else error("Expected identifiers but not found");
       while (true) {
-        all_ws();
         if (consume(OTHER, ",")) {
-          all_ws();
           const name = consume(ID) || error("Trailing comma in identifiers list");
           arr.push(name.value);
         } else break;
@@ -685,14 +595,11 @@
     }
 
     function iterable() {
-      all_ws();
       const grabbed = [];
       const ret = { type: null, idlType: null, readonly: false };
       if (consume(ID, "readonly")) {
         ret.readonly = true;
         grabbed.push(last_token);
-        var w = all_ws();
-        if (w) grabbed.push(w);
       }
       const consumeItType = ret.readonly ? readonly_iterable_type : iterable_type;
 
@@ -707,21 +614,16 @@
       ret.type = ittype;
       if (ret.type !== 'maplike' && ret.type !== 'setlike')
         delete ret.readonly;
-      all_ws();
       if (consume(OTHER, "<")) {
         ret.idlType = [type_with_extended_attributes()] || error(`Error parsing ${ittype} declaration`);
-        all_ws();
         if (secondTypeAllowed) {
           if (consume(OTHER, ",")) {
-            all_ws();
             ret.idlType.push(type_with_extended_attributes());
-            all_ws();
           }
           else if (secondTypeRequired)
             error(`Missing second type argument in ${ittype} declaration`);
         }
         if (!consume(OTHER, ">")) error(`Unterminated ${ittype} declaration`);
-        all_ws();
         if (!consume(OTHER, ";")) error(`Missing semicolon after ${ittype} declaration`);
       } else
         error(`Error parsing ${ittype} declaration`);
@@ -730,7 +632,6 @@
     }
 
     function interface_rest(isPartial, typeName = "interface") {
-      all_ws();
       const name = consume(ID) || error("No name for interface");
       const mems = [];
       const ret = current = {
@@ -740,17 +641,13 @@
         members: mems
       };
       if (!isPartial) ret.inheritance = inheritance() || null;
-      all_ws();
       consume(OTHER, "{") || error("Bodyless interface");
       while (true) {
-        all_ws();
         if (consume(OTHER, "}")) {
-          all_ws();
           consume(OTHER, ";") || error("Missing semicolon after interface");
           return ret;
         }
         const ea = extended_attrs();
-        all_ws();
         const cnt = const_();
         if (cnt) {
           cnt.extAttrs = ea;
@@ -770,9 +667,7 @@
     }
 
     function mixin_rest(isPartial) {
-      all_ws();
       if (!consume(ID, "mixin")) return;
-      all_ws();
       const name = consume(ID) || error("No name for interface mixin");
       const mems = [];
       const ret = current = {
@@ -781,17 +676,13 @@
         partial: isPartial,
         members: mems
       };
-      all_ws();
       consume(OTHER, "{") || error("Bodyless interface mixin");
       while (true) {
-        all_ws();
         if (consume(OTHER, "}")) {
-          all_ws();
           consume(OTHER, ";") || error("Missing semicolon after interface mixin");
           return ret;
         }
         const ea = extended_attrs();
-        all_ws();
         const cnt = const_();
         if (cnt) {
           cnt.extAttrs = ea;
@@ -808,7 +699,6 @@
     }
 
     function interface_(isPartial) {
-      all_ws();
       if (!consume(ID, "interface")) return;
       return mixin_rest(isPartial) ||
         interface_rest(isPartial) ||
@@ -816,9 +706,7 @@
     }
 
     function namespace(isPartial) {
-      all_ws();
       if (!consume(ID, "namespace")) return;
-      all_ws();
       const name = consume(ID) || error("No name for namespace");
       const mems = [];
       const ret = current = {
@@ -827,17 +715,13 @@
         partial: isPartial,
         members: mems
       };
-      all_ws();
       consume(OTHER, "{") || error("Bodyless namespace");
       while (true) {
-        all_ws();
         if (consume(OTHER, "}")) {
-          all_ws();
           consume(OTHER, ";") || error("Missing semicolon after namespace");
           return ret;
         }
         const ea = extended_attrs();
-        all_ws();
         const mem = noninherited_attribute() ||
           regular_operation() ||
           error("Unknown member");
@@ -847,7 +731,6 @@
     }
 
     function noninherited_attribute(prefix) {
-      const w = all_ws();
       const grabbed = [];
       const ret = {
         type: "attribute",
@@ -859,12 +742,9 @@
       if (prefix) {
         ret[prefix] = true;
       }
-      if (w) grabbed.push(w);
       if (consume(ID, "readonly")) {
         ret.readonly = true;
         grabbed.push(last_token);
-        const w = all_ws();
-        if (w) grabbed.push(w);
       }
       const rest = attribute_rest(ret);
       if (!rest) {
@@ -874,7 +754,6 @@
     }
 
     function regular_operation(prefix) {
-      all_ws();
       const ret = Object.assign({}, EMPTY_OPERATION);
       if (prefix) {
         ret[prefix] = true;
@@ -884,7 +763,6 @@
     }
 
     function partial() {
-      all_ws();
       if (!consume(ID, "partial")) return;
       const thing = dictionary(true) ||
         interface_(true) ||
@@ -894,9 +772,7 @@
     }
 
     function dictionary(isPartial) {
-      all_ws();
       if (!consume(ID, "dictionary")) return;
-      all_ws();
       const name = consume(ID) || error("No name for dictionary");
       const mems = [];
       const ret = current = {
@@ -906,20 +782,15 @@
         members: mems
       };
       if (!isPartial) ret.inheritance = inheritance() || null;
-      all_ws();
       consume(OTHER, "{") || error("Bodyless dictionary");
       while (true) {
-        all_ws();
         if (consume(OTHER, "}")) {
-          all_ws();
           consume(OTHER, ";") || error("Missing semicolon after dictionary");
           return ret;
         }
         const ea = extended_attrs();
-        all_ws();
         const required = consume(ID, "required");
         const typ = type_with_extended_attributes("dictionary-type") || error("No type for dictionary member");
-        all_ws();
         const name = consume(ID) || error("No name for dictionary member");
         const dflt = default_();
         if (required && dflt) error("Required member must not have a default");
@@ -934,15 +805,12 @@
           member["default"] = dflt;
         }
         ret.members.push(member);
-        all_ws();
         consume(OTHER, ";") || error("Unterminated dictionary member");
       }
     }
 
     function enum_() {
-      all_ws();
       if (!consume(ID, "enum")) return;
-      all_ws();
       const name = consume(ID) || error("No name for enum");
       const vals = [];
       const ret = current = {
@@ -950,14 +818,11 @@
         name: sanitize_name(name.value, "enum"),
         values: vals
       };
-      all_ws();
       consume(OTHER, "{") || error("No curly for enum");
       let value_expected = true;
       while (true) {
-        all_ws();
         if (consume(OTHER, "}")) {
           if (!ret.values.length) error("No value in enum");
-          all_ws();
           consume(OTHER, ";") || error("No semicolon after enum");
           return ret;
         }
@@ -969,9 +834,7 @@
         // No trivia exposure yet
         val.trivia = undefined;
         ret.values.push(val);
-        all_ws();
         if (consume(OTHER, ",")) {
-          all_ws();
           value_expected = true;
         } else {
           value_expected = false;
@@ -980,66 +843,50 @@
     }
 
     function typedef() {
-      all_ws();
       if (!consume(ID, "typedef")) return;
       const ret = {
         type: "typedef"
       };
-      all_ws();
       ret.idlType = type_with_extended_attributes("typedef-type") || error("No type in typedef");
-      all_ws();
       const name = consume(ID) || error("No name in typedef");
       ret.name = sanitize_name(name.value, "typedef");
       current = ret;
-      all_ws();
       consume(OTHER, ";") || error("Unterminated typedef");
       return ret;
     }
 
     function implements_() {
-      all_ws();
       const target = consume(ID);
       if (!target) return;
-      const w = all_ws();
       if (consume(ID, "implements")) {
         const ret = {
           type: "implements",
           target: target.value
         };
-        all_ws();
         const imp = consume(ID) || error("Incomplete implements statement");
         ret["implements"] = imp.value;
-        all_ws();
         consume(OTHER, ";") || error("No terminating ; for implements statement");
         return ret;
       } else {
         // rollback
-        if (w)
-          unconsume(w);
         unconsume(target);
       }
     }
 
     function includes() {
-      all_ws();
       const target = consume(ID);
       if (!target) return;
-      const w = all_ws();
       if (consume(ID, "includes")) {
         const ret = {
           type: "includes",
           target: target.value
         };
-        all_ws();
         const imp = consume(ID) || error("Incomplete includes statement");
         ret["includes"] = imp.value;
-        all_ws();
         consume(OTHER, ";") || error("No terminating ; for includes statement");
         return ret;
       } else {
         // rollback
-        if (w)
-          unconsume(w);
         unconsume(target);
       }
     }

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -15,17 +15,6 @@
     "other": /[^\t\n\r 0-9A-Z_a-z]/y
   };
 
-  function attemptTokenMatch(str, type, lastIndex, tokens) {
-    const re = tokenRe[type];
-    re.lastIndex = lastIndex;
-    const result = re.exec(str);
-    if (result) {
-      tokens.push({ type, value: result[0] });
-      return re.lastIndex;
-    }
-    return -1;
-  }
-
   function tokenise(str) {
     const tokens = [];
     let lastIndex = 0;
@@ -33,32 +22,32 @@
       const nextChar = str.charAt(lastIndex);
       let result = -1;
       if (/[-0-9.]/.test(nextChar)) {
-        result = attemptTokenMatch(str, "float", lastIndex, tokens);
+        result = attemptTokenMatch("float");
         if (result === -1) {
-          result = attemptTokenMatch(str, "integer", lastIndex, tokens);
+          result = attemptTokenMatch("integer");
         }
         if (result === -1) {
           // '-' and '.' can also match "other".
-          result = attemptTokenMatch(str, "other", lastIndex, tokens);
+          result = attemptTokenMatch("other");
         }
       } else if (/[A-Z_a-z]/.test(nextChar)) {
-        result = attemptTokenMatch(str, "identifier", lastIndex, tokens);
+        result = attemptTokenMatch("identifier");
       } else if (nextChar === '"') {
-        result = attemptTokenMatch(str, "string", lastIndex, tokens);
+        result = attemptTokenMatch("string");
         if (result === -1) {
           // '"' can also match "other".
-          result = attemptTokenMatch(str, "other", lastIndex, tokens);
+          result = attemptTokenMatch("other");
         }
       } else if (/[\t\n\r ]/.test(nextChar)) {
-        result = attemptTokenMatch(str, "whitespace", lastIndex, tokens);
+        result = attemptTokenMatch("whitespace");
       } else if (nextChar === '/') {
-        result = attemptTokenMatch(str, "comment", lastIndex, tokens);
+        result = attemptTokenMatch("comment");
         if (result === -1) {
           // '/' can also match "other".
-          result = attemptTokenMatch(str, "other", lastIndex, tokens);
+          result = attemptTokenMatch("other");
         }
       } else {
-        result = attemptTokenMatch(str, "other", lastIndex, tokens);
+        result = attemptTokenMatch("other");
       }
       if (result === -1) {
         throw new Error("Token stream not progressing");
@@ -66,6 +55,17 @@
       lastIndex = result;
     }
     return tokens;
+
+    function attemptTokenMatch(type) {
+      const re = tokenRe[type];
+      re.lastIndex = lastIndex;
+      const result = re.exec(str);
+      if (result) {
+        tokens.push({ type, value: result[0] });
+        return re.lastIndex;
+      }
+      return -1;
+    }
   }
 
   class WebIDLParseError {
@@ -169,11 +169,6 @@
       }
     }
 
-    const all_ws_re = {
-      "ws": /([\t\n\r ]+)/y,
-      "line-comment": /\/\/(.*)\r?\n?/y,
-      "multiline-comment": /\/\*((?:[^*]|\*[^/])*)\*\//y
-    };
     function all_ws() {
       const t = { type: "whitespace", value: "" };
       while (true) {

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -18,10 +18,20 @@
   function tokenise(str) {
     const tokens = [];
     let lastIndex = 0;
+    let trivia = "";
     while (lastIndex < str.length) {
       const nextChar = str.charAt(lastIndex);
       let result = -1;
-      if (/[-0-9.]/.test(nextChar)) {
+
+      if (/[\t\n\r ]/.test(nextChar)) {
+        result = attemptTokenMatch("whitespace", true);
+      } else if (nextChar === '/') {
+        result = attemptTokenMatch("comment", true);
+      }
+
+      if (result !== -1) {
+        trivia += tokens.pop().value;
+      } else if (/[-0-9.]/.test(nextChar)) {
         result = attemptTokenMatch("float");
         if (result === -1) {
           result = attemptTokenMatch("integer");
@@ -38,14 +48,6 @@
           // '"' can also match "other".
           result = attemptTokenMatch("other");
         }
-      } else if (/[\t\n\r ]/.test(nextChar)) {
-        result = attemptTokenMatch("whitespace");
-      } else if (nextChar === '/') {
-        result = attemptTokenMatch("comment");
-        if (result === -1) {
-          // '/' can also match "other".
-          result = attemptTokenMatch("other");
-        }
       } else {
         result = attemptTokenMatch("other");
       }
@@ -56,12 +58,15 @@
     }
     return tokens;
 
-    function attemptTokenMatch(type) {
+    function attemptTokenMatch(type, noFlushTrivia) {
       const re = tokenRe[type];
       re.lastIndex = lastIndex;
       const result = re.exec(str);
       if (result) {
-        tokens.push({ type, value: result[0] });
+        tokens.push({ type, value: result[0], trivia });
+        if (!noFlushTrivia) {
+          trivia = "";
+        }
         return re.lastIndex;
       }
       return -1;
@@ -119,6 +124,8 @@
         tok += tokens[numTokens].value;
         numTokens++;
       }
+      // Count newlines preceding the actual errorneous token
+      line += count(tokens[0].trivia, "\n");
 
       let message;
       if (current) {
@@ -146,10 +153,18 @@
       if (!tokens.length || tokens[0].type !== type) return;
       if (typeof value === "undefined" || tokens[0].value === value) {
         last_token = tokens.shift();
+        line += count(last_token.trivia, "\n");
         if (type === ID && last_token.value.startsWith('_'))
           last_token.value = last_token.value.substring(1);
         return last_token;
       }
+    }
+
+    function unconsume(...toks) {
+      for (let tok of toks) {
+        line -= count(tok.trivia, "\n");
+      }
+      tokens.unshift(...toks);
     }
 
     function count(str, char) {
@@ -226,7 +241,7 @@
       const tok = consume(OTHER, "-");
       if (tok) {
         if (consume(ID, "Infinity")) return { type: "Infinity", negative: true };
-        else tokens.unshift(tok);
+        else unconsume(tok);
       }
     }
 
@@ -330,7 +345,7 @@
       }
       ret.idlType = type_with_extended_attributes("argument-type");
       if (!ret.idlType) {
-        if (opt_token) tokens.unshift(opt_token);
+        if (opt_token) unconsume(opt_token);
         return;
       }
       const type_token = last_token;
@@ -350,8 +365,8 @@
       all_ws();
       const name = consume(ID);
       if (!name) {
-        if (opt_token) tokens.unshift(opt_token);
-        tokens.unshift(type_token);
+        if (opt_token) unconsume(opt_token);
+        unconsume(type_token);
         return;
       }
       ret.name = name.value;
@@ -396,6 +411,10 @@
           consume(FLOAT) ||
           consume(INT) ||
           consume(STR);
+        if (ret.rhs) {
+          // No trivia exposure yet
+          ret.rhs.trivia = undefined;
+        }
       }
       all_ws();
       if (consume(OTHER, "(")) {
@@ -446,6 +465,8 @@
         } else {
           const str = consume(STR) || error("No value for default");
           str.value = str.value.slice(1, -1);
+          // No trivia exposure yet
+          str.trivia = undefined;
           return str;
         }
       }
@@ -557,7 +578,7 @@
       }
       const rest = attribute_rest(ret);
       if (!rest) {
-        tokens = grabbed.concat(tokens);
+        unconsume(...grabbed);
       }
       return rest;
     }
@@ -677,7 +698,7 @@
 
       const ittype = consumeItType();
       if (!ittype) {
-        tokens = grabbed.concat(tokens);
+        unconsume(...grabbed);
         return;
       }
 
@@ -847,7 +868,7 @@
       }
       const rest = attribute_rest(ret);
       if (!rest) {
-        tokens = grabbed.concat(tokens);
+        unconsume(...grabbed);
       }
       return rest;
     }
@@ -945,6 +966,8 @@
         }
         const val = consume(STR) || error("Unexpected value in enum");
         val.value = val.value.slice(1, -1);
+        // No trivia exposure yet
+        val.trivia = undefined;
         ret.values.push(val);
         all_ws();
         if (consume(OTHER, ",")) {
@@ -992,8 +1015,8 @@
       } else {
         // rollback
         if (w)
-          tokens.unshift(w);
-        tokens.unshift(target);
+          unconsume(w);
+        unconsume(target);
       }
     }
 
@@ -1016,8 +1039,8 @@
       } else {
         // rollback
         if (w)
-          tokens.unshift(w);
-        tokens.unshift(target);
+          unconsume(w);
+        unconsume(target);
       }
     }
 

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -24,9 +24,9 @@
       let result = -1;
 
       if (/[\t\n\r ]/.test(nextChar)) {
-        result = attemptTokenMatch("whitespace", true);
+        result = attemptTokenMatch("whitespace", { noFlushTrivia: true });
       } else if (nextChar === '/') {
-        result = attemptTokenMatch("comment", true);
+        result = attemptTokenMatch("comment", { noFlushTrivia: true });
       }
 
       if (result !== -1) {
@@ -58,7 +58,7 @@
     }
     return tokens;
 
-    function attemptTokenMatch(type, noFlushTrivia) {
+    function attemptTokenMatch(type, {noFlushTrivia} = {}) {
       const re = tokenRe[type];
       re.lastIndex = lastIndex;
       const result = re.exec(str);
@@ -161,6 +161,8 @@
     }
 
     function unconsume(...toks) {
+      // TODO: use const when Servo updates its JS engine
+      // https://github.com/servo/servo/issues/20231
       for (let tok of toks) {
         line -= count(tok.trivia, "\n");
       }


### PR DESCRIPTION
...to better align with [the spec](https://heycam.github.io/webidl/#idl-grammar):

>Implicitly, any number of whitespace and comment terminals are allowed between every other terminal in the input text being parsed.

Now:

1. We don't have to manually add `all_ws()` everywhere (so that we can prevent bugs like #68).
2. All trivia tokens are stored, no need to manually process it when rollback (to prevent bugs like #145).
3. The stored trivia tokens help implementing #125 😁 