### PR TITLE
Prevent keywords from being identifiers

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -130,7 +130,9 @@
     }
 
     toString() {
-      return `${this.message}, line ${this.line} (tokens: ${JSON.stringify(this.input)})\n${JSON.stringify(this.tokens, null, 4)}`;
+      const escapedInput = JSON.stringify(this.input);
+      const tokens = JSON.stringify(this.tokens, null, 4);
+      return `${this.message}, line ${this.line} (tokens: ${escapedInput})\n${tokens}`;
     }
   }
 

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -199,10 +199,15 @@
       if (typeof value === "undefined" || tokens[0].value === value) {
         last_token = tokens.shift();
         line += count(last_token.trivia, "\n");
-        if (type === ID && last_token.value.startsWith('_'))
-          last_token.value = last_token.value.substring(1);
         return last_token;
       }
+    }
+
+    function unescape(identifier) {
+      if (identifier.startsWith('_')) {
+        identifier = identifier.slice(1);
+      }
+      return identifier;
     }
 
     function unconsume(...toks) {
@@ -378,7 +383,8 @@
         unconsume(type_token);
         return;
       }
-      ret.name = name.value;
+      ret.name = unescape(name.value);
+      ret.escapedName = name.value;
       if (ret.optional) {
         const dflt = default_();
         if (typeof dflt !== "undefined") {
@@ -501,7 +507,8 @@
     function operation_rest(ret) {
       if (!ret) ret = {};
       const name = consume(ID);
-      ret.name = name ? name.value : null;
+      ret.name = name ? unescape(name.value) : null;
+      ret.escapedName = name ? name.value : null;
       consume(OTHER, "(") || error("Invalid operation");
       ret.arguments = argument_list();
       consume(OTHER, ")") || error("Unterminated operation");
@@ -561,7 +568,8 @@
       if (ret.idlType.sequence) error("Attributes cannot accept sequence types");
       if (ret.idlType.generic === "record") error("Attributes cannot accept record types");
       const name = consume(ID) || error("No name in attribute");
-      ret.name = name.value;
+      ret.name = unescape(name.value);
+      ret.escapedName = name.value;
       consume(OTHER, ";") || error("Unterminated attribute");
       return ret;
     }
@@ -842,7 +850,8 @@
         if (required && dflt) error("Required member must not have a default");
         const member = {
           type: "field",
-          name: name.value,
+          name: unescape(name.value),
+          escapedName: name.value,
           required: !!required,
           idlType: typ,
           extAttrs: ea

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -8,12 +8,56 @@
     // against integers early.
     "float": /-?(?=[0-9]*\.|[0-9]+[eE])(([0-9]+\.[0-9]*|[0-9]*\.[0-9]+)([Ee][-+]?[0-9]+)?|[0-9]+[Ee][-+]?[0-9]+)/y,
     "integer": /-?(0([Xx][0-9A-Fa-f]+|[0-7]*)|[1-9][0-9]*)/y,
-    "identifier": /[A-Z_a-z][0-9A-Z_a-z-]*/y,
+    "identifier": /_?[A-Za-z][0-9A-Z_a-z-]*/y,
     "string": /"[^"]*"/y,
     "whitespace": /[\t\n\r ]+/y,
     "comment": /((\/(\/.*|\*([^*]|\*[^\/])*\*\/)[\t\n\r ]*)+)/y,
     "other": /[^\t\n\r 0-9A-Z_a-z]/y
   };
+
+  const namedTerminals = [
+    "unsigned",
+    "short",
+    "long",
+    "unrestricted",
+    "float",
+    "double",
+    "boolean",
+    "byte",
+    "octet",
+    "true",
+    "false",
+    "null",
+    "Infinity",
+    "NaN",
+    "or",
+    "optional",
+    "const",
+    "callback",
+    "interface",
+    "inherit",
+    "readonly",
+    "attribute",
+    "void",
+    "getter",
+    "setter",
+    "deleter",
+    "static",
+    "stringifier",
+    "iterable",
+    "legacyiterable",
+    "maplike",
+    "setlike",
+    "mixin",
+    "namespace",
+    "partial",
+    "dictionary",
+    "required",
+    "enum",
+    "typedef",
+    "implements",
+    "includes"
+  ];
 
   function tokenise(str) {
     const tokens = [];
@@ -42,6 +86,10 @@
         }
       } else if (/[A-Z_a-z]/.test(nextChar)) {
         result = attemptTokenMatch("identifier");
+        const token = tokens[tokens.length - 1];
+        if (result !== -1 && namedTerminals.includes(token.value)) {
+          token.type = token.value;
+        }
       } else if (nextChar === '"') {
         result = attemptTokenMatch("string");
         if (result === -1) {
@@ -82,7 +130,7 @@
     }
 
     toString() {
-      return `${this.message}, line ${this.line} (tokens: '${this.input}')\n${JSON.stringify(this.tokens, null, 4)}`;
+      return `${this.message}, line ${this.line} (tokens: ${JSON.stringify(this.input)})\n${JSON.stringify(this.tokens, null, 4)}`;
     }
   }
 
