### PR TITLE
Add trivia field for interfaces/mixins

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -546,6 +546,7 @@
       const tok = consume("interface");
       if (tok) {
         ret = interface_rest(false, "callback interface");
+        ret.trivia.base = tok.trivia;
         return ret;
       }
       const name = consume(ID) || error("No name for callback");
@@ -709,18 +710,27 @@
 
     function interface_rest(isPartial, typeName = "interface") {
       const name = consume(ID) || error("No name for interface");
+      const trivia = {
+        base: null,
+        name: name.trivia
+      };
       const mems = [];
       const ret = current = {
         type: typeName,
         name: isPartial ? name.value : sanitize_name(name.value, "interface"),
         partial: isPartial,
-        members: mems
+        members: mems,
+        trivia
       };
       if (!isPartial) ret.inheritance = inheritance() || null;
-      consume("{") || error("Bodyless interface");
+      const open = consume("{") || error("Bodyless interface");
+      trivia.open = open.trivia;
       while (true) {
-        if (consume("}")) {
-          consume(";") || error("Missing semicolon after interface");
+        const close = consume("}");
+        if (close) {
+          trivia.close = close.trivia;
+          const termination = consume(";") || error("Missing semicolon after interface");
+          trivia.termination = termination.trivia;
           return ret;
         }
         const ea = extended_attrs();
@@ -737,14 +747,20 @@
     }
 
     function mixin_rest(isPartial) {
-      if (!consume("mixin")) return;
+      const mixin = consume("mixin");
+      if (!mixin) return;
+      const trivia = {
+        base: null,
+        mixin: mixin.trivia
+      }
       const name = consume(ID) || error("No name for interface mixin");
       const mems = [];
       const ret = current = {
         type: "interface mixin",
         name: isPartial ? name.value : sanitize_name(name.value, "interface mixin"),
         partial: isPartial,
-        members: mems
+        members: mems,
+        trivia
       };
       consume("{") || error("Bodyless interface mixin");
       while (true) {
@@ -764,10 +780,13 @@
     }
 
     function interface_(isPartial) {
-      if (!consume("interface")) return;
-      return mixin_rest(isPartial) ||
+      const base = consume("interface");
+      if (!base) return;
+      const ret = mixin_rest(isPartial) ||
         interface_rest(isPartial) ||
         error("Interface has no proper body");
+      ret.trivia.base = base.trivia;
+      return ret;
     }
 
     function namespace(isPartial) {

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -86,17 +86,17 @@
 
     function interface_(it) {
       let ret = extended_attributes(it.extAttrs);
-      if (it.partial) ret += "partial ";
-      ret += `interface ${it.name} `;
-      if (it.inheritance) ret += `: ${it.inheritance} `;
-      ret += `{${iterate(it.members)}};`;
+      if (it.partial) ret += "partial";
+      ret += `${it.trivia.base}interface${it.trivia.name}${it.name}`;
+      if (it.inheritance) ret += `: ${it.inheritance}`;
+      ret += `${it.trivia.open}{${iterate(it.members)}${it.trivia.close}}${it.trivia.termination};`;
       return ret;
     };
 
     function interface_mixin(it) {
       let ret = extended_attributes(it.extAttrs);
-      if (it.partial) ret += "partial ";
-      ret += `interface mixin ${it.name} `;
+      if (it.partial) ret += "partial";
+      ret += `${it.trivia.base}interface${it.trivia.mixin}mixin ${it.name} `;
       ret += `{${iterate(it.members)}};`;
       return ret;
     }
@@ -167,7 +167,7 @@
       return `${it.readonly ? "readonly " : ""}setlike<${type(it.idlType[0])}>;`;
     };
     function callbackInterface(it) {
-      return `callback ${interface_(it)}`;
+      return `callback${interface_(it)}`;
     };
 
     const table = {

--- a/test/syntax.js
+++ b/test/syntax.js
@@ -7,13 +7,7 @@ const debug = true;
 describe("Parses all of the IDLs to produce the correct ASTs", () => {
   for (const test of collect("syntax")) {
     it(`should produce the same AST for ${test.path}`, () => {
-      try {
-        expect(test.diff()).toBeFalsy();
-      }
-      catch (e) {
-        console.log(e.toString());
-        throw e;
-      }
+      expect(test.diff()).toBeFalsy();
     });
   }
 });

--- a/test/syntax/json/allowany.json
+++ b/test/syntax/json/allowany.json
@@ -106,6 +106,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/attributes.json
+++ b/test/syntax/json/attributes.json
@@ -45,7 +45,7 @@
             "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n\n",
             "name": " ",
             "open": " ",
-            "close": "\n\n",
+            "close": "\n",
             "termination": ""
         },
         "inheritance": null,

--- a/test/syntax/json/attributes.json
+++ b/test/syntax/json/attributes.json
@@ -41,6 +41,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/callback.json
+++ b/test/syntax/json/callback.json
@@ -73,6 +73,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": " ",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },

--- a/test/syntax/json/constants.json
+++ b/test/syntax/json/constants.json
@@ -148,6 +148,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/constructor.json
+++ b/test/syntax/json/constructor.json
@@ -77,6 +77,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": [
             {

--- a/test/syntax/json/documentation-dos.json
+++ b/test/syntax/json/documentation-dos.json
@@ -4,6 +4,13 @@
         "name": "Documentation",
         "partial": false,
         "members": [],
+        "trivia": {
+            "base": "/**\n* \\brief Testing documentation features\n*\n* This is a\n* single paragraph\n*\n* <p>This is valid.</p>\n* <p>This is <em>valid</em>.</p>\n* <p>This is <b>valid</b>.</p>\n* <p>This is <a href=''>valid</a>.</p>\n* <ul>\n* <li>This</li>\n* <li>is</li>\n* <li>valid</li>\n* </ul>\n* <dl>\n* <dt>This</dt>\n* <dd>valid</dd>\n* </dl>\n* <table>\n* <tr>\n* <td>this</td>\n* <td>is</td>\n* </tr>\n* <tr>\n* <td>valid</td>\n* </tr>\n* </table>\n* <p>This is <br> valid.</p>\n* <p>This is <br /> valid.</p>\n* <p>This is <br/> valid.</p>\n*/\n",
+            "name": " ",
+            "open": " ",
+            "close": "",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/documentation.json
+++ b/test/syntax/json/documentation.json
@@ -4,6 +4,13 @@
         "name": "Documentation",
         "partial": false,
         "members": [],
+        "trivia": {
+            "base": "/**\n* \\brief Testing documentation features\n*\n* This is a\n* single paragraph\n*\n* <p>This is valid.</p>\n* <p>This is <em>valid</em>.</p>\n* <p>This is <b>valid</b>.</p>\n* <p>This is <a href=''>valid</a>.</p>\n* <ul>\n* <li>This</li>\n* <li>is</li>\n* <li>valid</li>\n* </ul>\n* <dl>\n* <dt>This</dt>\n* <dd>valid</dd>\n* </dl>\n* <table>\n* <tr>\n* <td>this</td>\n* <td>is</td>\n* </tr>\n* <tr>\n* <td>valid</td>\n* </tr>\n* </table>\n* <p>This is <br> valid.</p>\n* <p>This is <br /> valid.</p>\n* <p>This is <br/> valid.</p>\n* <p><img src=\"foo.png\" alt=\"Valid\"/></p>\n*/\n",
+            "name": " ",
+            "open": " ",
+            "close": "",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/enum.json
+++ b/test/syntax/json/enum.json
@@ -113,6 +113,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },

--- a/test/syntax/json/equivalent-decl.json
+++ b/test/syntax/json/equivalent-decl.json
@@ -113,6 +113,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },
@@ -320,6 +327,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n\n\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/extended-attributes.json
+++ b/test/syntax/json/extended-attributes.json
@@ -4,6 +4,13 @@
         "name": "ServiceWorkerGlobalScope",
         "partial": false,
         "members": [],
+        "trivia": {
+            "base": "\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n\n",
+            "termination": ""
+        },
         "inheritance": "WorkerGlobalScope",
         "extAttrs": [
             {
@@ -34,6 +41,13 @@
         "name": "IdInterface",
         "partial": false,
         "members": [],
+        "trivia": {
+            "base": "\n",
+            "name": " ",
+            "open": " ",
+            "close": "",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": [
             {
@@ -143,6 +157,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": [
             {
@@ -224,6 +245,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": [
             {

--- a/test/syntax/json/generic.json
+++ b/test/syntax/json/generic.json
@@ -71,6 +71,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },
@@ -134,6 +141,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n\n// Extracted from https://slightlyoff.github.io/ServiceWorker/spec/service_worker/ on 2014-05-08\n\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },
@@ -170,6 +184,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n\n// Extracted from https://slightlyoff.github.io/ServiceWorker/spec/service_worker/ on 2014-05-13\n\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": "Event",
         "extAttrs": []
     }

--- a/test/syntax/json/getter-setter.json
+++ b/test/syntax/json/getter-setter.json
@@ -113,6 +113,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/identifier-qualified-names.json
+++ b/test/syntax/json/identifier-qualified-names.json
@@ -92,6 +92,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n\n  // Interface identifier: \"System\"\n  // Qualified name:       \"::framework::System\"\n  ",
+            "name": " ",
+            "open": " ",
+            "close": "\n  ",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },
@@ -137,6 +144,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n\n\n    // Interface identifier: \"TextField\"\n    // Qualified name:       \"::framework::gui::TextField\"\n    ",
+            "name": " ",
+            "open": " ",
+            "close": "\n    ",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },
@@ -183,6 +197,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/implements.json
+++ b/test/syntax/json/implements.json
@@ -23,6 +23,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n  ",
+            "name": " ",
+            "open": " ",
+            "close": "\n    // ...\n  ",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },
@@ -101,6 +108,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n\n  ",
+            "name": " ",
+            "open": " ",
+            "close": "\n    // ...\n  ",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },

--- a/test/syntax/json/indexed-properties.json
+++ b/test/syntax/json/indexed-properties.json
@@ -277,6 +277,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/inherits-getter.json
+++ b/test/syntax/json/inherits-getter.json
@@ -23,6 +23,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },
@@ -68,6 +75,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": "Animal",
         "extAttrs": []
     },
@@ -95,6 +109,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": "Person",
         "extAttrs": []
     }

--- a/test/syntax/json/interface-inherits.json
+++ b/test/syntax/json/interface-inherits.json
@@ -23,6 +23,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },
@@ -50,6 +57,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": "Animal",
         "extAttrs": []
     },
