### PR TITLE
fix: prevent tokeniser error when it meets _0

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -15,7 +15,7 @@
     "other": /[^\t\n\r 0-9A-Za-z]/y
   };
 
-  const namedTerminals = [
+  const nonRegexTerminals = [
     "Infinity",
     "NaN",
     "attribute",
@@ -87,7 +87,7 @@
       } else if (/[A-Z_a-z]/.test(nextChar)) {
         result = attemptTokenMatch("identifier");
         const token = tokens[tokens.length - 1];
-        if (result !== -1 && namedTerminals.includes(token.value)) {
+        if (result !== -1 && nonRegexTerminals.includes(token.value)) {
           token.type = token.value;
         }
       } else if (nextChar === '"') {

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -12,7 +12,7 @@
     "string": /"[^"]*"/y,
     "whitespace": /[\t\n\r ]+/y,
     "comment": /((\/(\/.*|\*([^*]|\*[^\/])*\*\/)[\t\n\r ]*)+)/y,
-    "other": /[^\t\n\r 0-9A-Z_a-z]/y
+    "other": /[^\t\n\r 0-9A-Za-z]/y
   };
 
   const namedTerminals = [
@@ -92,11 +92,10 @@
         }
       } else if (nextChar === '"') {
         result = attemptTokenMatch("string");
-        if (result === -1) {
-          // '"' can also match "other".
-          result = attemptTokenMatch("other");
-        }
-      } else {
+      }
+      
+      // other as the last try
+      if (result === -1) {
         result = attemptTokenMatch("other");
       }
       if (result === -1) {

--- a/test/invalid/json/id-underscored-number.json
+++ b/test/invalid/json/id-underscored-number.json
@@ -1,3 +1,4 @@
 {
-    "message": "Token stream not progressing"
+    "message": "Got an error before parsing any named definition: No name for interface",
+    "line": 1
 }


### PR DESCRIPTION
It turns out I was not fully understanding the tokenizer error. The `other` regex was different from the one in the spec and it was causing token stream error. Now `_0` is parsed as: `_` as `other` and `0` as `integer`.