### PR TITLE
refactor: unconsume by position

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -203,10 +203,12 @@
 
     function error(str) {
       const maxTokens = 5;
-      const tok = tokens.slice(0, maxTokens).map(t => t.trivia + t.value).join("");
+      const tok = tokens
+        .slice(consume_position, consume_position + maxTokens)
+        .map(t => t.trivia + t.value).join("");
       // Count newlines preceding the actual erroneous token
       if (tokens.length) {
-        line += count(tokens[0].trivia, "\n");
+        line += count(tokens[consume_position].trivia, "\n");
       }
 
       let message;
@@ -229,21 +231,20 @@
       return name;
     }
 
-    let last_token = null;
+    let consume_position = 0;
 
     function probe(type) {
-      return tokens.length > 0 && tokens[0].type === type;
+      return tokens.length > consume_position && tokens[consume_position].type === type;
     }
 
     function consume(...candidates) {
       // TODO: use const when Servo updates its JS engine
       for (let type of candidates) {
         if (!probe(type)) continue;
-        if (typeof value === "undefined" || tokens[0].value === value) {
-          last_token = tokens.shift();
-          line += count(last_token.trivia, "\n");
-          return last_token;
-        }
+        const token = tokens[consume_position];
+        consume_position++;
+        line += count(token.trivia, "\n");
+        return token;
       }
     }
 
@@ -251,13 +252,11 @@
       return identifier.startsWith('_') ? identifier.slice(1) : identifier;
     }
 
