### PR TITLE
refactor: consume argument name in object spread way

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -410,7 +410,7 @@
       if (!ret.optional && consume("...")) {
         ret.variadic = true;
       }
-      const name = argument_name(ID);
+      const name = consume(ID, ...argumentNameKeywords);
       if (!name) {
         unconsume(start_position);
         return;
@@ -421,19 +421,6 @@
         ret.default = default_() || null;
       }
       return ret;
-    }
-
-    function argument_name() {
-      let name = consume(ID);
-      if (name) {
-        return name;
-      }
-      for (const keyword of argumentNameKeywords) {
-        name = consume(keyword);
-        if (name) {
-          return name;
-        }
-      }
     }
 
     function argument_list() {
@@ -859,7 +846,7 @@
           extAttrs: ea
         };
         if (typeof dflt !== "undefined") {
-          member["default"] = dflt;
+          member.default = dflt;
         }
         ret.members.push(member);
         consume(";") || error("Unterminated dictionary member");
@@ -918,7 +905,7 @@
           target: target.value
         };
         const imp = consume(ID) || error("Incomplete implements statement");
-        ret["implements"] = imp.value;
+        ret.implements = imp.value;
         consume(";") || error("No terminating ; for implements statement");
         return ret;
       } else {
@@ -937,7 +924,7 @@
           target: target.value
         };
         const imp = consume(ID) || error("Incomplete includes statement");
-        ret["includes"] = imp.value;
+        ret.includes = imp.value;
         consume(";") || error("No terminating ; for includes statement");
         return ret;
       } else {

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -42,7 +42,7 @@
       ret += type(arg.idlType);
       if (arg.variadic) ret += "...";
       ret += ` ${arg.escapedName}`;
-      if (arg["default"]) ret += ` = ${const_value(arg["default"])}`;
+      if (arg.default) ret += ` = ${const_value(arg.default)}`;
       return ret;
     };
     function args(its) {
@@ -61,7 +61,7 @@
         if (it.rhs.type === "identifier-list") ret += `=(${it.rhs.value.join(',')})`;
         else ret += `=${it.rhs.value}`;
       }
-      if (it.arguments) ret += `(${it["arguments"].length ? args(it["arguments"]) : ""})`;
+      if (it.arguments) ret += `(${it.arguments.length ? args(it.arguments) : ""})`;
       context.shift(); // XXX need to add more contexts, but not more than needed for ReSpec
       return ret;
     };
@@ -79,13 +79,13 @@
       }
       ret += type(it.idlType) + " ";
       if (it.name) ret += it.escapedName;
-      ret += `(${args(it["arguments"])});`;
+      ret += `(${args(it.arguments)});`;
       return ret;
     };
 
     function attribute(it) {
       let ret = extended_attributes(it.extAttrs);
-      if (it["static"]) ret += "static ";
+      if (it.static) ret += "static ";
       if (it.stringifier) ret += "stringifier ";
       if (it.inherit) ret += "inherit ";
       if (it.readonly) ret += "readonly ";
@@ -130,7 +130,7 @@
       let ret = extended_attributes(it.extAttrs);
       if (it.required) ret += "required ";
       ret += `${type(it.idlType)} ${it.escapedName}`;
-      if (it["default"]) ret += ` = ${const_value(it["default"])}`;
+      if (it.default) ret += ` = ${const_value(it.default)}`;
       ret += ";";
       return ret;
     };
@@ -145,7 +145,7 @@
     };
     function implements_(it) {
       const ret = extended_attributes(it.extAttrs);
-      return `${ret}${it.target} implements ${it["implements"]};`;
+      return `${ret}${it.target} implements ${it.implements};`;
     };
     function includes(it) {
       const ret = extended_attributes(it.extAttrs);
@@ -153,7 +153,7 @@
     };
     function callback(it) {
       const ret = extended_attributes(it.extAttrs);
-      return `${ret}callback ${it.name} = ${type(it.idlType)}(${args(it["arguments"])});`;
+      return `${ret}callback ${it.name} = ${type(it.idlType)}(${args(it.arguments)});`;
     };
     function enum_(it) {
       let ret = extended_attributes(it.extAttrs);


### PR DESCRIPTION
Thanks to variadic `consume()` by #173. Also removes some remaining ES3-era property accesses.