### PR TITLE
refactor: merge operation functions

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -583,9 +583,9 @@
       return typ;
     }
 
-    function operation() {
+    function operation({ regular = false } = {}) {
       const ret = Object.assign({}, EMPTY_OPERATION);
-      while (true) {
+      while (!regular) {
         if (consume("getter")) ret.getter = true;
         else if (consume("setter")) ret.setter = true;
         else if (consume("deleter")) ret.deleter = true;
@@ -599,7 +599,7 @@
     function static_member() {
       if (!consume("static")) return;
       const member = attribute({ noInherit: true }) ||
-        regular_operation() ||
+        operation({ regular: true }) ||
         error("No body in static member");
       member.static = true;
       return member;
@@ -611,7 +611,7 @@
         return Object.assign({}, EMPTY_OPERATION, { stringifier: true });
       }
       const member = attribute({ noInherit: true }) ||
-        regular_operation() ||
+        operation({ regular: true }) ||
         error("Unterminated stringifier");
       member.stringifier = true;
       return member;
@@ -743,7 +743,7 @@
         }
         const mem = stringifier() ||
           attribute({ noInherit: true }) ||
-          regular_operation() ||
+          operation({ regular: true }) ||
           error("Unknown member");
         mem.extAttrs = ea;
         ret.members.push(mem);
@@ -775,17 +775,11 @@
         }
         const ea = extended_attrs();
         const mem = attribute({ noInherit: true, readonly: true }) ||
-          regular_operation() ||
+          operation({ regular: true }) ||
           error("Unknown member");
         mem.extAttrs = ea;
         ret.members.push(mem);
       }
-    }
-
-    function regular_operation() {
-      const ret = Object.assign({}, EMPTY_OPERATION);
-      ret.idlType = return_type();
-      return operation_rest(ret);
     }
 
     function partial() {


### PR DESCRIPTION
I tried modifying `operation()` to fix something and then found I have to modify both operation functions. This PR merges them so we can have a single operation function.