@@ -117,15 +165,12 @@
     });
 
     function error(str) {
-      let tok = "";
-      let numTokens = 0;
       const maxTokens = 5;
-      while (numTokens < maxTokens && tokens.length > numTokens) {
-        tok += tokens[numTokens].value;
-        numTokens++;
-      }
+      const tok = tokens.slice(0, maxTokens).map(t => t.trivia + t.value).join("");
       // Count newlines preceding the actual errorneous token
-      line += count(tokens[0].trivia, "\n");
+      if (tokens.length) {
+        line += count(tokens[0].trivia, "\n");
+      }
 
       let message;
       if (current) {
@@ -179,11 +224,11 @@
 
     function integer_type() {
       let ret = "";
-      if (consume(ID, "unsigned")) ret = "unsigned ";
-      if (consume(ID, "short")) return ret + "short";
-      if (consume(ID, "long")) {
+      if (consume("unsigned")) ret = "unsigned ";
+      if (consume("short")) return ret + "short";
+      if (consume("long")) {
         ret += "long";
-        if (consume(ID, "long")) return ret + " long";
+        if (consume("long")) return ret + " long";
         return ret;
       }
       if (ret) error("Failed to parse integer type");
@@ -191,31 +236,31 @@
 
     function float_type() {
       let ret = "";
-      if (consume(ID, "unrestricted")) ret = "unrestricted ";
-      if (consume(ID, "float")) return ret + "float";
-      if (consume(ID, "double")) return ret + "double";
+      if (consume("unrestricted")) ret = "unrestricted ";
+      if (consume("float")) return ret + "float";
+      if (consume("double")) return ret + "double";
       if (ret) error("Failed to parse float type");
     }
 
     function primitive_type() {
       const num_type = integer_type() || float_type();
       if (num_type) return num_type;
-      if (consume(ID, "boolean")) return "boolean";
-      if (consume(ID, "byte")) return "byte";
-      if (consume(ID, "octet")) return "octet";
+      if (consume("boolean")) return "boolean";
+      if (consume("byte")) return "byte";
+      if (consume("octet")) return "octet";
     }
 
     function const_value() {
-      if (consume(ID, "true")) return { type: "boolean", value: true };
-      if (consume(ID, "false")) return { type: "boolean", value: false };
-      if (consume(ID, "null")) return { type: "null" };
-      if (consume(ID, "Infinity")) return { type: "Infinity", negative: false };
-      if (consume(ID, "NaN")) return { type: "NaN" };
+      if (consume("true")) return { type: "boolean", value: true };
+      if (consume("false")) return { type: "boolean", value: false };
+      if (consume("null")) return { type: "null" };
+      if (consume("Infinity")) return { type: "Infinity", negative: false };
+      if (consume("NaN")) return { type: "NaN" };
       const ret = consume(FLOAT) || consume(INT);
       if (ret) return { type: "number", value: ret.value };
       const tok = consume(OTHER, "-");
       if (tok) {
-        if (consume(ID, "Infinity")) return { type: "Infinity", negative: true };
+        if (consume("Infinity")) return { type: "Infinity", negative: true };
         else unconsume(tok);
       }
     }
@@ -282,7 +327,7 @@
       const fst = type_with_extended_attributes() || error("Union type with no content");
       ret.idlType.push(fst);
       while (true) {
-        if (!consume(ID, "or")) break;
+        if (!consume("or")) break;
         const typ = type_with_extended_attributes() || error("No type after 'or' in union type");
         ret.idlType.push(typ);
       }
@@ -305,7 +350,7 @@
     function argument() {
       const ret = { optional: false, variadic: false };
       ret.extAttrs = extended_attrs();
-      const opt_token = consume(ID, "optional");
+      const opt_token = consume("optional");
       if (opt_token) {
         ret.optional = true;
       }
@@ -425,7 +470,7 @@
     }
 
     function const_() {
-      if (!consume(ID, "const")) return;
+      if (!consume("const")) return;
       const ret = { type: "const", nullable: false };
       let typ = primitive_type();
       if (!typ) {
@@ -466,8 +511,8 @@
 
     function callback() {
       let ret;
-      if (!consume(ID, "callback")) return;
-      const tok = consume(ID, "interface");
+      if (!consume("callback")) return;
+      const tok = consume("interface");
       if (tok) {
         ret = interface_rest(false, "callback interface");
         return ret;
@@ -492,12 +537,12 @@
         inherit: false,
         readonly: false
       };
-      if (consume(ID, "inherit")) {
+      if (consume("inherit")) {
         if (ret.static || ret.stringifier) error("Cannot have a static or stringifier inherit");
         ret.inherit = true;
         grabbed.push(last_token);
       }
-      if (consume(ID, "readonly")) {
+      if (consume("readonly")) {
         ret.readonly = true;
         grabbed.push(last_token);
       }
@@ -509,7 +554,7 @@
     }
 
     function attribute_rest(ret) {
-      if (!consume(ID, "attribute")) {
+      if (!consume("attribute")) {
         return;
       }
       ret.idlType = type_with_extended_attributes("attribute-type") || error("No type in attribute");
@@ -524,8 +569,8 @@
     function return_type() {
       const typ = type("return-type");
       if (!typ) {
-        if (consume(ID, "void")) {
-          return "void";
+        if (consume("void")) {
+          return Object.assign({ type: "return-type" }, EMPTY_IDLTYPE, { idlType: "void" });
         } else error("No return type");
       }
       return typ;
@@ -534,9 +579,9 @@
     function operation() {
       const ret = Object.assign({}, EMPTY_OPERATION);
       while (true) {
-        if (consume(ID, "getter")) ret.getter = true;
-        else if (consume(ID, "setter")) ret.setter = true;
-        else if (consume(ID, "deleter")) ret.deleter = true;
+        if (consume("getter")) ret.getter = true;
+        else if (consume("setter")) ret.setter = true;
+        else if (consume("deleter")) ret.deleter = true;
         else break;
       }
       if (ret.getter || ret.setter || ret.deleter) {
@@ -550,14 +595,14 @@
     }
 
     function static_member() {
-      if (!consume(ID, "static")) return;
+      if (!consume("static")) return;
       return noninherited_attribute("static") ||
         regular_operation("static") ||
         error("No body in static member");
     }
 
     function stringifier() {
-      if (!consume(ID, "stringifier")) return;
+      if (!consume("stringifier")) return;
       if (consume(OTHER, ";")) {
         return Object.assign({}, EMPTY_OPERATION, { stringifier: true });
       }
@@ -583,23 +628,23 @@
     }
 
     function iterable_type() {
-      if (consume(ID, "iterable")) return "iterable";
-      else if (consume(ID, "legacyiterable")) return "legacyiterable";
-      else if (consume(ID, "maplike")) return "maplike";
-      else if (consume(ID, "setlike")) return "setlike";
+      if (consume("iterable")) return "iterable";
+      else if (consume("legacyiterable")) return "legacyiterable";
+      else if (consume("maplike")) return "maplike";
+      else if (consume("setlike")) return "setlike";
       else return;
     }
 
     function readonly_iterable_type() {
-      if (consume(ID, "maplike")) return "maplike";
-      else if (consume(ID, "setlike")) return "setlike";
+      if (consume("maplike")) return "maplike";
+      else if (consume("setlike")) return "setlike";
       else return;
     }
 
     function iterable() {
       const grabbed = [];
       const ret = { type: null, idlType: null, readonly: false };
-      if (consume(ID, "readonly")) {
+      if (consume("readonly")) {
         ret.readonly = true;
         grabbed.push(last_token);
       }
@@ -668,7 +713,7 @@
     }
 
     function mixin_rest(isPartial) {
-      if (!consume(ID, "mixin")) return;
+      if (!consume("mixin")) return;
       const name = consume(ID) || error("No name for interface mixin");
       const mems = [];
       const ret = current = {
@@ -700,14 +745,14 @@
     }
 
     function interface_(isPartial) {
-      if (!consume(ID, "interface")) return;
+      if (!consume("interface")) return;
       return mixin_rest(isPartial) ||
         interface_rest(isPartial) ||
         error("Interface has no proper body");
     }
 
     function namespace(isPartial) {
-      if (!consume(ID, "namespace")) return;
+      if (!consume("namespace")) return;
       const name = consume(ID) || error("No name for namespace");
       const mems = [];
       const ret = current = {
@@ -743,7 +788,7 @@
       if (prefix) {
         ret[prefix] = true;
       }
-      if (consume(ID, "readonly")) {
+      if (consume("readonly")) {
         ret.readonly = true;
         grabbed.push(last_token);
       }
@@ -764,7 +809,7 @@
     }
 
     function partial() {
-      if (!consume(ID, "partial")) return;
+      if (!consume("partial")) return;
       const thing = dictionary(true) ||
         interface_(true) ||
         namespace(true) ||
@@ -773,7 +818,7 @@
     }
 
     function dictionary(isPartial) {
-      if (!consume(ID, "dictionary")) return;
+      if (!consume("dictionary")) return;
       const name = consume(ID) || error("No name for dictionary");
       const mems = [];
       const ret = current = {
@@ -790,7 +835,7 @@
           return ret;
         }
         const ea = extended_attrs();
-        const required = consume(ID, "required");
+        const required = consume("required");
         const typ = type_with_extended_attributes("dictionary-type") || error("No type for dictionary member");
         const name = consume(ID) || error("No name for dictionary member");
         const dflt = default_();
@@ -811,7 +856,7 @@
     }
 
     function enum_() {
-      if (!consume(ID, "enum")) return;
+      if (!consume("enum")) return;
       const name = consume(ID) || error("No name for enum");
       const vals = [];
       const ret = current = {
@@ -844,7 +889,7 @@
     }
 
     function typedef() {
-      if (!consume(ID, "typedef")) return;
+      if (!consume("typedef")) return;
       const ret = {
         type: "typedef"
       };
@@ -859,7 +904,7 @@
     function implements_() {
       const target = consume(ID);
       if (!target) return;
-      if (consume(ID, "implements")) {
+      if (consume("implements")) {
         const ret = {
           type: "implements",
           target: target.value
@@ -877,7 +922,7 @@
     function includes() {
       const target = consume(ID);
       if (!target) return;
-      if (consume(ID, "includes")) {
+      if (consume("includes")) {
         const ret = {
           type: "includes",
           target: target.value

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -16,47 +16,47 @@
   };
 
   const namedTerminals = [
-    "unsigned",
-    "short",
-    "long",
-    "unrestricted",
-    "float",
-    "double",
-    "boolean",
-    "byte",
-    "octet",
-    "true",
-    "false",
-    "null",
     "Infinity",
     "NaN",
-    "or",
-    "optional",
-    "const",
-    "callback",
-    "interface",
-    "inherit",
-    "readonly",
     "attribute",
-    "void",
-    "getter",
-    "setter",
+    "boolean",
+    "byte",
+    "callback",
+    "const",
     "deleter",
-    "static",
-    "stringifier",
+    "dictionary",
+    "double",
+    "enum",
+    "false",
+    "float",
+    "getter",
+    "implements",
+    "includes",
+    "inherit",
+    "interface",
     "iterable",
     "legacyiterable",
+    "long",
     "maplike",
-    "setlike",
     "mixin",
     "namespace",
+    "null",
+    "octet",
+    "optional",
+    "or",
     "partial",
-    "dictionary",
+    "readonly",
     "required",
-    "enum",
+    "setlike",
+    "setter",
+    "short",
+    "static",
+    "stringifier",
+    "true",
     "typedef",
-    "implements",
-    "includes"
+    "unrestricted",
+    "unsigned",
+    "void"
   ];
 
   function tokenise(str) {
@@ -106,7 +106,7 @@
     }
     return tokens;
 
-    function attemptTokenMatch(type, {noFlushTrivia} = {}) {
+    function attemptTokenMatch(type, { noFlushTrivia } = {}) {
       const re = tokenRe[type];
       re.lastIndex = lastIndex;
       const result = re.exec(str);
@@ -204,10 +204,7 @@
     }
 
     function unescape(identifier) {
-      if (identifier.startsWith('_')) {
-        identifier = identifier.slice(1);
-      }
-      return identifier;
+      return identifier.startsWith('_') ? identifier.slice(1) : identifier;
     }
 
     function unconsume(...toks) {

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -41,7 +41,7 @@
       if (arg.optional) ret += "optional ";
       ret += type(arg.idlType);
       if (arg.variadic) ret += "...";
-      ret += ` ${arg.name}`;
+      ret += ` ${arg.escapedName}`;
       if (arg["default"]) ret += ` = ${const_value(arg["default"])}`;
       return ret;
     };
@@ -78,7 +78,7 @@
         if (it[mod]) ret += mod + " ";
       }
       ret += type(it.idlType) + " ";
-      if (it.name) ret += it.name;
+      if (it.name) ret += it.escapedName;
       ret += `(${args(it["arguments"])});`;
       return ret;
     };
@@ -89,7 +89,7 @@
       if (it.stringifier) ret += "stringifier ";
       if (it.readonly) ret += "readonly ";
       if (it.inherit) ret += "inherit ";
-      ret += `attribute ${type(it.idlType)} ${it.name};`;
+      ret += `attribute ${type(it.idlType)} ${it.escapedName};`;
       return ret;
     };
 
@@ -129,7 +129,7 @@
     function field(it) {
       let ret = extended_attributes(it.extAttrs);
       if (it.required) ret += "required ";
-      ret += `${type(it.idlType)} ${it.name}`;
+      ret += `${type(it.idlType)} ${it.escapedName}`;
       if (it["default"]) ret += ` = ${const_value(it["default"])}`;
       ret += ";";
       return ret;

--- a/test/invalid/idl/id-underscored-number.widl
+++ b/test/invalid/idl/id-underscored-number.widl
@@ -1,0 +1,1 @@
+interface _0 {};

--- a/test/invalid/json/id-underscored-number.json
+++ b/test/invalid/json/id-underscored-number.json
@@ -1,0 +1,3 @@
+{
+    "message": "Token stream not progressing"
+}

--- a/test/invalid/json/readonly-iterable.json
+++ b/test/invalid/json/readonly-iterable.json
@@ -1,4 +1,4 @@
 {
-    "message": "Got an error during or right after parsing `interface ReadonlyIterable`: Invalid operation",
+    "message": "Got an error during or right after parsing `interface ReadonlyIterable`: No return type",
     "line": 2
 }

--- a/test/invalid/json/typedef-nested.json
+++ b/test/invalid/json/typedef-nested.json
@@ -1,4 +1,4 @@
 {
-    "message":  "Got an error during or right after parsing `interface Widget`: Invalid operation"
+    "message":  "Got an error during or right after parsing `interface Widget`: No return type"
 ,   "line":     14
 }

--- a/test/syntax/idl/identifier-qualified-names.widl
+++ b/test/syntax/idl/identifier-qualified-names.widl
@@ -26,7 +26,3 @@
       // Attribute identifier: "value"
       attribute DOMString? _value;
     };
-
-interface Foo {
- void op(object interface);
-};

--- a/test/syntax/json/allowany.json
+++ b/test/syntax/json/allowany.json
@@ -21,6 +21,7 @@
                     "extAttrs": []
                 },
                 "name": "g",
+                "escapedName": "g",
                 "arguments": [],
                 "extAttrs": []
             },
@@ -41,6 +42,7 @@
                     "extAttrs": []
                 },
                 "name": "g",
+                "escapedName": "g",
                 "arguments": [
                     {
                         "optional": false,
@@ -55,7 +57,8 @@
                             "idlType": "B",
                             "extAttrs": []
                         },
-                        "name": "b"
+                        "name": "b",
+                        "escapedName": "b"
                     }
                 ],
                 "extAttrs": []
@@ -77,6 +80,7 @@
                     "extAttrs": []
                 },
                 "name": "g",
+                "escapedName": "g",
                 "arguments": [
                     {
                         "optional": false,
@@ -98,7 +102,8 @@
                             "idlType": "DOMString",
                             "extAttrs": []
                         },
-                        "name": "s"
+                        "name": "s",
+                        "escapedName": "s"
                     }
                 ],
                 "extAttrs": []

--- a/test/syntax/json/attributes.json
+++ b/test/syntax/json/attributes.json
@@ -20,6 +20,7 @@
                     "extAttrs": []
                 },
                 "name": "age",
+                "escapedName": "age",
                 "extAttrs": []
             }
         ],

--- a/test/syntax/json/callback.json
+++ b/test/syntax/json/callback.json
@@ -25,7 +25,8 @@
                     "idlType": "DOMString",
                     "extAttrs": []
                 },
-                "name": "status"
+                "name": "status",
+                "escapedName": "status"
             }
         ],
         "extAttrs": []
@@ -52,6 +53,7 @@
                     "extAttrs": []
                 },
                 "name": "eventOccurred",
+                "escapedName": "eventOccurred",
                 "arguments": [
                     {
                         "optional": false,
@@ -66,7 +68,8 @@
                             "idlType": "DOMString",
                             "extAttrs": []
                         },
-                        "name": "details"
+                        "name": "details",
+                        "escapedName": "details"
                     }
                 ],
                 "extAttrs": []
@@ -101,7 +104,8 @@
                     "idlType": "any",
                     "extAttrs": []
                 },
-                "name": "a"
+                "name": "a",
+                "escapedName": "a"
             },
             {
                 "optional": false,
@@ -116,7 +120,8 @@
                     "idlType": "any",
                     "extAttrs": []
                 },
-                "name": "b"
+                "name": "b",
+                "escapedName": "b"
             }
         ],
         "extAttrs": []

--- a/test/syntax/json/constructor.json
+++ b/test/syntax/json/constructor.json
@@ -20,6 +20,7 @@
                     "extAttrs": []
                 },
                 "name": "r",
+                "escapedName": "r",
                 "extAttrs": []
             },
             {
@@ -38,6 +39,7 @@
                     "extAttrs": []
                 },
                 "name": "cx",
+                "escapedName": "cx",
                 "extAttrs": []
             },
             {
@@ -56,6 +58,7 @@
                     "extAttrs": []
                 },
                 "name": "cy",
+                "escapedName": "cy",
                 "extAttrs": []
             },
             {
@@ -74,6 +77,7 @@
                     "extAttrs": []
                 },
                 "name": "circumference",
+                "escapedName": "circumference",
                 "extAttrs": []
             }
         ],
