### PR TITLE
fix: prevent empty iterable declaration

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -692,7 +692,7 @@
       if (ret.type !== 'maplike' && ret.type !== 'setlike')
         delete ret.readonly;
       if (consume("<")) {
-        ret.idlType = [type_with_extended_attributes()] || error(`Error parsing ${ittype} declaration`);
+        ret.idlType = [type_with_extended_attributes() || error(`Error parsing ${ittype} declaration`)];
         if (secondTypeAllowed) {
           if (consume(",")) {
             ret.idlType.push(type_with_extended_attributes());

--- a/test/invalid/idl/iterable-empty.widl
+++ b/test/invalid/idl/iterable-empty.widl
@@ -1,0 +1,3 @@
+interface X {
+    iterable<>;
+};

--- a/test/invalid/json/iterable-empty.json
+++ b/test/invalid/json/iterable-empty.json
@@ -1,0 +1,4 @@
+{
+    "message": "Got an error during or right after parsing `interface X`: Error parsing iterable declaration",
+    "line": 2
+}


### PR DESCRIPTION
```webidl
interface X {
  iterable<>; // should be illegal
};
```

Fixes a mistake. 🤣