### PR TITLE
Add trivia for iterable declarations

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -729,24 +729,19 @@
     }
 
     function iterable_type() {
-      if (consume("iterable")) return "iterable";
-      else if (consume("legacyiterable")) return "legacyiterable";
-      else if (consume("maplike")) return "maplike";
-      else if (consume("setlike")) return "setlike";
-      else return;
+      return consume("iterable", "legacyiterable", "maplike", "setlike");
     }
 
     function readonly_iterable_type() {
-      if (consume("maplike")) return "maplike";
-      else if (consume("setlike")) return "setlike";
-      else return;
+      return consume("maplike", "setlike");
     }
 
     function iterable() {
       const start_position = consume_position;
-      const ret = { type: null, idlType: null, readonly: false };
-      if (consume("readonly")) {
-        ret.readonly = true;
+      const ret = { type: null, idlType: null, readonly: null, trivia: {} };
+      const readonly = consume("readonly");
+      if (readonly) {
+        ret.readonly = { trivia: readonly.trivia };
       }
       const consumeItType = ret.readonly ? readonly_iterable_type : iterable_type;
 
@@ -755,25 +750,29 @@
         unconsume(start_position);
         return;
       }
+      ret.trivia.type = ittype.trivia;
 
-      const secondTypeRequired = ittype === "maplike";
-      const secondTypeAllowed = secondTypeRequired || ittype === "iterable";
-      ret.type = ittype;
+      const secondTypeRequired = ittype.value === "maplike";
+      const secondTypeAllowed = secondTypeRequired || ittype.value === "iterable";
+      ret.type = ittype.value;
       if (ret.type !== 'maplike' && ret.type !== 'setlike')
         delete ret.readonly;
-      if (consume("<")) {
-        ret.idlType = [type_with_extended_attributes() || error(`Error parsing ${ittype} declaration`)];
-        if (secondTypeAllowed) {
-          if (consume(",")) {
-            ret.idlType.push(type_with_extended_attributes());
-          }
-          else if (secondTypeRequired)
-            error(`Missing second type argument in ${ittype} declaration`);
+      const open = consume("<") || error(`Error parsing ${ittype.value} declaration`);
+      ret.trivia.open = open.trivia;
+      const first = type_with_extended_attributes() || error(`Error parsing ${ittype.value} declaration`);
+      ret.idlType = [first];
+      if (secondTypeAllowed) {
+        first.separator = untyped_consume(",") || null;
+        if (first.separator) {
+          ret.idlType.push(type_with_extended_attributes());
         }
-        if (!consume(">")) error(`Unterminated ${ittype} declaration`);
-        if (!consume(";")) error(`Missing semicolon after ${ittype} declaration`);
-      } else
-        error(`Error parsing ${ittype} declaration`);
+        else if (secondTypeRequired)
+          error(`Missing second type argument in ${ittype.value} declaration`);
+      }
+      const close = consume(">") || error(`Unterminated ${ittype.value} declaration`);
+      ret.trivia.close = close.trivia;
+      const termination = consume(";") || error(`Missing semicolon after ${ittype.value} declaration`);
+      ret.trivia.termination = termination.trivia;
 
       return ret;
     }

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -141,7 +141,8 @@
     };
     function iterable_like(it) {
       const readonly = it.readonly ? `${it.readonly.trivia}readonly` : "";
-      return `${readonly}${it.trivia.type}${it.type}${it.trivia.open}<${it.idlType.map(type).join("")}${it.trivia.close}>${it.trivia.termination};`;
+      const bracket = `${it.trivia.open}<${it.idlType.map(type).join("")}${it.trivia.close}>`;
+      return `${readonly}${it.trivia.type}${it.type}${bracket}${it.trivia.termination};`;
     };
     function callbackInterface(it) {
       return `callback${interface_(it)}`;

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -140,8 +140,8 @@
       return `${ext}enum ${it.name} {${values}};`;
     };
     function iterable_like(it) {
-      const readonly = it.readonly ? "readonly " : "";
-      return `${readonly}${it.type}<${it.idlType.map(type).join(",")}>;`;
+      const readonly = it.readonly ? `${it.readonly.trivia}readonly` : "";
+      return `${readonly}${it.trivia.type}${it.type}${it.trivia.open}<${it.idlType.map(type).join("")}${it.trivia.close}>${it.trivia.termination};`;
     };
     function callbackInterface(it) {
       return `callback${interface_(it)}`;

--- a/test/syntax/json/iterable.json
+++ b/test/syntax/json/iterable.json
@@ -23,6 +23,12 @@
                         }
                     }
                 ],