@@ -101,7 +105,8 @@
                             "idlType": "float",
                             "extAttrs": []
                         },
-                        "name": "radius"
+                        "name": "radius",
+                        "escapedName": "radius"
                     }
                 ],
                 "type": "extended-attribute",

--- a/test/syntax/json/dictionary-inherits.json
+++ b/test/syntax/json/dictionary-inherits.json
@@ -7,6 +7,7 @@
             {
                 "type": "field",
                 "name": "fillPattern",
+                "escapedName": "fillPattern",
                 "required": false,
                 "idlType": {
                     "type": "dictionary-type",
@@ -26,6 +27,7 @@
             {
                 "type": "field",
                 "name": "strokePattern",
+                "escapedName": "strokePattern",
                 "required": false,
                 "idlType": {
                     "type": "dictionary-type",
@@ -44,6 +46,7 @@
             {
                 "type": "field",
                 "name": "position",
+                "escapedName": "position",
                 "required": false,
                 "idlType": {
                     "type": "dictionary-type",
@@ -68,6 +71,7 @@
             {
                 "type": "field",
                 "name": "hydrometry",
+                "escapedName": "hydrometry",
                 "required": false,
                 "idlType": {
                     "type": "dictionary-type",

--- a/test/syntax/json/dictionary.json
+++ b/test/syntax/json/dictionary.json
@@ -7,6 +7,7 @@
             {
                 "type": "field",
                 "name": "fillPattern",
+                "escapedName": "fillPattern",
                 "required": false,
                 "idlType": {
                     "type": "dictionary-type",
@@ -26,6 +27,7 @@
             {
                 "type": "field",
                 "name": "strokePattern",
+                "escapedName": "strokePattern",
                 "required": false,
                 "idlType": {
                     "type": "dictionary-type",
@@ -44,6 +46,7 @@
             {
                 "type": "field",
                 "name": "position",
+                "escapedName": "position",
                 "required": false,
                 "idlType": {
                     "type": "dictionary-type",
@@ -59,6 +62,7 @@
             {
                 "type": "field",
                 "name": "seq",
+                "escapedName": "seq",
                 "required": false,
                 "idlType": {
                     "type": "dictionary-type",
@@ -86,6 +90,7 @@
             {
                 "type": "field",
                 "name": "reqSeq",
+                "escapedName": "reqSeq",
                 "required": true,
                 "idlType": {
                     "type": "dictionary-type",
@@ -110,6 +115,7 @@
             {
                 "type": "field",
                 "name": "h",
+                "escapedName": "h",
                 "required": false,
                 "idlType": {
                     "type": "dictionary-type",
@@ -125,6 +131,7 @@
             {
                 "type": "field",
                 "name": "d",
+                "escapedName": "d",
                 "required": false,
                 "idlType": {
                     "type": "dictionary-type",

--- a/test/syntax/json/enum.json
+++ b/test/syntax/json/enum.json
@@ -39,6 +39,7 @@
                     "extAttrs": []
                 },
                 "name": "type",
+                "escapedName": "type",
                 "extAttrs": []
             },
             {
@@ -57,6 +58,7 @@
                     "extAttrs": []
                 },
                 "name": "size",
+                "escapedName": "size",
                 "extAttrs": []
             },
             {
@@ -76,6 +78,7 @@
                     "extAttrs": []
                 },
                 "name": "initialize",
+                "escapedName": "initialize",
                 "arguments": [
                     {
                         "optional": false,
@@ -90,7 +93,8 @@
                             "idlType": "MealType",
                             "extAttrs": []
                         },
-                        "name": "type"
+                        "name": "type",
+                        "escapedName": "type"
                     },
                     {
                         "optional": false,
@@ -105,7 +109,8 @@
                             "idlType": "float",
                             "extAttrs": []
                         },
-                        "name": "size"
+                        "name": "size",
+                        "escapedName": "size"
                     }
                 ],
                 "extAttrs": []

--- a/test/syntax/json/equivalent-decl.json
+++ b/test/syntax/json/equivalent-decl.json
@@ -20,6 +20,7 @@
                     "extAttrs": []
                 },
                 "name": "propertyCount",
+                "escapedName": "propertyCount",
                 "extAttrs": []
             },
             {
@@ -39,6 +40,7 @@
                     "extAttrs": []
                 },
                 "name": "getProperty",
+                "escapedName": "getProperty",
                 "arguments": [
                     {
                         "optional": false,
@@ -53,7 +55,8 @@
                             "idlType": "DOMString",
                             "extAttrs": []
                         },
-                        "name": "propertyName"
+                        "name": "propertyName",
+                        "escapedName": "propertyName"
                     }
                 ],
                 "extAttrs": []
@@ -75,6 +78,7 @@
                     "extAttrs": []
                 },
                 "name": "setProperty",
+                "escapedName": "setProperty",
                 "arguments": [
                     {
                         "optional": false,
@@ -89,7 +93,8 @@
                             "idlType": "DOMString",
                             "extAttrs": []
                         },
-                        "name": "propertyName"
+                        "name": "propertyName",
+                        "escapedName": "propertyName"
                     },
                     {
                         "optional": false,
@@ -104,7 +109,8 @@
                             "idlType": "float",
                             "extAttrs": []
                         },
-                        "name": "propertyValue"
+                        "name": "propertyValue",
+                        "escapedName": "propertyValue"
                     }
                 ],
                 "extAttrs": []
@@ -134,6 +140,7 @@
                     "extAttrs": []
                 },
                 "name": "propertyCount",
+                "escapedName": "propertyCount",
                 "extAttrs": []
             },
             {
@@ -153,6 +160,7 @@
                     "extAttrs": []
                 },
                 "name": "getProperty",
+                "escapedName": "getProperty",
                 "arguments": [
                     {
                         "optional": false,
@@ -167,7 +175,8 @@
                             "idlType": "DOMString",
                             "extAttrs": []
                         },
-                        "name": "propertyName"
+                        "name": "propertyName",
+                        "escapedName": "propertyName"
                     }
                 ],
                 "extAttrs": []
@@ -189,6 +198,7 @@
                     "extAttrs": []
                 },
                 "name": "setProperty",
+                "escapedName": "setProperty",
                 "arguments": [
                     {
                         "optional": false,
@@ -203,7 +213,8 @@
                             "idlType": "DOMString",
                             "extAttrs": []
                         },
-                        "name": "propertyName"
+                        "name": "propertyName",
+                        "escapedName": "propertyName"
                     },
                     {
                         "optional": false,
@@ -218,7 +229,8 @@
                             "idlType": "float",
                             "extAttrs": []
                         },
-                        "name": "propertyValue"
+                        "name": "propertyValue",
+                        "escapedName": "propertyValue"
                     }
                 ],
                 "extAttrs": []
@@ -240,6 +252,7 @@
                     "extAttrs": []
                 },
                 "name": null,
+                "escapedName": null,
                 "arguments": [
                     {
                         "optional": false,
@@ -254,7 +267,8 @@
                             "idlType": "DOMString",
                             "extAttrs": []
                         },
-                        "name": "propertyName"
+                        "name": "propertyName",
+                        "escapedName": "propertyName"
                     }
                 ],
                 "extAttrs": []
@@ -276,6 +290,7 @@
                     "extAttrs": []
                 },
                 "name": null,
+                "escapedName": null,
                 "arguments": [
                     {
                         "optional": false,
@@ -290,7 +305,8 @@
                             "idlType": "DOMString",
                             "extAttrs": []
                         },
-                        "name": "propertyName"
+                        "name": "propertyName",
+                        "escapedName": "propertyName"
                     },
                     {
                         "optional": false,
@@ -305,7 +321,8 @@
                             "idlType": "float",
                             "extAttrs": []
                         },
-                        "name": "propertyValue"
+                        "name": "propertyValue",
+                        "escapedName": "propertyValue"
                     }
                 ],
                 "extAttrs": []