@@ -77,6 +91,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": "Animal",
         "extAttrs": []
     }

--- a/test/syntax/json/iterable.json
+++ b/test/syntax/json/iterable.json
@@ -19,6 +19,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },
@@ -50,6 +57,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },
@@ -80,6 +94,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/legacyiterable.json
+++ b/test/syntax/json/legacyiterable.json
@@ -19,6 +19,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/maplike.json
+++ b/test/syntax/json/maplike.json
@@ -28,6 +28,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },
@@ -60,6 +67,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },
@@ -106,6 +120,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n\n// Extracted from https://heycam.github.io/webidl/#idl-type-extended-attribute-associated-with on 2017-07-01\n\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/mixin.json
+++ b/test/syntax/json/mixin.json
@@ -23,6 +23,10 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "// Extracted from https://heycam.github.io/webidl/#using-mixins-and-partials on 2017-11-02\n\n",
+            "mixin": " "
+        },
         "extAttrs": []
     },
     {
@@ -61,6 +65,10 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": " ",
+            "mixin": " "
+        },
         "extAttrs": []
     }
 ]

--- a/test/syntax/json/namedconstructor.json
+++ b/test/syntax/json/namedconstructor.json
@@ -4,6 +4,13 @@
         "name": "HTMLAudioElement",
         "partial": false,
         "members": [],
