### PR TITLE
fix: write inherit readonly attribute in proper order

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -87,8 +87,8 @@
       let ret = extended_attributes(it.extAttrs);
       if (it["static"]) ret += "static ";
       if (it.stringifier) ret += "stringifier ";
-      if (it.readonly) ret += "readonly ";
       if (it.inherit) ret += "inherit ";
+      if (it.readonly) ret += "readonly ";
       ret += `attribute ${type(it.idlType)} ${it.escapedName};`;
       return ret;
     };

--- a/test/syntax/idl/inherits-getter.widl
+++ b/test/syntax/idl/inherits-getter.widl
@@ -14,3 +14,9 @@ interface Person : Animal {
   // the description of Person.
   inherit attribute DOMString name;
 };
+
+interface Ghost : Person {
+
+  // An attribute that only inherits the getter behavior
+  inherit readonly attribute DOMString name;
+};

--- a/test/syntax/json/inherits-getter.json
+++ b/test/syntax/json/inherits-getter.json
@@ -73,5 +73,33 @@
         ],
         "inheritance": "Animal",
         "extAttrs": []
+    },
+    {
+        "type": "interface",
+        "name": "Ghost",
+        "partial": false,
+        "members": [
+            {
+                "type": "attribute",
+                "static": false,
+                "stringifier": false,
+                "inherit": true,
+                "readonly": true,
+                "idlType": {
+                    "type": "attribute-type",
+                    "sequence": false,
+                    "generic": null,
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "DOMString",
+                    "extAttrs": []
+                },
+                "name": "name",
+                "escapedName": "name",
+                "extAttrs": []
+            }
+        ],
+        "inheritance": "Person",
+        "extAttrs": []
     }
 ]


### PR DESCRIPTION
https://heycam.github.io/webidl/#prod-ReadWriteAttribute

```
ReadWriteAttribute ::
    inherit ReadOnly AttributeRest
    AttributeRest
```

`inherit readonly`, not `readonly inherit` 😁

This only affects the currently unexposed writer so IMO no need for a version bump.