--- a/test/syntax/json/extended-attributes.json
+++ b/test/syntax/json/extended-attributes.json
@@ -86,6 +86,7 @@
                     "extAttrs": []
                 },
                 "name": "r",
+                "escapedName": "r",
                 "extAttrs": []
             },
             {
@@ -104,6 +105,7 @@
                     "extAttrs": []
                 },
                 "name": "cx",
+                "escapedName": "cx",
                 "extAttrs": []
             },
             {
@@ -122,6 +124,7 @@
                     "extAttrs": []
                 },
                 "name": "cy",
+                "escapedName": "cy",
                 "extAttrs": []
             },
             {
@@ -140,6 +143,7 @@
                     "extAttrs": []
                 },
                 "name": "circumference",
+                "escapedName": "circumference",
                 "extAttrs": []
             }
         ],
@@ -167,7 +171,8 @@
                             "idlType": "double",
                             "extAttrs": []
                         },
-                        "name": "radius"
+                        "name": "radius",
+                        "escapedName": "radius"
                     }
                 ],
                 "type": "extended-attribute",
@@ -222,6 +227,7 @@
                     ]
                 },
                 "name": "attrib",
+                "escapedName": "attrib",
                 "extAttrs": []
             }
         ],

--- a/test/syntax/json/generic.json
+++ b/test/syntax/json/generic.json
@@ -45,6 +45,7 @@
                     "extAttrs": []
                 },
                 "name": "bar",
+                "escapedName": "bar",
                 "arguments": [],
                 "extAttrs": []
             },
@@ -72,6 +73,7 @@
                     "extAttrs": []
                 },
                 "name": "baz",
+                "escapedName": "baz",
                 "extAttrs": []
             }
         ],
@@ -108,6 +110,7 @@
                     "extAttrs": []
                 },
                 "name": "getServiced",
+                "escapedName": "getServiced",
                 "arguments": [],
                 "extAttrs": []
             },
@@ -136,6 +139,7 @@
                     "extAttrs": []
                 },
                 "name": "reloadAll",
+                "escapedName": "reloadAll",
                 "arguments": [],
                 "extAttrs": []
             }
@@ -173,6 +177,7 @@
                     "extAttrs": []
                 },
                 "name": "default",
+                "escapedName": "default",
                 "arguments": [],
                 "extAttrs": []
             }

--- a/test/syntax/json/getter-setter.json
+++ b/test/syntax/json/getter-setter.json
@@ -20,6 +20,7 @@
                     "extAttrs": []
                 },
                 "name": "propertyCount",
+                "escapedName": "propertyCount",
                 "extAttrs": []
             },
             {
@@ -39,6 +40,7 @@
                     "extAttrs": []
                 },
                 "name": null,
+                "escapedName": null,
                 "arguments": [
                     {
                         "optional": false,
@@ -53,7 +55,8 @@
                             "idlType": "DOMString",
                             "extAttrs": []
                         },
-                        "name": "propertyName"
+                        "name": "propertyName",
+                        "escapedName": "propertyName"
                     }
                 ],
                 "extAttrs": []
@@ -75,6 +78,7 @@
                     "extAttrs": []
                 },
                 "name": null,
+                "escapedName": null,
                 "arguments": [
                     {
                         "optional": false,
@@ -89,7 +93,8 @@
                             "idlType": "DOMString",
                             "extAttrs": []
                         },
-                        "name": "propertyName"
+                        "name": "propertyName",
+                        "escapedName": "propertyName"
                     },
                     {
                         "optional": false,
@@ -104,7 +109,8 @@
                             "idlType": "float",
                             "extAttrs": []
                         },
-                        "name": "propertyValue"
+                        "name": "propertyValue",
+                        "escapedName": "propertyValue"
                     }
                 ],
                 "extAttrs": []

--- a/test/syntax/json/identifier-qualified-names.json
+++ b/test/syntax/json/identifier-qualified-names.json
@@ -138,50 +138,5 @@
         ],
         "inheritance": null,
         "extAttrs": []
-    },
-    {
-        "type": "interface",
-        "name": "Foo",
-        "partial": false,
-        "members": [
-            {
-                "type": "operation",
-                "getter": false,
-                "setter": false,
-                "deleter": false,
-                "static": false,
-                "stringifier": false,
-                "idlType": {
-                    "type": "return-type",
-                    "sequence": false,
-                    "generic": null,
-                    "nullable": false,
-                    "union": false,
-                    "idlType": "void",
-                    "extAttrs": []
-                },
-                "name": "op",
-                "arguments": [
-                    {
-                        "optional": false,
-                        "variadic": false,
-                        "extAttrs": [],
-                        "idlType": {
-                            "type": "argument-type",
-                            "sequence": false,
-                            "generic": null,
-                            "nullable": false,
-                            "union": false,
-                            "idlType": "object",
-                            "extAttrs": []
-                        },
-                        "name": "interface"
-                    }
-                ],
-                "extAttrs": []
-            }
-        ],
-        "inheritance": null,
-        "extAttrs": []
     }
 ]