+        "trivia": {
+            "base": "\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n  // ...\n",
+            "termination": ""
+        },
         "inheritance": "HTMLMediaElement",
         "extAttrs": [
             {

--- a/test/syntax/json/nointerfaceobject.json
+++ b/test/syntax/json/nointerfaceobject.json
@@ -42,6 +42,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": [
             {

--- a/test/syntax/json/nullable.json
+++ b/test/syntax/json/nullable.json
@@ -23,6 +23,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },
@@ -50,6 +57,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n  // ...\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/nullableobjects.json
+++ b/test/syntax/json/nullableobjects.json
@@ -4,6 +4,13 @@
         "name": "A",
         "partial": false,
         "members": [],
+        "trivia": {
+            "base": "// Extracted from WebIDL spec 2011-05-23\n\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n  // ...\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },
@@ -12,6 +19,13 @@
         "name": "B",
         "partial": false,
         "members": [],
+        "trivia": {
+            "base": "\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n  // ...\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },
@@ -95,6 +109,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/operation-optional-arg.json
+++ b/test/syntax/json/operation-optional-arg.json
@@ -93,6 +93,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/overloading.json
+++ b/test/syntax/json/overloading.json
@@ -4,6 +4,13 @@
         "name": "A",
         "partial": false,
         "members": [],
+        "trivia": {
+            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n  // ...\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },
@@ -12,6 +19,13 @@
         "name": "B",
         "partial": false,
         "members": [],
+        "trivia": {
+            "base": "\n\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n  // ...\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },
@@ -95,6 +109,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },
@@ -322,6 +343,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/overridebuiltins.json
+++ b/test/syntax/json/overridebuiltins.json
@@ -60,6 +60,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": [
             {

--- a/test/syntax/json/partial-interface.json
+++ b/test/syntax/json/partial-interface.json
@@ -23,6 +23,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },
@@ -50,6 +57,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": " ",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "extAttrs": []
     }
 ]

--- a/test/syntax/json/primitives.json
+++ b/test/syntax/json/primitives.json
@@ -311,6 +311,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/promise-void.json
+++ b/test/syntax/json/promise-void.json
@@ -30,6 +30,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/prototyperoot.json
+++ b/test/syntax/json/prototyperoot.json
@@ -23,6 +23,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": [
             {

--- a/test/syntax/json/putforwards.json
+++ b/test/syntax/json/putforwards.json
@@ -51,6 +51,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/record.json
+++ b/test/syntax/json/record.json
@@ -120,6 +120,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": [
             {
@@ -214,6 +221,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/reg-operations.json
+++ b/test/syntax/json/reg-operations.json
@@ -41,6 +41,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },
@@ -160,6 +167,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/replaceable.json
+++ b/test/syntax/json/replaceable.json
@@ -50,6 +50,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/sequence.json
+++ b/test/syntax/json/sequence.json
@@ -76,6 +76,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n// edited to remove sequence as attributes, now invalid\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n  // ...\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },
@@ -136,6 +143,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n\n// Extracted from https://heycam.github.io/webidl/#idl-type-extended-attribute-associated-with on 2017-07-01\n\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/setlike.json
+++ b/test/syntax/json/setlike.json
@@ -20,6 +20,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },
@@ -44,6 +51,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },
@@ -75,6 +89,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/static.json
+++ b/test/syntax/json/static.json
@@ -4,6 +4,13 @@
         "name": "Point",
         "partial": false,
         "members": [],
+        "trivia": {
+            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
+            "name": " ",
+            "open": " ",
+            "close": " /* ... */ ",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },
@@ -154,6 +161,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/stringifier-attribute.json
+++ b/test/syntax/json/stringifier-attribute.json
@@ -41,6 +41,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": [
             {

--- a/test/syntax/json/stringifier-custom.json
+++ b/test/syntax/json/stringifier-custom.json
@@ -79,6 +79,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": [
             {

--- a/test/syntax/json/stringifier.json
+++ b/test/syntax/json/stringifier.json
@@ -25,6 +25,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },
@@ -43,6 +50,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/treatasnull.json
+++ b/test/syntax/json/treatasnull.json
@@ -88,6 +88,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/treatasundefined.json
+++ b/test/syntax/json/treatasundefined.json
@@ -88,6 +88,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/typedef.json
+++ b/test/syntax/json/typedef.json
@@ -41,6 +41,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n      ",
+            "name": " ",
+            "open": " ",
+            "close": "\n      ",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },
@@ -106,6 +113,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n\n      ",
+            "name": " ",
+            "open": " ",
+            "close": "\n      ",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },
@@ -207,6 +221,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "\n\n  ",
+            "name": " ",
+            "open": " ",
+            "close": "\n  ",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     },

