### PR TITLE
fix: allow required for an attribute name

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -603,7 +603,7 @@
       ret.idlType = type_with_extended_attributes("attribute-type") || error("No type in attribute");
       if (ret.idlType.generic === "sequence") error("Attributes cannot accept sequence types");
       if (ret.idlType.generic === "record") error("Attributes cannot accept record types");
-      const name = consume(ID) || error("No name in attribute");
+      const name = consume(ID, "required") || error("No name in attribute");
       ret.name = unescape(name.value);
       ret.escapedName = name.value;
       consume(";") || error("Unterminated attribute");

--- a/test/syntax/idl/attributes.widl
+++ b/test/syntax/idl/attributes.widl
@@ -6,4 +6,6 @@ interface Person {
   // short can take.
   attribute unsigned short age;
 
+  // required is an allowed attribute name
+  attribute any required;
 };

--- a/test/syntax/json/attributes.json
+++ b/test/syntax/json/attributes.json
@@ -21,6 +21,24 @@
                 "name": "age",
                 "escapedName": "age",
                 "extAttrs": []
+            },
+            {
+                "type": "attribute",
+                "static": false,
+                "stringifier": false,
+                "inherit": false,
+                "readonly": false,
+                "idlType": {
+                    "type": "attribute-type",
+                    "generic": null,
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "any",
+                    "extAttrs": []
+                },
+                "name": "required",
+                "escapedName": "required",
+                "extAttrs": []
             }
         ],
         "inheritance": null,


### PR DESCRIPTION
Fixes #181 

IMO it's weird that some keywords can be used as a name, but anyway:

https://heycam.github.io/webidl/#prod-AttributeName

```
AttributeName ::
    AttributeNameKeyword
    identifier
AttributeNameKeyword ::
    required
```