--- a/test/syntax/json/identifier-qualified-names.json
+++ b/test/syntax/json/identifier-qualified-names.json
@@ -35,6 +35,7 @@
                     "extAttrs": []
                 },
                 "name": "createObject",
+                "escapedName": "createObject",
                 "arguments": [
                     {
                         "optional": false,
@@ -49,7 +50,8 @@
                             "idlType": "DOMString",
                             "extAttrs": []
                         },
-                        "name": "interface"
+                        "name": "interface",
+                        "escapedName": "_interface"
                     }
                 ],
                 "extAttrs": []
@@ -71,6 +73,7 @@
                     "extAttrs": []
                 },
                 "name": null,
+                "escapedName": null,
                 "arguments": [
                     {
                         "optional": false,
@@ -85,7 +88,8 @@
                             "idlType": "DOMString",
                             "extAttrs": []
                         },
-                        "name": "keyName"
+                        "name": "keyName",
+                        "escapedName": "keyName"
                     }
                 ],
                 "extAttrs": []
@@ -115,6 +119,7 @@
                     "extAttrs": []
                 },
                 "name": "const",
+                "escapedName": "_const",
                 "extAttrs": []
             },
             {
@@ -133,6 +138,7 @@
                     "extAttrs": []
                 },
                 "name": "value",
+                "escapedName": "_value",
                 "extAttrs": []
             }
         ],

--- a/test/syntax/json/implements.json
+++ b/test/syntax/json/implements.json
@@ -20,6 +20,7 @@
                     "extAttrs": []
                 },
                 "name": "nodeType",
+                "escapedName": "nodeType",
                 "extAttrs": []
             }
         ],
@@ -48,6 +49,7 @@
                     "extAttrs": []
                 },
                 "name": "addEventListener",
+                "escapedName": "addEventListener",
                 "arguments": [
                     {
                         "optional": false,
@@ -62,7 +64,8 @@
                             "idlType": "DOMString",
                             "extAttrs": []
                         },
-                        "name": "type"
+                        "name": "type",
+                        "escapedName": "type"
                     },
                     {
                         "optional": false,
@@ -77,7 +80,8 @@
                             "idlType": "EventListener",
                             "extAttrs": []
                         },
-                        "name": "listener"
+                        "name": "listener",
+                        "escapedName": "listener"
                     },
                     {
                         "optional": false,
@@ -92,7 +96,8 @@
                             "idlType": "boolean",
                             "extAttrs": []
                         },
-                        "name": "useCapture"
+                        "name": "useCapture",
+                        "escapedName": "useCapture"
                     }
                 ],
                 "extAttrs": []

--- a/test/syntax/json/indexed-properties.json
+++ b/test/syntax/json/indexed-properties.json
@@ -20,6 +20,7 @@
                     "extAttrs": []
                 },
                 "name": "size",
+                "escapedName": "size",
                 "extAttrs": []
             },
             {
@@ -39,6 +40,7 @@
                     "extAttrs": []
                 },
                 "name": "getByIndex",
+                "escapedName": "getByIndex",
                 "arguments": [
                     {
                         "optional": false,
@@ -53,7 +55,8 @@
                             "idlType": "unsigned long",
                             "extAttrs": []
                         },
-                        "name": "index"
+                        "name": "index",
+                        "escapedName": "index"
                     }
                 ],
                 "extAttrs": []
@@ -75,6 +78,7 @@
                     "extAttrs": []
                 },
                 "name": "setByIndex",
+                "escapedName": "setByIndex",
                 "arguments": [
                     {
                         "optional": false,
@@ -89,7 +93,8 @@
                             "idlType": "unsigned long",
                             "extAttrs": []
                         },
-                        "name": "index"
+                        "name": "index",
+                        "escapedName": "index"
                     },
                     {
                         "optional": false,
@@ -104,7 +109,8 @@
                             "idlType": "any",
                             "extAttrs": []
                         },
-                        "name": "value"
+                        "name": "value",
+                        "escapedName": "value"
                     }
                 ],
                 "extAttrs": []
@@ -126,6 +132,7 @@
                     "extAttrs": []
                 },
                 "name": "removeByIndex",
+                "escapedName": "removeByIndex",
                 "arguments": [
                     {
                         "optional": false,
@@ -140,7 +147,8 @@
                             "idlType": "unsigned long",
                             "extAttrs": []
                         },
-                        "name": "index"
+                        "name": "index",
+                        "escapedName": "index"
                     }
                 ],
                 "extAttrs": []
@@ -162,6 +170,7 @@
                     "extAttrs": []
                 },
                 "name": "get",
+                "escapedName": "get",
                 "arguments": [
                     {
                         "optional": false,
@@ -176,7 +185,8 @@
                             "idlType": "DOMString",
                             "extAttrs": []
                         },
-                        "name": "name"
+                        "name": "name",
+                        "escapedName": "name"
                     }
                 ],
                 "extAttrs": []
@@ -198,6 +208,7 @@
                     "extAttrs": []
                 },
                 "name": "set",
+                "escapedName": "set",
                 "arguments": [
                     {
                         "optional": false,
@@ -212,7 +223,8 @@
                             "idlType": "DOMString",
                             "extAttrs": []
                         },
-                        "name": "name"
+                        "name": "name",
+                        "escapedName": "name"
                     },
                     {
                         "optional": false,
@@ -227,7 +239,8 @@
                             "idlType": "any",
                             "extAttrs": []
                         },
-                        "name": "value"
+                        "name": "value",
+                        "escapedName": "value"
                     }
                 ],
                 "extAttrs": []
@@ -249,6 +262,7 @@
                     "extAttrs": []
                 },
                 "name": "remove",
+                "escapedName": "remove",
                 "arguments": [
                     {
                         "optional": false,
@@ -263,7 +277,8 @@
                             "idlType": "DOMString",
                             "extAttrs": []
                         },
-                        "name": "name"
+                        "name": "name",
+                        "escapedName": "name"
                     }
                 ],
                 "extAttrs": []

--- a/test/syntax/json/inherits-getter.json
+++ b/test/syntax/json/inherits-getter.json
@@ -20,6 +20,7 @@
                     "extAttrs": []
                 },
                 "name": "name",
+                "escapedName": "name",
                 "extAttrs": []
             }
         ],
@@ -47,6 +48,7 @@
                     "extAttrs": []
                 },
                 "name": "age",
+                "escapedName": "age",
                 "extAttrs": []
             },
             {
@@ -65,6 +67,7 @@
                     "extAttrs": []
                 },
                 "name": "name",
+                "escapedName": "name",
                 "extAttrs": []
             }
         ],

--- a/test/syntax/json/interface-inherits.json
+++ b/test/syntax/json/interface-inherits.json
@@ -20,6 +20,7 @@
                     "extAttrs": []
                 },
                 "name": "name",
+                "escapedName": "name",
                 "extAttrs": []
             }
         ],
@@ -47,6 +48,7 @@
                     "extAttrs": []
                 },
                 "name": "pet",
+                "escapedName": "pet",
                 "extAttrs": []
             }
         ],
@@ -74,6 +76,7 @@
                     "extAttrs": []
                 },
                 "name": "owner",
+                "escapedName": "owner",
                 "extAttrs": []
             }
         ],

--- a/test/syntax/json/mixin.json
+++ b/test/syntax/json/mixin.json
@@ -20,6 +20,7 @@
                     "extAttrs": []
                 },
                 "name": "crypto",
+                "escapedName": "crypto",
                 "extAttrs": []
             }
         ],
@@ -58,6 +59,7 @@
                     "extAttrs": []
                 },
                 "name": "crypto",
+                "escapedName": "crypto",
                 "extAttrs": []
             }
         ],

--- a/test/syntax/json/namedconstructor.json
+++ b/test/syntax/json/namedconstructor.json
@@ -31,7 +31,8 @@
                             "idlType": "DOMString",
                             "extAttrs": []
                         },
-                        "name": "src"
+                        "name": "src",
+                        "escapedName": "src"
                     }
                 ],
                 "type": "extended-attribute",

--- a/test/syntax/json/namespace.json
+++ b/test/syntax/json/namespace.json
@@ -20,6 +20,7 @@
                     "extAttrs": []
                 },
                 "name": "unit",
+                "escapedName": "unit",
                 "extAttrs": []
             },
             {
@@ -39,6 +40,7 @@
                     "extAttrs": []
                 },
                 "name": "dotProduct",
+                "escapedName": "dotProduct",
                 "arguments": [
                     {
                         "optional": false,
@@ -53,7 +55,8 @@
                             "idlType": "Vector",
                             "extAttrs": []
                         },
-                        "name": "x"
+                        "name": "x",
+                        "escapedName": "x"
                     },
                     {
                         "optional": false,
@@ -68,7 +71,8 @@
                             "idlType": "Vector",
                             "extAttrs": []
                         },