--- a/test/syntax/json/typesuffixes.json
+++ b/test/syntax/json/typesuffixes.json
@@ -49,6 +49,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/uniontype.json
+++ b/test/syntax/json/uniontype.json
@@ -124,6 +124,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/syntax/json/variadic-operations.json
+++ b/test/syntax/json/variadic-operations.json
@@ -97,6 +97,13 @@
                 "extAttrs": []
             }
         ],
+        "trivia": {
+            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
         "inheritance": null,
         "extAttrs": []
     }

--- a/test/util/collect.js
+++ b/test/util/collect.js
@@ -23,8 +23,9 @@ function* collect(base, { expectError } = {}) {
       opt = JSON.parse(fs.readFileSync(optFile, "utf8"));
 
     try {
-      const ast = wp.parse(fs.readFileSync(path, "utf8").replace(/\r\n/g, "\n"), opt);
-      yield new TestItem({ ast, path, opt });
+      const text = fs.readFileSync(path, "utf8").replace(/\r\n/g, "\n");
+      const ast = wp.parse(text, opt);
+      yield new TestItem({ text, ast, path, opt });
     }
     catch (error) {
       if (expectError) {
@@ -39,7 +40,8 @@ function* collect(base, { expectError } = {}) {
 
 
 class TestItem {
-  constructor({ ast, path, error, opt }) {
+  constructor({ text, ast, path, error, opt }) {
+    this.text = text;
     this.ast = ast;
     this.path = path;
     this.error = error;

--- a/test/writer.js
+++ b/test/writer.js
@@ -4,20 +4,23 @@ const { collect } = require("./util/collect");
 const wp = require("../lib/webidl2");
 const writer = require("../lib/writer");
 const expect = require("expect");
+const path = require("path");
 const debug = true;
 
 describe("Rewrite and parses all of the IDLs to produce the same ASTs", () => {
+  const whitelist = [
+    "documentation",
+    "documentation-dos"
+  ];
   for (const test of collect("syntax")) {
     it(`should produce the same AST for ${test.path}`, () => {
-      try {
-        const diff = test.diff(wp.parse(writer.write(test.ast), test.opt));
-        if (diff && debug) console.log(JSON.stringify(diff, null, 4));
-        expect(diff).toBe(undefined);
+      const rewritten = writer.write(test.ast);
+      if (whitelist.includes(path.basename(test.path).slice(0, -5))) {
+        expect(rewritten).toEqual(test.text.trim());
       }
-      catch (e) {
-        console.log(e.toString());
-        throw e;
-      }
+      const diff = test.diff(wp.parse(rewritten, test.opt));
+      if (diff && debug) console.log(JSON.stringify(diff, null, 4));
+      expect(diff).toBe(undefined);
     });
   }
 });


### PR DESCRIPTION
This is the very first commit of #185.

This adds `trivia` field for interfaces and mixins, with no breaking change.