### PR TITLE
refactor(lib/writer): remove args()

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -724,13 +724,8 @@
           return ret;
         }
         const ea = extended_attrs();
-        const cnt = const_();
-        if (cnt) {
-          cnt.extAttrs = ea;
-          ret.members.push(cnt);
-          continue;
-        }
-        const mem = static_member() ||
+        const mem = const_() ||
+          static_member() ||
           stringifier() ||
           iterable() ||
           attribute() ||
@@ -758,13 +753,8 @@
           return ret;
         }
         const ea = extended_attrs();
-        const cnt = const_();
-        if (cnt) {
-          cnt.extAttrs = ea;
-          ret.members.push(cnt);
-          continue;
-        }
-        const mem = stringifier() ||
+        const mem = const_() ||
+          stringifier() ||
           attribute({ noInherit: true }) ||
           operation({ regular: true }) ||
           error("Unknown member");

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -825,7 +825,7 @@
         const required = consume("required");
         const typ = type_with_extended_attributes("dictionary-type") || error("No type for dictionary member");
         const name = consume(ID) || error("No name for dictionary member");
-        const dflt = default_();
+        const dflt = default_() || null;
         if (required && dflt) error("Required member must not have a default");
         const member = {
           type: "field",
@@ -833,11 +833,9 @@
           escapedName: name.value,
           required: !!required,
           idlType: typ,
-          extAttrs: ea
+          extAttrs: ea,
+          default: dflt
         };
-        if (typeof dflt !== "undefined") {
-          member.default = dflt;
-        }
         ret.members.push(member);
         consume(";") || error("Unterminated dictionary member");
       }

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -45,23 +45,14 @@
       if (arg.default) ret += ` = ${const_value(arg.default)}`;
       return ret;
     };
-    function args(its) {
-      let res = "";
-      for (let i = 0, n = its.length; i < n; i++) {
-        const arg = its[i];
-        res += argument(arg);
-        if (i < n - 1) res += ",";
-      }
-      return res;
-    };
     function make_ext_at(it) {
       context.unshift(it);
       let ret = it.name;
       if (it.rhs) {
-        if (it.rhs.type === "identifier-list") ret += `=(${it.rhs.value.join(',')})`;
+        if (it.rhs.type === "identifier-list") ret += `=(${it.rhs.value.join(",")})`;
         else ret += `=${it.rhs.value}`;
       }
-      if (it.arguments) ret += `(${it.arguments.length ? args(it.arguments) : ""})`;
+      if (it.arguments) ret += `(${it.arguments.length ? it.arguments.map(argument).join(",") : ""})`;
       context.shift(); // XXX need to add more contexts, but not more than needed for ReSpec
       return ret;
     };
@@ -70,7 +61,7 @@
       return `[${eats.map(make_ext_at).join(", ")}]`;
     };
 
-    const modifiers = "getter setter creator deleter legacycaller stringifier static".split(" ");
+    const modifiers = "getter setter deleter stringifier static".split(" ");
     function operation(it) {
       let ret = extended_attributes(it.extAttrs);
       if (it.stringifier && !it.idlType) return "stringifier;";
@@ -79,7 +70,7 @@
       }
       ret += type(it.idlType) + " ";
       if (it.name) ret += it.escapedName;
-      ret += `(${args(it.arguments)});`;
+      ret += `(${it.arguments.map(argument).join(",")});`;
       return ret;
     };
 
@@ -153,7 +144,7 @@
     };
     function callback(it) {
       const ret = extended_attributes(it.extAttrs);
-      return `${ret}callback ${it.name} = ${type(it.idlType)}(${args(it.arguments)});`;
+      return `${ret}callback ${it.name} = ${type(it.idlType)}(${it.arguments.map(argument).join(",")});`;
     };
     function enum_(it) {
       let ret = extended_attributes(it.extAttrs);

--- a/test/syntax/json/dictionary-inherits.json
+++ b/test/syntax/json/dictionary-inherits.json
@@ -54,7 +54,8 @@
                     "idlType": "Point",
                     "extAttrs": []
                 },
-                "extAttrs": []
+                "extAttrs": [],
+                "default": null
             }
         ],
         "inheritance": null,
@@ -78,7 +79,8 @@
                     "idlType": "float",
                     "extAttrs": []
                 },
-                "extAttrs": []
+                "extAttrs": [],
+                "default": null
             }
         ],
         "inheritance": "PaintOptions",

--- a/test/syntax/json/dictionary.json
+++ b/test/syntax/json/dictionary.json
@@ -54,7 +54,8 @@
                     "idlType": "Point",
                     "extAttrs": []
                 },
-                "extAttrs": []
+                "extAttrs": [],
+                "default": null
             },
             {
                 "type": "field",
@@ -95,7 +96,8 @@
                     "idlType": "long",
                     "extAttrs": []
                 },
-                "extAttrs": []
+                "extAttrs": [],
+                "default": null
             }
         ],
         "inheritance": null,
@@ -119,7 +121,8 @@
                     "idlType": "long",
                     "extAttrs": []
                 },
-                "extAttrs": []
+                "extAttrs": [],
+                "default": null
             },
             {
                 "type": "field",
@@ -134,7 +137,8 @@
                     "idlType": "long",
                     "extAttrs": []
                 },
-                "extAttrs": []
+                "extAttrs": [],
+                "default": null
             }
         ],
         "extAttrs": []


### PR DESCRIPTION
IMO `map()`+`join()` is better for readability than a for i++ loop 😁

Also removes obsolete `creator` and `legacycaller` from writer.