-                        "name": "y"
+                        "name": "y",
+                        "escapedName": "y"
                     }
                 ],
                 "extAttrs": []
@@ -90,6 +94,7 @@
                     "extAttrs": []
                 },
                 "name": "crossProduct",
+                "escapedName": "crossProduct",
                 "arguments": [
                     {
                         "optional": false,
@@ -104,7 +109,8 @@
                             "idlType": "Vector",
                             "extAttrs": []
                         },
-                        "name": "x"
+                        "name": "x",
+                        "escapedName": "x"
                     },
                     {
                         "optional": false,
@@ -119,7 +125,8 @@
                             "idlType": "Vector",
                             "extAttrs": []
                         },
-                        "name": "y"
+                        "name": "y",
+                        "escapedName": "y"
                     }
                 ],
                 "extAttrs": []

--- a/test/syntax/json/nointerfaceobject.json
+++ b/test/syntax/json/nointerfaceobject.json
@@ -21,6 +21,7 @@
                     "extAttrs": []
                 },
                 "name": "lookupEntry",
+                "escapedName": "lookupEntry",
                 "arguments": [
                     {
                         "optional": false,
@@ -35,7 +36,8 @@
                             "idlType": "unsigned long",
                             "extAttrs": []
                         },
-                        "name": "key"
+                        "name": "key",
+                        "escapedName": "key"
                     }
                 ],
                 "extAttrs": []

--- a/test/syntax/json/nullable.json
+++ b/test/syntax/json/nullable.json
@@ -48,6 +48,7 @@
                     "extAttrs": []
                 },
                 "name": "namespaceURI",
+                "escapedName": "namespaceURI",
                 "extAttrs": []
             }
         ],

--- a/test/syntax/json/nullableobjects.json
+++ b/test/syntax/json/nullableobjects.json
@@ -37,6 +37,7 @@
                     "extAttrs": []
                 },
                 "name": "f",
+                "escapedName": "f",
                 "arguments": [
                     {
                         "optional": false,
@@ -51,7 +52,8 @@
                             "idlType": "A",
                             "extAttrs": []
                         },
-                        "name": "x"
+                        "name": "x",
+                        "escapedName": "x"
                     }
                 ],
                 "extAttrs": []
@@ -73,6 +75,7 @@
                     "extAttrs": []
                 },
                 "name": "f",
+                "escapedName": "f",
                 "arguments": [
                     {
                         "optional": false,
@@ -87,7 +90,8 @@
                             "idlType": "B",
                             "extAttrs": []
                         },
-                        "name": "x"
+                        "name": "x",
+                        "escapedName": "x"
                     }
                 ],
                 "extAttrs": []

--- a/test/syntax/json/operation-optional-arg.json
+++ b/test/syntax/json/operation-optional-arg.json
@@ -21,6 +21,7 @@
                     "extAttrs": []
                 },
                 "name": "createColor",
+                "escapedName": "createColor",
                 "arguments": [
                     {
                         "optional": false,
@@ -35,7 +36,8 @@
                             "idlType": "float",
                             "extAttrs": []
                         },
-                        "name": "v1"
+                        "name": "v1",
+                        "escapedName": "v1"
                     },
                     {
                         "optional": false,
@@ -50,7 +52,8 @@
                             "idlType": "float",
                             "extAttrs": []
                         },
-                        "name": "v2"
+                        "name": "v2",
+                        "escapedName": "v2"
                     },
                     {
                         "optional": false,
@@ -65,7 +68,8 @@
                             "idlType": "float",
                             "extAttrs": []
                         },
-                        "name": "v3"
+                        "name": "v3",
+                        "escapedName": "v3"
                     },
                     {
                         "optional": true,
@@ -81,6 +85,7 @@
                             "extAttrs": []
                         },
                         "name": "alpha",
+                        "escapedName": "alpha",
                         "default": {
                             "type": "number",
                             "value": "3.5"

--- a/test/syntax/json/overloading.json
+++ b/test/syntax/json/overloading.json
@@ -37,6 +37,7 @@
                     "extAttrs": []
                 },
                 "name": "f",
+                "escapedName": "f",
                 "arguments": [
                     {
                         "optional": false,
@@ -51,7 +52,8 @@
                             "idlType": "A",
                             "extAttrs": []
                         },
-                        "name": "x"
+                        "name": "x",
+                        "escapedName": "x"
                     }
                 ],
                 "extAttrs": []
@@ -73,6 +75,7 @@
                     "extAttrs": []
                 },
                 "name": "f",
+                "escapedName": "f",
                 "arguments": [
                     {
                         "optional": false,
@@ -87,7 +90,8 @@
                             "idlType": "B",
                             "extAttrs": []
                         },
-                        "name": "x"
+                        "name": "x",
+                        "escapedName": "x"
                     }
                 ],
                 "extAttrs": []
@@ -118,6 +122,7 @@
                     "extAttrs": []
                 },
                 "name": "f",
+                "escapedName": "f",
                 "arguments": [
                     {
                         "optional": false,
@@ -132,7 +137,8 @@
                             "idlType": "DOMString",
                             "extAttrs": []
                         },
-                        "name": "a"
+                        "name": "a",
+                        "escapedName": "a"
                     }
                 ],
                 "extAttrs": []
@@ -154,6 +160,7 @@
                     "extAttrs": []
                 },
                 "name": "f",
+                "escapedName": "f",
                 "arguments": [
                     {
                         "optional": false,
@@ -175,7 +182,8 @@
                             "idlType": "DOMString",
                             "extAttrs": []
                         },
-                        "name": "a"
+                        "name": "a",
+                        "escapedName": "a"
                     },
                     {
                         "optional": false,
@@ -190,7 +198,8 @@
                             "idlType": "DOMString",
                             "extAttrs": []
                         },
-                        "name": "b"
+                        "name": "b",
+                        "escapedName": "b"
                     },
                     {
                         "optional": false,
@@ -205,7 +214,8 @@
                             "idlType": "float",
                             "extAttrs": []
                         },
-                        "name": "c"
+                        "name": "c",
+                        "escapedName": "c"
                     }
                 ],
                 "extAttrs": []
@@ -227,6 +237,7 @@
                     "extAttrs": []
                 },
                 "name": "f",
+                "escapedName": "f",
                 "arguments": [],
                 "extAttrs": []
             },
@@ -247,6 +258,7 @@
                     "extAttrs": []
                 },
                 "name": "f",
+                "escapedName": "f",
                 "arguments": [
                     {
                         "optional": false,
@@ -261,7 +273,8 @@
                             "idlType": "long",
                             "extAttrs": []
                         },
-                        "name": "a"
+                        "name": "a",
+                        "escapedName": "a"
                     },
                     {
                         "optional": false,
@@ -276,7 +289,8 @@
                             "idlType": "DOMString",
                             "extAttrs": []
                         },
-                        "name": "b"
+                        "name": "b",
+                        "escapedName": "b"
                     },
                     {
                         "optional": true,
@@ -291,7 +305,8 @@
                             "idlType": "DOMString",
                             "extAttrs": []
                         },
-                        "name": "c"
+                        "name": "c",
+                        "escapedName": "c"
                     },
                     {
                         "optional": false,
@@ -306,7 +321,8 @@
                             "idlType": "float",
                             "extAttrs": []
                         },
-                        "name": "d"
+                        "name": "d",
+                        "escapedName": "d"
                     }
                 ],
                 "extAttrs": []

--- a/test/syntax/json/overridebuiltins.json
+++ b/test/syntax/json/overridebuiltins.json
@@ -20,6 +20,7 @@
                     "extAttrs": []
                 },
                 "name": "length",
+                "escapedName": "length",
                 "extAttrs": []
             },
             {
@@ -39,6 +40,7 @@
                     "extAttrs": []
                 },
                 "name": "lookup",
+                "escapedName": "lookup",
                 "arguments": [
                     {
                         "optional": false,
@@ -53,7 +55,8 @@
                             "idlType": "DOMString",
                             "extAttrs": []
                         },
-                        "name": "key"
+                        "name": "key",
+                        "escapedName": "key"
                     }
                 ],
                 "extAttrs": []

--- a/test/syntax/json/partial-interface.json
+++ b/test/syntax/json/partial-interface.json
@@ -20,6 +20,7 @@
                     "extAttrs": []
                 },
                 "name": "bar",
+                "escapedName": "bar",
                 "extAttrs": []
             }
         ],
@@ -47,6 +48,7 @@
                     "extAttrs": []
                 },
                 "name": "quux",
+                "escapedName": "quux",
                 "extAttrs": []
             }
         ],

--- a/test/syntax/json/primitives.json
+++ b/test/syntax/json/primitives.json
@@ -20,6 +20,7 @@
                     "extAttrs": []
                 },
                 "name": "truth",