-    function unconsume(...toks) {
-      // TODO: use const when Servo updates its JS engine
-      // https://github.com/servo/servo/issues/20231
-      for (let tok of toks) {
-        line -= count(tok.trivia, "\n");
+    function unconsume(position) {
+      while (consume_position > position) {
+        consume_position--;
+        line -= count(tokens[consume_position].trivia, "\n");
       }
-      tokens.unshift(...toks);
     }
 
     function count(str, char) {
@@ -397,6 +396,7 @@
 
     function argument() {
       const ret = { optional: false, variadic: false };
+      const start_position = consume_position;
       ret.extAttrs = extended_attrs();
       const opt_token = consume("optional");
       if (opt_token) {
@@ -404,17 +404,15 @@
       }
       ret.idlType = type_with_extended_attributes("argument-type");
       if (!ret.idlType) {
-        if (opt_token) unconsume(opt_token);
+        unconsume(start_position);
         return;
       }
-      const type_token = last_token;
       if (!ret.optional && consume("...")) {
         ret.variadic = true;
       }
       const name = argument_name(ID);
       if (!name) {
-        if (opt_token) unconsume(opt_token);
-        unconsume(type_token);
+        unconsume(start_position);
         return;
       }
       ret.name = unescape(name.value);
@@ -578,7 +576,7 @@
     }
 
     function attribute({ noInherit = false, readonly = false } = {}) {
-      const grabbed = [];
+      const start_position = consume_position;
       const ret = {
         type: "attribute",
         static: false,
@@ -588,17 +586,15 @@
       };
       if (!noInherit && consume("inherit")) {
         ret.inherit = true;
-        grabbed.push(last_token);
       }
       if (consume("readonly")) {
         ret.readonly = true;
-        grabbed.push(last_token);
       } else if (readonly && probe("attribute")) {
         error("Attributes must be readonly in this context");
       }
       const rest = attribute_rest(ret);
       if (!rest) {
-        unconsume(...grabbed);
+        unconsume(start_position);
       }
       return rest;
     }
@@ -692,17 +688,16 @@
     }
 
     function iterable() {
-      const grabbed = [];
+      const start_position = consume_position;
       const ret = { type: null, idlType: null, readonly: false };
       if (consume("readonly")) {
         ret.readonly = true;
-        grabbed.push(last_token);
       }
       const consumeItType = ret.readonly ? readonly_iterable_type : iterable_type;
 
       const ittype = consumeItType();
       if (!ittype) {
-        unconsume(...grabbed);
+        unconsume(start_position);
         return;
       }
 
@@ -917,6 +912,7 @@
     }
 
     function implements_() {
+      const start_position = consume_position;
       const target = consume(ID);
       if (!target) return;
       if (consume("implements")) {
@@ -930,11 +926,12 @@
         return ret;
       } else {
         // rollback
-        unconsume(target);
+        unconsume(start_position);
       }
     }
 
     function includes() {
+      const start_position = consume_position;
       const target = consume(ID);
       if (!target) return;
       if (consume("includes")) {
@@ -948,7 +945,7 @@
         return ret;
       } else {
         // rollback
-        unconsume(target);
+        unconsume(start_position);
       }
     }
 
@@ -980,7 +977,7 @@
       return defs;
     }
     const res = definitions();
-    if (tokens.length) error("Unrecognised tokens");
+    if (consume_position < tokens.length) error("Unrecognised tokens");
     return res;
   }
 

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -395,8 +395,8 @@
     }
 
     function argument() {
-      const ret = { optional: false, variadic: false };
       const start_position = consume_position;
+      const ret = { optional: false, variadic: false, default: null };
       ret.extAttrs = extended_attrs();
       const opt_token = consume("optional");
       if (opt_token) {
@@ -418,10 +418,7 @@
       ret.name = unescape(name.value);
       ret.escapedName = name.value;
       if (ret.optional) {
-        const dflt = default_();
-        if (typeof dflt !== "undefined") {
-          ret["default"] = dflt;
-        }
+        ret.default = default_() || null;
       }
       return ret;
     }

--- a/test/syntax/json/allowany.json
+++ b/test/syntax/json/allowany.json
@@ -45,6 +45,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -81,6 +82,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [
                             {
                                 "name": "AllowAny",

--- a/test/syntax/json/callback.json
+++ b/test/syntax/json/callback.json
@@ -14,6 +14,7 @@
             {
                 "optional": false,
                 "variadic": false,
+                "default": null,
                 "extAttrs": [],
                 "idlType": {
                     "type": "argument-type",
@@ -55,6 +56,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -89,6 +91,7 @@
             {
                 "optional": false,
                 "variadic": false,
+                "default": null,
                 "extAttrs": [],
                 "idlType": {
                     "type": "argument-type",
@@ -104,6 +107,7 @@
             {
                 "optional": false,
                 "variadic": false,
+                "default": null,
                 "extAttrs": [],
                 "idlType": {
                     "type": "argument-type",

--- a/test/syntax/json/constructor.json
+++ b/test/syntax/json/constructor.json
@@ -91,6 +91,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",

--- a/test/syntax/json/enum.json
+++ b/test/syntax/json/enum.json
@@ -80,6 +80,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -95,6 +96,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",

--- a/test/syntax/json/equivalent-decl.json
+++ b/test/syntax/json/equivalent-decl.json
@@ -43,6 +43,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -79,6 +80,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -94,6 +96,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -157,6 +160,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -193,6 +197,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -208,6 +213,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -244,6 +250,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -280,6 +287,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -295,6 +303,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",

--- a/test/syntax/json/extended-attributes.json
+++ b/test/syntax/json/extended-attributes.json
@@ -157,6 +157,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",

--- a/test/syntax/json/getter-setter.json
+++ b/test/syntax/json/getter-setter.json
@@ -43,6 +43,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -79,6 +80,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -94,6 +96,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",

--- a/test/syntax/json/identifier-qualified-names.json
+++ b/test/syntax/json/identifier-qualified-names.json
@@ -38,6 +38,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -74,6 +75,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -164,6 +166,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",

--- a/test/syntax/json/implements.json
+++ b/test/syntax/json/implements.json
@@ -52,6 +52,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -67,6 +68,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -82,6 +84,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",

--- a/test/syntax/json/indexed-properties.json
+++ b/test/syntax/json/indexed-properties.json
@@ -43,6 +43,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -79,6 +80,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -94,6 +96,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -130,6 +133,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -166,6 +170,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -202,6 +207,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -217,6 +223,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -253,6 +260,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",

--- a/test/syntax/json/namedconstructor.json
+++ b/test/syntax/json/namedconstructor.json
@@ -21,6 +21,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",

--- a/test/syntax/json/namespace.json
+++ b/test/syntax/json/namespace.json
@@ -43,6 +43,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -58,6 +59,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -94,6 +96,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -109,6 +112,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",

--- a/test/syntax/json/nointerfaceobject.json
+++ b/test/syntax/json/nointerfaceobject.json
@@ -25,6 +25,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",

--- a/test/syntax/json/nullableobjects.json
+++ b/test/syntax/json/nullableobjects.json
@@ -41,6 +41,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -77,6 +78,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",

--- a/test/syntax/json/operation-optional-arg.json
+++ b/test/syntax/json/operation-optional-arg.json
@@ -25,6 +25,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -40,6 +41,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -55,6 +57,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -70,6 +73,10 @@
                     {
                         "optional": true,
                         "variadic": false,
+                        "default": {
+                            "type": "number",
+                            "value": "3.5"
+                        },
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -80,11 +87,7 @@
                             "extAttrs": []
                         },
                         "name": "alpha",
-                        "escapedName": "alpha",
-                        "default": {
-                            "type": "number",
-                            "value": "3.5"
-                        }
+                        "escapedName": "alpha"
                     }
                 ],
                 "extAttrs": []

--- a/test/syntax/json/overloading.json
+++ b/test/syntax/json/overloading.json
@@ -41,6 +41,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -77,6 +78,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -122,6 +124,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -158,6 +161,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [
                             {
                                 "name": "AllowAny",
@@ -180,6 +184,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -195,6 +200,7 @@
                     {
                         "optional": false,
                         "variadic": true,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -251,6 +257,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -266,6 +273,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -281,6 +289,7 @@
                     {
                         "optional": true,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -296,6 +305,7 @@
                     {
                         "optional": false,
                         "variadic": true,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",

--- a/test/syntax/json/overridebuiltins.json
+++ b/test/syntax/json/overridebuiltins.json
@@ -43,6 +43,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",

--- a/test/syntax/json/record.json
+++ b/test/syntax/json/record.json
@@ -25,6 +25,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -127,6 +128,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",

--- a/test/syntax/json/reg-operations.json
+++ b/test/syntax/json/reg-operations.json
@@ -90,6 +90,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -126,6 +127,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -141,6 +143,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",

--- a/test/syntax/json/sequence.json
+++ b/test/syntax/json/sequence.json
@@ -25,6 +25,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -104,6 +105,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",

--- a/test/syntax/json/static.json
+++ b/test/syntax/json/static.json
@@ -105,6 +105,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -120,6 +121,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -135,6 +137,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",

--- a/test/syntax/json/treatasnull.json
+++ b/test/syntax/json/treatasnull.json
@@ -61,6 +61,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [
                             {
                                 "name": "TreatNullAs",

--- a/test/syntax/json/treatasundefined.json
+++ b/test/syntax/json/treatasundefined.json
@@ -61,6 +61,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [
                             {
                                 "name": "TreatUndefinedAs",

--- a/test/syntax/json/typedef.json
+++ b/test/syntax/json/typedef.json
@@ -153,6 +153,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -189,6 +190,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",

--- a/test/syntax/json/typesuffixes.json
+++ b/test/syntax/json/typesuffixes.json
@@ -25,6 +25,7 @@
                     {
                         "optional": false,
                         "variadic": false,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",

--- a/test/syntax/json/variadic-operations.json
+++ b/test/syntax/json/variadic-operations.json
@@ -43,6 +43,7 @@
                     {
                         "optional": false,
                         "variadic": true,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",
@@ -79,6 +80,7 @@
                     {
                         "optional": false,
                         "variadic": true,
+                        "default": null,
                         "extAttrs": [],
                         "idlType": {
                             "type": "argument-type",


### PR DESCRIPTION
This PR:

1. removes use of `array.unshift()` 😁
2. removes any need to remember all tokens to unconsume, prevents bugs like #145 
3. enables, but not in this PR, potentially better error message by showing preceding tokens in situations like #178. Not sure how should the format be.
4. fixes strange token order in error messages:
   ```
   > require(".").parse("interface X { operation(optional sequence<abc>); }");
   Thrown: Got an error during or right after parsing `interface X`: Unterminated operation, line 1 (tokens: ">optional); }")
   ```
5. always add `default` field for arguments. Previously it was added only when the value exists.