+                "trivia": {
+                    "type": "\n  ",
+                    "open": "",
+                    "close": "",
+                    "termination": ""
+                },
                 "extAttrs": []
             }
         ],
@@ -53,7 +59,10 @@
                         "baseName": "short",
                         "prefix": null,
                         "postfix": null,
-                        "separator": null,
+                        "separator": {
+                            "value": ",",
+                            "trivia": ""
+                        },
                         "extAttrs": [],
                         "trivia": {
                             "base": ""
@@ -77,6 +86,12 @@
                         }
                     }
                 ],
+                "trivia": {
+                    "type": "\n  ",
+                    "open": "",
+                    "close": "",
+                    "termination": ""
+                },
                 "extAttrs": []
             }
         ],
@@ -121,6 +136,12 @@
                         }
                     }
                 ],
+                "trivia": {
+                    "type": "\n  ",
+                    "open": "",
+                    "close": "",
+                    "termination": ""
+                },
                 "extAttrs": []
             }
         ],

--- a/test/syntax/json/legacyiterable.json
+++ b/test/syntax/json/legacyiterable.json
@@ -23,6 +23,12 @@
                         }
                     }
                 ],
+                "trivia": {
+                    "type": "\n  ",
+                    "open": "",
+                    "close": "",
+                    "termination": ""
+                },
                 "extAttrs": []
             }
         ],

--- a/test/syntax/json/maplike.json
+++ b/test/syntax/json/maplike.json
@@ -16,7 +16,10 @@
                         "baseName": "long",
                         "prefix": null,
                         "postfix": null,
-                        "separator": null,
+                        "separator": {
+                            "value": ",",
+                            "trivia": ""
+                        },
                         "extAttrs": [],
                         "trivia": {
                             "base": ""
@@ -38,7 +41,13 @@
                         }
                     }
                 ],
-                "readonly": false,
+                "readonly": null,
+                "trivia": {
+                    "type": "\n  ",
+                    "open": "",
+                    "close": "",
+                    "termination": ""
+                },
                 "extAttrs": []
             }
         ],
@@ -69,7 +78,10 @@
                         "baseName": "long",
                         "prefix": null,
                         "postfix": null,
-                        "separator": null,
+                        "separator": {
+                            "value": ",",
+                            "trivia": ""
+                        },
                         "extAttrs": [],
                         "trivia": {
                             "base": ""
@@ -91,7 +103,15 @@
                         }
                     }
                 ],
-                "readonly": true,
+                "readonly": {
+                    "trivia": "\n  "
+                },
+                "trivia": {
+                    "type": " ",
+                    "open": "",
+                    "close": "",
+                    "termination": ""
+                },
                 "extAttrs": []
             }
         ],
@@ -122,7 +142,10 @@
                         "baseName": "DOMString",
                         "prefix": null,
                         "postfix": null,
-                        "separator": null,
+                        "separator": {
+                            "value": ",",
+                            "trivia": ""
+                        },
                         "extAttrs": [
                             {
                                 "name": "XAttr2",
@@ -158,7 +181,13 @@
                         }
                     }
                 ],
-                "readonly": false,
+                "readonly": null,
+                "trivia": {
+                    "type": "\n    ",
+                    "open": "",
+                    "close": "",
+                    "termination": ""
+                },
                 "extAttrs": []
             }
         ],

--- a/test/syntax/json/setlike.json
+++ b/test/syntax/json/setlike.json
@@ -23,7 +23,13 @@
                         }
                     }
                 ],
-                "readonly": false,
+                "readonly": null,
+                "trivia": {
+                    "type": "\n  ",
+                    "open": "",
+                    "close": "",
+                    "termination": ""
+                },
                 "extAttrs": []
             }
         ],
@@ -61,7 +67,15 @@
                         }
                     }
                 ],
-                "readonly": true,
+                "readonly": {
+                    "trivia": "\n  "
+                },
+                "trivia": {
+                    "type": " ",
+                    "open": "",
+                    "close": "",
+                    "termination": ""
+                },
                 "extAttrs": []
             }
         ],
@@ -106,7 +120,13 @@
                         }
                     }
                 ],
-                "readonly": false,
+                "readonly": null,
+                "trivia": {
+                    "type": "\n  ",
+                    "open": "",
+                    "close": "",
+                    "termination": ""
+                },
                 "extAttrs": []
             }
         ],


### PR DESCRIPTION
Again includes a null pattern for optional `readonly`.