+                "escapedName": "truth",
                 "extAttrs": []
             },
             {
@@ -38,6 +39,7 @@
                     "extAttrs": []
                 },
                 "name": "character",
+                "escapedName": "character",
                 "extAttrs": []
             },
             {
@@ -56,6 +58,7 @@
                     "extAttrs": []
                 },
                 "name": "value",
+                "escapedName": "value",
                 "extAttrs": []
             },
             {
@@ -74,6 +77,7 @@
                     "extAttrs": []
                 },
                 "name": "number",
+                "escapedName": "number",
                 "extAttrs": []
             },
             {
@@ -92,6 +96,7 @@
                     "extAttrs": []
                 },
                 "name": "positive",
+                "escapedName": "positive",
                 "extAttrs": []
             },
             {
@@ -110,6 +115,7 @@
                     "extAttrs": []
                 },
                 "name": "big",
+                "escapedName": "big",
                 "extAttrs": []
             },
             {
@@ -128,6 +134,7 @@
                     "extAttrs": []
                 },
                 "name": "bigpositive",
+                "escapedName": "bigpositive",
                 "extAttrs": []
             },
             {
@@ -146,6 +153,7 @@
                     "extAttrs": []
                 },
                 "name": "bigbig",
+                "escapedName": "bigbig",
                 "extAttrs": []
             },
             {
@@ -164,6 +172,7 @@
                     "extAttrs": []
                 },
                 "name": "bigbigpositive",
+                "escapedName": "bigbigpositive",
                 "extAttrs": []
             },
             {
@@ -182,6 +191,7 @@
                     "extAttrs": []
                 },
                 "name": "real",
+                "escapedName": "real",
                 "extAttrs": []
             },
             {
@@ -200,6 +210,7 @@
                     "extAttrs": []
                 },
                 "name": "bigreal",
+                "escapedName": "bigreal",
                 "extAttrs": []
             },
             {
@@ -218,6 +229,7 @@
                     "extAttrs": []
                 },
                 "name": "realwithinfinity",
+                "escapedName": "realwithinfinity",
                 "extAttrs": []
             },
             {
@@ -236,6 +248,7 @@
                     "extAttrs": []
                 },
                 "name": "bigrealwithinfinity",
+                "escapedName": "bigrealwithinfinity",
                 "extAttrs": []
             },
             {
@@ -254,6 +267,7 @@
                     "extAttrs": []
                 },
                 "name": "string",
+                "escapedName": "string",
                 "extAttrs": []
             },
             {
@@ -272,6 +286,7 @@
                     "extAttrs": []
                 },
                 "name": "bytes",
+                "escapedName": "bytes",
                 "extAttrs": []
             },
             {
@@ -290,6 +305,7 @@
                     "extAttrs": []
                 },
                 "name": "date",
+                "escapedName": "date",
                 "extAttrs": []
             },
             {
@@ -308,6 +324,7 @@
                     "extAttrs": []
                 },
                 "name": "regexp",
+                "escapedName": "regexp",
                 "extAttrs": []
             }
         ],

--- a/test/syntax/json/prototyperoot.json
+++ b/test/syntax/json/prototyperoot.json
@@ -20,6 +20,7 @@
                     "extAttrs": []
                 },
                 "name": "nodeType",
+                "escapedName": "nodeType",
                 "extAttrs": []
             }
         ],

--- a/test/syntax/json/putforwards.json
+++ b/test/syntax/json/putforwards.json
@@ -20,6 +20,7 @@
                     "extAttrs": []
                 },
                 "name": "name",
+                "escapedName": "name",
                 "extAttrs": [
                     {
                         "name": "PutForwards",
@@ -48,6 +49,7 @@
                     "extAttrs": []
                 },
                 "name": "age",
+                "escapedName": "age",
                 "extAttrs": []
             }
         ],

--- a/test/syntax/json/record.json
+++ b/test/syntax/json/record.json
@@ -21,6 +21,7 @@
                     "extAttrs": []
                 },
                 "name": "foo",
+                "escapedName": "foo",
                 "arguments": [
                     {
                         "optional": false,
@@ -62,7 +63,8 @@
                             },
                             "extAttrs": []
                         },
-                        "name": "param"
+                        "name": "param",
+                        "escapedName": "param"
                     }
                 ],
                 "extAttrs": []
@@ -122,6 +124,7 @@
                     "extAttrs": []
                 },
                 "name": "bar",
+                "escapedName": "bar",
                 "arguments": [],
                 "extAttrs": []
             },
@@ -142,6 +145,7 @@
                     "extAttrs": []
                 },
                 "name": "baz",
+                "escapedName": "baz",
                 "arguments": [],
                 "extAttrs": []
             }
@@ -183,7 +187,8 @@
                             ],
                             "extAttrs": []
                         },
-                        "name": "init"
+                        "name": "init",
+                        "escapedName": "init"
                     }
                 ],
                 "type": "extended-attribute",
@@ -239,6 +244,7 @@
                     "extAttrs": []
                 },
                 "name": "bar",
+                "escapedName": "bar",
                 "arguments": [],
                 "extAttrs": []
             }

--- a/test/syntax/json/reg-operations.json
+++ b/test/syntax/json/reg-operations.json
@@ -20,6 +20,7 @@
                     "extAttrs": []
                 },
                 "name": "width",
+                "escapedName": "width",
                 "extAttrs": []
             },
             {
@@ -38,6 +39,7 @@
                     "extAttrs": []
                 },
                 "name": "height",
+                "escapedName": "height",
                 "extAttrs": []
             }
         ],
@@ -66,6 +68,7 @@
                     "extAttrs": []
                 },
                 "name": "isMouseOver",
+                "escapedName": "isMouseOver",
                 "arguments": [],
                 "extAttrs": []
             },
@@ -86,6 +89,7 @@
                     "extAttrs": []
                 },
                 "name": "setDimensions",
+                "escapedName": "setDimensions",
                 "arguments": [
                     {
                         "optional": false,
@@ -100,7 +104,8 @@
                             "idlType": "Dimensions",
                             "extAttrs": []
                         },
-                        "name": "size"
+                        "name": "size",
+                        "escapedName": "size"
                     }
                 ],
                 "extAttrs": []
@@ -122,6 +127,7 @@
                     "extAttrs": []
                 },
                 "name": "setDimensions",
+                "escapedName": "setDimensions",
                 "arguments": [
                     {
                         "optional": false,
@@ -136,7 +142,8 @@
                             "idlType": "unsigned long",
                             "extAttrs": []
                         },
-                        "name": "width"
+                        "name": "width",
+                        "escapedName": "width"
                     },
                     {
                         "optional": false,
@@ -151,7 +158,8 @@
                             "idlType": "unsigned long",
                             "extAttrs": []
                         },
-                        "name": "height"
+                        "name": "height",
+                        "escapedName": "height"
                     }
                 ],
                 "extAttrs": []

--- a/test/syntax/json/replaceable.json
+++ b/test/syntax/json/replaceable.json
@@ -20,6 +20,7 @@
                     "extAttrs": []
                 },
                 "name": "value",
+                "escapedName": "value",
                 "extAttrs": [
                     {
                         "name": "Replaceable",
@@ -46,6 +47,7 @@
                     "extAttrs": []
                 },
                 "name": "increment",
+                "escapedName": "increment",
                 "arguments": [],
                 "extAttrs": []
             }

--- a/test/syntax/json/sequence.json
+++ b/test/syntax/json/sequence.json
@@ -21,6 +21,7 @@
                     "extAttrs": []
                 },
                 "name": "drawPolygon",
+                "escapedName": "drawPolygon",
                 "arguments": [
                     {
                         "optional": false,
@@ -43,7 +44,8 @@
                             },
                             "extAttrs": []
                         },
-                        "name": "coordinates"
+                        "name": "coordinates",
+                        "escapedName": "coordinates"
                     }
                 ],
                 "extAttrs": []
@@ -73,6 +75,7 @@
                     "extAttrs": []
                 },
                 "name": "getInflectionPoints",
+                "escapedName": "getInflectionPoints",
                 "arguments": [],
                 "extAttrs": []
             }
@@ -102,6 +105,7 @@
                     "extAttrs": []
                 },
                 "name": "bar",
+                "escapedName": "bar",
                 "arguments": [],
                 "extAttrs": []
             }
@@ -131,6 +135,7 @@
                     "extAttrs": []
                 },
                 "name": "f1",
+                "escapedName": "f1",
                 "arguments": [
                     {
                         "optional": false,
@@ -160,7 +165,8 @@
                             },
                             "extAttrs": []
                         },
-                        "name": "arg"
+                        "name": "arg",
+                        "escapedName": "arg"
                     }
                 ],
                 "extAttrs": []

--- a/test/syntax/json/static.json
+++ b/test/syntax/json/static.json
@@ -28,6 +28,7 @@
                     "extAttrs": []
                 },
                 "name": "cx",
+                "escapedName": "cx",
                 "extAttrs": []
             },
             {
@@ -46,6 +47,7 @@
                     "extAttrs": []
                 },
                 "name": "cy",
+                "escapedName": "cy",
                 "extAttrs": []
             },
             {
@@ -64,6 +66,7 @@
                     "extAttrs": []
                 },
                 "name": "radius",
+                "escapedName": "radius",
                 "extAttrs": []
             },
             {
@@ -82,6 +85,7 @@
                     "extAttrs": []
                 },
                 "name": "triangulationCount",
+                "escapedName": "triangulationCount",
                 "extAttrs": []
             },
             {
@@ -101,6 +105,7 @@
                     "extAttrs": []
                 },
                 "name": "triangulate",
+                "escapedName": "triangulate",
                 "arguments": [
                     {
                         "optional": false,
@@ -115,7 +120,8 @@
                             "idlType": "Circle",
                             "extAttrs": []
                         },
-                        "name": "c1"
+                        "name": "c1",
+                        "escapedName": "c1"
                     },
                     {
                         "optional": false,
@@ -130,7 +136,8 @@
                             "idlType": "Circle",
                             "extAttrs": []
                         },
-                        "name": "c2"
+                        "name": "c2",
+                        "escapedName": "c2"
                     },
                     {
                         "optional": false,
@@ -145,7 +152,8 @@
                             "idlType": "Circle",
                             "extAttrs": []
                         },
-                        "name": "c3"
+                        "name": "c3",
+                        "escapedName": "c3"
                     }
                 ],
                 "extAttrs": []

--- a/test/syntax/json/stringifier-attribute.json
+++ b/test/syntax/json/stringifier-attribute.json
@@ -20,6 +20,7 @@
                     "extAttrs": []
                 },
                 "name": "id",
+                "escapedName": "id",
                 "extAttrs": []
             },
             {
@@ -38,6 +39,7 @@
                     "extAttrs": []
                 },
                 "name": "name",
+                "escapedName": "name",
                 "extAttrs": []
             }
         ],

--- a/test/syntax/json/stringifier-custom.json
+++ b/test/syntax/json/stringifier-custom.json
@@ -20,6 +20,7 @@
                     "extAttrs": []
                 },
                 "name": "id",
+                "escapedName": "id",
                 "extAttrs": []
             },
             {
@@ -38,6 +39,7 @@
                     "extAttrs": []
                 },
                 "name": "familyName",
+                "escapedName": "familyName",
                 "extAttrs": []
             },
             {
@@ -56,6 +58,7 @@
                     "extAttrs": []
                 },
                 "name": "givenName",
+                "escapedName": "givenName",
                 "extAttrs": []
             },
             {
@@ -75,6 +78,7 @@
                     "extAttrs": []
                 },
                 "name": null,
+                "escapedName": null,
                 "arguments": [],
                 "extAttrs": []
             }

--- a/test/syntax/json/stringifier.json
+++ b/test/syntax/json/stringifier.json
@@ -21,6 +21,7 @@
                     "extAttrs": []
                 },
                 "name": null,
+                "escapedName": null,
                 "arguments": [],
                 "extAttrs": []
             }

--- a/test/syntax/json/treatasnull.json
+++ b/test/syntax/json/treatasnull.json
@@ -20,6 +20,7 @@
                     "extAttrs": []
                 },
                 "name": "name",
+                "escapedName": "name",
                 "extAttrs": []
             },
             {
@@ -38,6 +39,7 @@
                     "extAttrs": []
                 },
                 "name": "owner",
+                "escapedName": "owner",
                 "extAttrs": []
             },
             {
@@ -57,6 +59,7 @@
                     "extAttrs": []
                 },
                 "name": "isMemberOfBreed",
+                "escapedName": "isMemberOfBreed",
                 "arguments": [
                     {
                         "optional": false,
@@ -81,7 +84,8 @@
                             "idlType": "DOMString",
                             "extAttrs": []
                         },
-                        "name": "breedName"
+                        "name": "breedName",
+                        "escapedName": "breedName"
                     }
                 ],
                 "extAttrs": []

--- a/test/syntax/json/treatasundefined.json
+++ b/test/syntax/json/treatasundefined.json
@@ -20,6 +20,7 @@
                     "extAttrs": []
                 },
                 "name": "name",
+                "escapedName": "name",
                 "extAttrs": []
             },
             {
@@ -38,6 +39,7 @@
                     "extAttrs": []
                 },
                 "name": "owner",
+                "escapedName": "owner",
                 "extAttrs": []
             },
             {
@@ -57,6 +59,7 @@
                     "extAttrs": []
                 },
                 "name": "isMemberOfBreed",
+                "escapedName": "isMemberOfBreed",
                 "arguments": [
                     {
                         "optional": false,
@@ -81,7 +84,8 @@
                             "idlType": "DOMString",
                             "extAttrs": []
                         },
-                        "name": "breedName"
+                        "name": "breedName",
+                        "escapedName": "breedName"
                     }
                 ],
                 "extAttrs": []

--- a/test/syntax/json/typedef.json
+++ b/test/syntax/json/typedef.json
@@ -20,6 +20,7 @@
                     "extAttrs": []
                 },
                 "name": "x",
+                "escapedName": "x",
                 "extAttrs": []
             },
             {
@@ -38,6 +39,7 @@
                     "extAttrs": []
                 },
                 "name": "y",
+                "escapedName": "y",
                 "extAttrs": []
             }
         ],
@@ -87,6 +89,7 @@
                     "extAttrs": []
                 },
                 "name": "topleft",
+                "escapedName": "topleft",
                 "extAttrs": []
             },
             {
@@ -105,6 +108,7 @@
                     "extAttrs": []
                 },
                 "name": "bottomright",
+                "escapedName": "bottomright",
                 "extAttrs": []
             }
         ],
@@ -132,6 +136,7 @@
                     "extAttrs": []
                 },
                 "name": "bounds",
+                "escapedName": "bounds",
                 "extAttrs": []
             },
             {
@@ -151,6 +156,7 @@
                     "extAttrs": []
                 },
                 "name": "pointWithinBounds",
+                "escapedName": "pointWithinBounds",
                 "arguments": [
                     {
                         "optional": false,
@@ -165,7 +171,8 @@
                             "idlType": "Point",
                             "extAttrs": []
                         },
-                        "name": "p"
+                        "name": "p",
+                        "escapedName": "p"
                     }
                 ],
                 "extAttrs": []
@@ -187,6 +194,7 @@
                     "extAttrs": []
                 },
                 "name": "allPointsWithinBounds",
+                "escapedName": "allPointsWithinBounds",
                 "arguments": [
                     {
                         "optional": false,
@@ -201,7 +209,8 @@
                             "idlType": "PointSequence",
                             "extAttrs": []
                         },
-                        "name": "ps"
+                        "name": "ps",
+                        "escapedName": "ps"
                     }
                 ],
                 "extAttrs": []

--- a/test/syntax/json/typesuffixes.json
+++ b/test/syntax/json/typesuffixes.json
@@ -21,6 +21,7 @@
                     "extAttrs": []
                 },
                 "name": "test",
+                "escapedName": "test",
                 "arguments": [
                     {
                         "optional": false,
@@ -43,7 +44,8 @@
                             },
                             "extAttrs": []
                         },
-                        "name": "foo"
+                        "name": "foo",
+                        "escapedName": "foo"
                     }
                 ],
                 "extAttrs": []

--- a/test/syntax/json/uniontype.json
+++ b/test/syntax/json/uniontype.json
@@ -86,6 +86,7 @@
                     "extAttrs": []
                 },
                 "name": "test",
+                "escapedName": "test",
                 "extAttrs": []
             },
             {
@@ -130,6 +131,7 @@
                     "extAttrs": []
                 },
                 "name": "test2",
+                "escapedName": "test2",
                 "extAttrs": []
             }
         ],

--- a/test/syntax/json/variadic-operations.json
+++ b/test/syntax/json/variadic-operations.json
@@ -20,6 +20,7 @@
                     "extAttrs": []
                 },
                 "name": "cardinality",
+                "escapedName": "cardinality",
                 "extAttrs": []
             },
             {
@@ -39,6 +40,7 @@
                     "extAttrs": []
                 },
                 "name": "union",
+                "escapedName": "union",
                 "arguments": [
                     {
                         "optional": false,
@@ -53,7 +55,8 @@
                             "idlType": "long",
                             "extAttrs": []
                         },
-                        "name": "ints"
+                        "name": "ints",
+                        "escapedName": "ints"
                     }
                 ],
                 "extAttrs": []
@@ -75,6 +78,7 @@
                     "extAttrs": []
                 },
                 "name": "intersection",
+                "escapedName": "intersection",
                 "arguments": [
                     {
                         "optional": false,
@@ -89,7 +93,8 @@
                             "idlType": "long",
                             "extAttrs": []
                         },
-                        "name": "ints"
+                        "name": "ints",
+                        "escapedName": "ints"
                     }
                 ],
                 "extAttrs": []


### PR DESCRIPTION
Closes #156 

This adds `escapedName` field for operations/attributes/arguments/dictionary fields so that writer.js can use raw escaped name.