### PR TITLE
Add trivia for extended attributes

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -454,7 +454,7 @@
     }
 
     function type_with_extended_attributes(typeName) {
-      const extAttrs = extended_attrs() || null;
+      const extAttrs = extended_attrs();
       const ret = single_type(typeName) || union_type(typeName);
       if (ret) ret.extAttrs = extAttrs;
       return ret;
@@ -463,7 +463,7 @@
     function argument() {
       const start_position = consume_position;
       const ret = { optional: null, variadic: null, default: null, trivia: {} };
-      ret.extAttrs = extended_attrs() || null;
+      ret.extAttrs = extended_attrs();
       const optional = consume("optional");
       if (optional) {
         ret.optional = { trivia: optional.trivia };
@@ -559,7 +559,7 @@
     // seems to be used
     function extended_attrs() {
       const open = consume("[");
-      if (!open) return;
+      if (!open) return null;
       const eas = {
         trivia: { open: open.trivia },
         items: []
@@ -876,7 +876,7 @@
           trivia.termination = termination.trivia;
           return ret;
         }
-        const ea = extended_attrs() || null;
+        const ea = extended_attrs();
         const mem = const_() ||
           static_member() ||
           stringifier() ||
@@ -911,7 +911,7 @@
           consume(";") || error("Missing semicolon after interface mixin");
           return ret;
         }
-        const ea = extended_attrs() || null;
+        const ea = extended_attrs();
         const mem = const_() ||
           stringifier() ||
           attribute({ noInherit: true }) ||
@@ -948,7 +948,7 @@
           consume(";") || error("Missing semicolon after namespace");
           return ret;
         }
-        const ea = extended_attrs() || null;
+        const ea = extended_attrs();
         const mem = attribute({ noInherit: true, readonly: true }) ||
           operation({ regular: true }) ||
           error("Unknown member");
@@ -983,7 +983,7 @@
           consume(";") || error("Missing semicolon after dictionary");
           return ret;
         }
-        const ea = extended_attrs() || null;
+        const ea = extended_attrs();
         const required = consume("required");
         const typ = type_with_extended_attributes("dictionary-type") || error("No type for dictionary member");
         const name = consume(ID) || error("No name for dictionary member");
@@ -1099,7 +1099,7 @@
       if (!tokens.length) return [];
       const defs = [];
       while (true) {
-        const ea = extended_attrs() || null;
+        const ea = extended_attrs();
         const def = definition();
         if (!def) {
           if (ea) error("Stray extended attributes");

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -203,7 +203,7 @@
       prefix: null,
       postfix: null,
       separator: null,
-      extAttrs: []
+      extAttrs: null
     });
 
     function error(str) {
@@ -454,16 +454,16 @@
     }
 
     function type_with_extended_attributes(typeName) {
-      const extAttrs = extended_attrs();
+      const extAttrs = extended_attrs() || null;
       const ret = single_type(typeName) || union_type(typeName);
-      if (extAttrs.length && ret) ret.extAttrs = extAttrs;
+      if (ret) ret.extAttrs = extAttrs;
       return ret;
     }
 
     function argument() {
       const start_position = consume_position;
       const ret = { optional: null, variadic: null, default: null, trivia: {} };
-      ret.extAttrs = extended_attrs();
+      ret.extAttrs = extended_attrs() || null;
       const optional = consume("optional");
       if (optional) {
         ret.optional = { trivia: optional.trivia };
@@ -511,33 +511,45 @@
     function simple_extended_attr() {
       const name = consume(ID);
       if (!name) return;
+      const trivia = { name: name.trivia };
       const ret = {
         name: name.value,
-        arguments: null,
+        signature: null,
         type: "extended-attribute",
-        rhs: null
+        rhs: null,
+        trivia
       };
       const eq = consume("=");
       if (eq) {
         ret.rhs = consume(ID, FLOAT, INT, STR);
         if (ret.rhs) {
-          // No trivia exposure yet
-          ret.rhs.trivia = undefined;
+          ret.rhs.trivia = {
+            assign: eq.trivia,
+            value: ret.rhs.trivia
+          };
         }
       }
-      if (consume("(")) {
+      const open = consume("(");
+      if (open) {
+        const listTrivia = { open: open.trivia };
         if (eq && !ret.rhs) {
           // [Exposed=(Window,Worker)]
+          listTrivia.assign = eq.trivia;
           ret.rhs = {
             type: "identifier-list",
-            value: identifiers()
+            value: identifiers(),
+            trivia: listTrivia
           };
         }
         else {
           // [NamedConstructor=Audio(DOMString src)] or [Constructor(DOMString str)]
-          ret.arguments = argument_list();
+          ret.signature = {
+            arguments: argument_list(),
+            trivia: listTrivia
+          };
         }
-        consume(")") || error("Unexpected token in extended attribute argument list");
+        const close = consume(")") || error("Unexpected token in extended attribute argument list");
+        listTrivia.close = close.trivia;
       }
       if (eq && !ret.rhs) error("No right hand side to extended attribute assignment");
       return ret;
@@ -546,13 +558,23 @@
     // Note: we parse something simpler than the official syntax. It's all that ever
     // seems to be used
     function extended_attrs() {
-      const eas = [];
-      if (!consume("[")) return eas;
-      eas[0] = simple_extended_attr() || error("Extended attribute with not content");
-      while (consume(",")) {
-        eas.push(simple_extended_attr() || error("Trailing comma in extended attribute"));
+      const open = consume("[");
+      if (!open) return;
+      const eas = {
+        trivia: { open: open.trivia },
+        items: []
+      };
+      const first = simple_extended_attr() || error("Extended attribute with not content");
+      first.separator = untyped_consume(",") || null;
+      eas.items.push(first);
+      while (first.separator) {
+        const attr = simple_extended_attr() || error("Trailing comma in extended attribute");
+        attr.separator = untyped_consume(",") || null;
+        eas.items.push(attr);
+        if (!attr.separator) break;
       }
-      consume("]") || error("No end of extended attribute");
+      const close = consume("]") || error("No end of extended attribute");
+      eas.trivia.close = close.trivia;
       return eas;
     }
 
@@ -854,7 +876,7 @@
           trivia.termination = termination.trivia;
           return ret;
         }
-        const ea = extended_attrs();
+        const ea = extended_attrs() || null;
         const mem = const_() ||
           static_member() ||
           stringifier() ||
@@ -889,7 +911,7 @@
           consume(";") || error("Missing semicolon after interface mixin");
           return ret;
         }
-        const ea = extended_attrs();
+        const ea = extended_attrs() || null;
         const mem = const_() ||
           stringifier() ||
           attribute({ noInherit: true }) ||
@@ -926,7 +948,7 @@
           consume(";") || error("Missing semicolon after namespace");
           return ret;
         }
-        const ea = extended_attrs();
+        const ea = extended_attrs() || null;
         const mem = attribute({ noInherit: true, readonly: true }) ||
           operation({ regular: true }) ||
           error("Unknown member");
@@ -961,7 +983,7 @@
           consume(";") || error("Missing semicolon after dictionary");
           return ret;
         }
-        const ea = extended_attrs();
+        const ea = extended_attrs() || null;
         const required = consume("required");
         const typ = type_with_extended_attributes("dictionary-type") || error("No type for dictionary member");
         const name = consume(ID) || error("No name for dictionary member");
@@ -1077,10 +1099,10 @@
       if (!tokens.length) return [];
       const defs = [];
       while (true) {
-        const ea = extended_attrs();
+        const ea = extended_attrs() || null;
         const def = definition();
         if (!def) {
-          if (ea.length) error("Stray extended attributes");
+          if (ea) error("Stray extended attributes");
           break;
         }
         def.extAttrs = ea;

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -49,17 +49,18 @@
       return ret;
     }
     function make_ext_at(it) {
-      let ret = it.name;
+      let ret = it.trivia.name + it.name;
       if (it.rhs) {
-        if (it.rhs.type === "identifier-list") ret += `=(${it.rhs.value.map(identifier).join("")})`;
-        else ret += `=${it.rhs.value}`;
+        if (it.rhs.type === "identifier-list") ret += `${it.rhs.trivia.assign}=${it.rhs.trivia.open}(${it.rhs.value.map(identifier).join("")}${it.rhs.trivia.close})`;
+        else ret += `${it.rhs.trivia.assign}=${it.rhs.trivia.value}${it.rhs.value}`;
       }
-      if (it.arguments) ret += `(${it.arguments.map(argument).join("")})`;
+      if (it.signature) ret += `${it.signature.trivia.open}(${it.signature.arguments.map(argument).join("")}${it.signature.trivia.close})`;
+      if (it.separator) ret += `${it.separator.trivia}${it.separator.value}`;
       return ret;
     };
     function extended_attributes(eats) {
-      if (!eats || !eats.length) return "";
-      return `[${eats.map(make_ext_at).join(", ")}]`;
+      if (!eats) return "";
+      return `${eats.trivia.open}[${eats.items.map(make_ext_at).join("")}${eats.trivia.close}]`;
     };
 
     function operation(it) {

--- a/test/syntax/json/allowany.json
+++ b/test/syntax/json/allowany.json
@@ -22,7 +22,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  "
                         }
@@ -41,7 +41,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -61,7 +61,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  "
                         }
@@ -83,7 +83,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -94,7 +94,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -108,7 +108,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -128,7 +128,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  "
                         }
@@ -150,14 +150,24 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [
-                                {
-                                    "name": "AllowAny",
-                                    "arguments": null,
-                                    "type": "extended-attribute",
-                                    "rhs": null
-                                }
-                            ],
+                            "extAttrs": {
+                                "trivia": {
+                                    "open": "",
+                                    "close": ""
+                                },
+                                "items": [
+                                    {
+                                        "name": "AllowAny",
+                                        "signature": null,
+                                        "type": "extended-attribute",
+                                        "rhs": null,
+                                        "trivia": {
+                                            "name": ""
+                                        },
+                                        "separator": null
+                                    }
+                                ]
+                            },
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -168,7 +178,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": " "
                                 }
@@ -182,7 +192,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -193,6 +203,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/attributes.json
+++ b/test/syntax/json/attributes.json
@@ -28,14 +28,14 @@
                     },
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "age",
                 "escapedName": "age",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -58,14 +58,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "required",
                 "escapedName": "required",
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -76,6 +76,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/callback.json
+++ b/test/syntax/json/callback.json
@@ -12,7 +12,7 @@
             "prefix": null,
             "postfix": null,
             "separator": null,
-            "extAttrs": [],
+            "extAttrs": null,
             "trivia": {
                 "base": " "
             }
@@ -25,7 +25,7 @@
                 "trivia": {
                     "name": " "
                 },
-                "extAttrs": [],
+                "extAttrs": null,
                 "idlType": {
                     "type": "argument-type",
                     "generic": null,
@@ -36,7 +36,7 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": ""
                     }
@@ -46,7 +46,7 @@
                 "separator": null
             }
         ],
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "callback interface",
@@ -71,7 +71,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  "
                         }
@@ -93,7 +93,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -104,7 +104,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -118,7 +118,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -129,7 +129,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "callback",
@@ -144,7 +144,7 @@
             "prefix": null,
             "postfix": null,
             "separator": null,
-            "extAttrs": [],
+            "extAttrs": null,
             "trivia": {
                 "base": " "
             }
@@ -157,7 +157,7 @@
                 "trivia": {
                     "name": " "
                 },
-                "extAttrs": [],
+                "extAttrs": null,
                 "idlType": {
                     "type": "argument-type",
                     "generic": null,
@@ -168,7 +168,7 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": ""
                     }
@@ -187,7 +187,7 @@
                 "trivia": {
                     "name": " "
                 },
-                "extAttrs": [],
+                "extAttrs": null,
                 "idlType": {
                     "type": "argument-type",
                     "generic": null,
@@ -198,7 +198,7 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
@@ -208,6 +208,6 @@
                 "separator": null
             }
         ],
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/constants.json
+++ b/test/syntax/json/constants.json
@@ -16,7 +16,7 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
@@ -33,7 +33,7 @@
                     "value": " ",
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "const",
@@ -47,7 +47,7 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
@@ -64,7 +64,7 @@
                     "value": " ",
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "const",
@@ -78,7 +78,7 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
@@ -95,7 +95,7 @@
                     "value": " ",
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "const",
@@ -112,7 +112,7 @@
                     },
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
@@ -129,7 +129,7 @@
                     "value": " ",
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "const",
@@ -143,7 +143,7 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
@@ -160,7 +160,7 @@
                     "value": " ",
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "const",
@@ -177,7 +177,7 @@
                     },
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
@@ -194,7 +194,7 @@
                     "value": " ",
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "const",
@@ -211,7 +211,7 @@
                     },
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
@@ -228,7 +228,7 @@
                     "value": " ",
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "const",
@@ -242,7 +242,7 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
@@ -258,7 +258,7 @@
                     "value": " ",
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -269,6 +269,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/constructor.json
+++ b/test/syntax/json/constructor.json
@@ -25,14 +25,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "r",
                 "escapedName": "r",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -55,14 +55,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "cx",
                 "escapedName": "cx",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -85,14 +85,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "cy",
                 "escapedName": "cy",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -117,14 +117,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "circumference",
                 "escapedName": "circumference",
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -135,47 +135,70 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": [
-            {
-                "name": "Constructor",
-                "arguments": null,
-                "type": "extended-attribute",
-                "rhs": null
+        "extAttrs": {
+            "trivia": {
+                "open": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
+                "close": ""
             },
-            {
-                "name": "Constructor",
-                "arguments": [
-                    {
-                        "optional": null,
-                        "variadic": null,
-                        "default": null,
-                        "trivia": {
-                            "name": " "
-                        },
-                        "extAttrs": [],
-                        "idlType": {
-                            "type": "argument-type",
-                            "generic": null,
-                            "nullable": null,
-                            "union": false,
-                            "idlType": "float",
-                            "baseName": "float",
-                            "prefix": null,
-                            "postfix": null,
-                            "separator": null,
-                            "extAttrs": [],
-                            "trivia": {
-                                "base": ""
-                            }
-                        },
-                        "name": "radius",
-                        "escapedName": "radius",
-                        "separator": null
+            "items": [
+                {
+                    "name": "Constructor",
+                    "signature": null,
+                    "type": "extended-attribute",
+                    "rhs": null,
+                    "trivia": {
+                        "name": ""
+                    },
+                    "separator": {
+                        "value": ",",
+                        "trivia": ""
                     }
-                ],
-                "type": "extended-attribute",
-                "rhs": null
-            }
-        ]
+                },
+                {
+                    "name": "Constructor",
+                    "signature": {
+                        "arguments": [
+                            {
+                                "optional": null,
+                                "variadic": null,
+                                "default": null,
+                                "trivia": {
+                                    "name": " "
+                                },
+                                "extAttrs": null,
+                                "idlType": {
+                                    "type": "argument-type",
+                                    "generic": null,
+                                    "nullable": null,
+                                    "union": false,
+                                    "idlType": "float",
+                                    "baseName": "float",
+                                    "prefix": null,
+                                    "postfix": null,
+                                    "separator": null,
+                                    "extAttrs": null,
+                                    "trivia": {
+                                        "base": ""
+                                    }
+                                },
+                                "name": "radius",
+                                "escapedName": "radius",
+                                "separator": null
+                            }
+                        ],
+                        "trivia": {
+                            "open": "",
+                            "close": ""
+                        }
+                    },
+                    "type": "extended-attribute",
+                    "rhs": null,
+                    "trivia": {
+                        "name": "\n "
+                    },
+                    "separator": null
+                }
+            ]
+        }
     }
 ]

--- a/test/syntax/json/dictionary-inherits.json
+++ b/test/syntax/json/dictionary-inherits.json
@@ -21,12 +21,12 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": "\n  "
                     }
                 },
-                "extAttrs": [],
+                "extAttrs": null,
                 "default": {
                     "type": "string",
                     "value": "black",
@@ -53,12 +53,12 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": "\n  "
                     }
                 },
-                "extAttrs": [],
+                "extAttrs": null,
                 "default": {
                     "type": "null",
                     "trivia": {
@@ -82,17 +82,17 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": "\n  "
                     }
                 },
-                "extAttrs": [],
+                "extAttrs": null,
                 "default": null
             }
         ],
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "dictionary",
@@ -114,12 +114,12 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": "\n  "
                     }
                 },
-                "extAttrs": [],
+                "extAttrs": null,
                 "default": null
             }
         ],
@@ -130,6 +130,6 @@
                 "name": " "
             }
         },
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/dictionary.json
+++ b/test/syntax/json/dictionary.json
@@ -21,12 +21,12 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": "\n  "
                     }
                 },
-                "extAttrs": [],
+                "extAttrs": null,
                 "default": {
                     "type": "string",
                     "value": "black",
@@ -53,12 +53,12 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": "\n  "
                     }
                 },
-                "extAttrs": [],
+                "extAttrs": null,
                 "default": {
                     "type": "null",
                     "trivia": {
@@ -82,12 +82,12 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": "\n  "
                     }
                 },
-                "extAttrs": [],
+                "extAttrs": null,
                 "default": null
             },
             {
@@ -117,7 +117,7 @@
                             "prefix": null,
                             "postfix": null,
                             "separator": null,
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "trivia": {
                                 "base": ""
                             }
@@ -127,12 +127,12 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": "\n  // https://heycam.github.io/webidl/#dfn-optional-argument-default-value allows sequences to default to \"[]\".\n  "
                     }
                 },
-                "extAttrs": [],
+                "extAttrs": null,
                 "default": {
                     "type": "sequence",
                     "value": [],
@@ -158,17 +158,17 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
-                "extAttrs": [],
+                "extAttrs": null,
                 "default": null
             }
         ],
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "dictionary",
@@ -190,12 +190,12 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": "\n  "
                     }
                 },
-                "extAttrs": [],
+                "extAttrs": null,
                 "default": null
             },
             {
@@ -213,15 +213,15 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": "\n  "
                     }
                 },
-                "extAttrs": [],
+                "extAttrs": null,
                 "default": null
             }
         ],
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/documentation-dos.json
+++ b/test/syntax/json/documentation-dos.json
@@ -12,6 +12,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/documentation.json
+++ b/test/syntax/json/documentation.json
@@ -12,6 +12,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/enum.json
+++ b/test/syntax/json/enum.json
@@ -16,7 +16,7 @@
                 "value": "other"
             }
         ],
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -44,14 +44,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "type",
                 "escapedName": "type",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -74,14 +74,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "size",
                 "escapedName": "size",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -101,7 +101,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "     // in grams\n\n  "
                         }
@@ -123,7 +123,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -134,7 +134,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -153,7 +153,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -164,7 +164,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": " "
                                 }
@@ -178,7 +178,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -189,7 +189,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "enum",
@@ -208,6 +208,6 @@
                 "value": "other"
             }
         ],
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/equivalent-decl.json
+++ b/test/syntax/json/equivalent-decl.json
@@ -30,14 +30,14 @@
                     },
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "propertyCount",
                 "escapedName": "propertyCount",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -59,7 +59,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": " "
                         }
@@ -81,7 +81,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -92,7 +92,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -106,7 +106,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -128,7 +128,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": " "
                         }
@@ -150,7 +150,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -161,7 +161,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -180,7 +180,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -191,7 +191,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": " "
                                 }
@@ -205,7 +205,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -216,7 +216,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -249,14 +249,14 @@
                     },
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "propertyCount",
                 "escapedName": "propertyCount",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -276,7 +276,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n\n  "
                         }
@@ -298,7 +298,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -309,7 +309,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -323,7 +323,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -343,7 +343,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  "
                         }
@@ -365,7 +365,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -376,7 +376,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -395,7 +395,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -406,7 +406,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": " "
                                 }
@@ -420,7 +420,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -442,7 +442,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": " "
                         }
@@ -460,7 +460,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -471,7 +471,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -485,7 +485,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -507,7 +507,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": " "
                         }
@@ -525,7 +525,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -536,7 +536,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -555,7 +555,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -566,7 +566,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": " "
                                 }
@@ -580,7 +580,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -591,6 +591,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/extended-attributes.json
+++ b/test/syntax/json/extended-attributes.json
@@ -18,40 +18,66 @@
                 "name": " "
             }
         },
-        "extAttrs": [
-            {
-                "name": "Global",
-                "arguments": null,
-                "type": "extended-attribute",
-                "rhs": {
-                    "type": "identifier-list",
-                    "value": [
-                        {
-                            "value": "Worker",
-                            "trivia": "",
-                            "separator": {
-                                "value": ",",
-                                "trivia": ""
-                            }
-                        },
-                        {
-                            "value": "ServiceWorker",
-                            "trivia": "",
-                            "separator": null
-                        }
-                    ]
-                }
+        "extAttrs": {
+            "trivia": {
+                "open": "// Extracted from http://www.w3.org/TR/2015/WD-service-workers-20150205/\n\n",
+                "close": ""
             },
-            {
-                "name": "Exposed",
-                "arguments": null,
-                "type": "extended-attribute",
-                "rhs": {
-                    "type": "identifier",
-                    "value": "ServiceWorker"
+            "items": [
+                {
+                    "name": "Global",
+                    "signature": null,
+                    "type": "extended-attribute",
+                    "rhs": {
+                        "type": "identifier-list",
+                        "value": [
+                            {
+                                "value": "Worker",
+                                "trivia": "",
+                                "separator": {
+                                    "value": ",",
+                                    "trivia": ""
+                                }
+                            },
+                            {
+                                "value": "ServiceWorker",
+                                "trivia": "",
+                                "separator": null
+                            }
+                        ],
+                        "trivia": {
+                            "open": "",
+                            "assign": "",
+                            "close": ""
+                        }
+                    },
+                    "trivia": {
+                        "name": ""
+                    },
+                    "separator": {
+                        "value": ",",
+                        "trivia": ""
+                    }
+                },
+                {
+                    "name": "Exposed",
+                    "signature": null,
+                    "type": "extended-attribute",
+                    "rhs": {
+                        "type": "identifier",
+                        "value": "ServiceWorker",
+                        "trivia": {
+                            "assign": "",
+                            "value": ""
+                        }
+                    },
+                    "trivia": {
+                        "name": " "
+                    },
+                    "separator": null
                 }
-            }
-        ]
+            ]
+        }
     },
     {
         "type": "interface",
@@ -66,35 +92,71 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": [
-            {
-                "name": "IntAttr",
-                "arguments": null,
-                "type": "extended-attribute",
-                "rhs": {
-                    "type": "integer",
-                    "value": "0"
-                }
+        "extAttrs": {
+            "trivia": {
+                "open": "\n\n// Conformance with ExtendedAttributeList grammar in http://www.w3.org/TR/WebIDL/#idl-extended-attributes\n// Section 3.11\n",
+                "close": ""
             },
-            {
-                "name": "FloatAttr",
-                "arguments": null,
-                "type": "extended-attribute",
-                "rhs": {
-                    "type": "float",
-                    "value": "3.14"
+            "items": [
+                {
+                    "name": "IntAttr",
+                    "signature": null,
+                    "type": "extended-attribute",
+                    "rhs": {
+                        "type": "integer",
+                        "value": "0",
+                        "trivia": {
+                            "assign": "",
+                            "value": ""
+                        }
+                    },
+                    "trivia": {
+                        "name": ""
+                    },
+                    "separator": {
+                        "value": ",",
+                        "trivia": ""
+                    }
+                },
+                {
+                    "name": "FloatAttr",
+                    "signature": null,
+                    "type": "extended-attribute",
+                    "rhs": {
+                        "type": "float",
+                        "value": "3.14",
+                        "trivia": {
+                            "assign": "",
+                            "value": ""
+                        }
+                    },
+                    "trivia": {
+                        "name": " "
+                    },
+                    "separator": {
+                        "value": ",",
+                        "trivia": ""
+                    }
+                },
+                {
+                    "name": "StringAttr",
+                    "signature": null,
+                    "type": "extended-attribute",
+                    "rhs": {
+                        "type": "string",
+                        "value": "\"abc\"",
+                        "trivia": {
+                            "assign": "",
+                            "value": ""
+                        }
+                    },
+                    "trivia": {
+                        "name": " "
+                    },
+                    "separator": null
                 }
-            },
-            {
-                "name": "StringAttr",
-                "arguments": null,
-                "type": "extended-attribute",
-                "rhs": {
-                    "type": "string",
-                    "value": "\"abc\""
-                }
-            }
-        ]
+            ]
+        }
     },
     {
         "type": "interface",
@@ -122,14 +184,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "r",
                 "escapedName": "r",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -152,14 +214,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "cx",
                 "escapedName": "cx",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -182,14 +244,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "cy",
                 "escapedName": "cy",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -214,14 +276,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "circumference",
                 "escapedName": "circumference",
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -232,48 +294,71 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": [
-            {
-                "name": "Constructor",
-                "arguments": null,
-                "type": "extended-attribute",
-                "rhs": null
+        "extAttrs": {
+            "trivia": {
+                "open": "\n\n// Extracted from http://www.w3.org/TR/2016/REC-WebIDL-1-20161215/#Constructor on 2017-5-18 with whitespace differences\n",
+                "close": "\n"
             },
-            {
-                "name": "Constructor",
-                "arguments": [
-                    {
-                        "optional": null,
-                        "variadic": null,
-                        "default": null,
-                        "trivia": {
-                            "name": " "
-                        },
-                        "extAttrs": [],
-                        "idlType": {
-                            "type": "argument-type",
-                            "generic": null,
-                            "nullable": null,
-                            "union": false,
-                            "idlType": "double",
-                            "baseName": "double",
-                            "prefix": null,
-                            "postfix": null,
-                            "separator": null,
-                            "extAttrs": [],
-                            "trivia": {
-                                "base": ""
-                            }
-                        },
-                        "name": "radius",
-                        "escapedName": "radius",
-                        "separator": null
+            "items": [
+                {
+                    "name": "Constructor",
+                    "signature": null,
+                    "type": "extended-attribute",
+                    "rhs": null,
+                    "trivia": {
+                        "name": "\n  "
+                    },
+                    "separator": {
+                        "value": ",",
+                        "trivia": ""
                     }
-                ],
-                "type": "extended-attribute",
-                "rhs": null
-            }
-        ]
+                },
+                {
+                    "name": "Constructor",
+                    "signature": {
+                        "arguments": [
+                            {
+                                "optional": null,
+                                "variadic": null,
+                                "default": null,
+                                "trivia": {
+                                    "name": " "
+                                },
+                                "extAttrs": null,
+                                "idlType": {
+                                    "type": "argument-type",
+                                    "generic": null,
+                                    "nullable": null,
+                                    "union": false,
+                                    "idlType": "double",
+                                    "baseName": "double",
+                                    "prefix": null,
+                                    "postfix": null,
+                                    "separator": null,
+                                    "extAttrs": null,
+                                    "trivia": {
+                                        "base": ""
+                                    }
+                                },
+                                "name": "radius",
+                                "escapedName": "radius",
+                                "separator": null
+                            }
+                        ],
+                        "trivia": {
+                            "open": "",
+                            "close": ""
+                        }
+                    },
+                    "type": "extended-attribute",
+                    "rhs": null,
+                    "trivia": {
+                        "name": "\n  "
+                    },
+                    "separator": null
+                }
+            ]
+        }
     },
     {
         "type": "interface",
@@ -310,7 +395,7 @@
                                 "value": "or",
                                 "trivia": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "trivia": {
                                 "base": ""
                             }
@@ -325,7 +410,7 @@
                             "prefix": null,
                             "postfix": null,
                             "separator": null,
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "trivia": {
                                 "base": " "
                             }
@@ -335,14 +420,24 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [
-                        {
-                            "name": "XAttr",
-                            "arguments": null,
-                            "type": "extended-attribute",
-                            "rhs": null
-                        }
-                    ],
+                    "extAttrs": {
+                        "trivia": {
+                            "open": " ",
+                            "close": ""
+                        },
+                        "items": [
+                            {
+                                "name": "XAttr",
+                                "signature": null,
+                                "type": "extended-attribute",
+                                "rhs": null,
+                                "trivia": {
+                                    "name": ""
+                                },
+                                "separator": null
+                            }
+                        ]
+                    },
                     "trivia": {
                         "open": " ",
                         "close": ""
@@ -350,7 +445,7 @@
                 },
                 "name": "attrib",
                 "escapedName": "attrib",
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -361,16 +456,30 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": [
-            {
-                "name": "Exposed",
-                "arguments": null,
-                "type": "extended-attribute",
-                "rhs": {
-                    "type": "identifier",
-                    "value": "Window"
+        "extAttrs": {
+            "trivia": {
+                "open": "\n\n// Extracted from https://heycam.github.io/webidl/#idl-annotated-types on 2017-12-15\n",
+                "close": ""
+            },
+            "items": [
+                {
+                    "name": "Exposed",
+                    "signature": null,
+                    "type": "extended-attribute",
+                    "rhs": {
+                        "type": "identifier",
+                        "value": "Window",
+                        "trivia": {
+                            "assign": "",
+                            "value": ""
+                        }
+                    },
+                    "trivia": {
+                        "name": ""
+                    },
+                    "separator": null
                 }
-            }
-        ]
+            ]
+        }
     }
 ]

--- a/test/syntax/json/generic.json
+++ b/test/syntax/json/generic.json
@@ -60,7 +60,7 @@
                                                 "prefix": null,
                                                 "postfix": null,
                                                 "separator": null,
-                                                "extAttrs": [],
+                                                "extAttrs": null,
                                                 "trivia": {
                                                     "base": ""
                                                 }
@@ -70,7 +70,7 @@
                                         "prefix": null,
                                         "postfix": null,
                                         "separator": null,
-                                        "extAttrs": [],
+                                        "extAttrs": null,
                                         "trivia": {
                                             "base": ""
                                         }
@@ -80,7 +80,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -90,7 +90,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  "
                         }
@@ -109,7 +109,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -146,7 +146,7 @@
                             "prefix": null,
                             "postfix": null,
                             "separator": null,
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "trivia": {
                                 "base": ""
                             }
@@ -156,14 +156,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "baz",
                 "escapedName": "baz",
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -174,7 +174,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -213,7 +213,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -223,7 +223,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  "
                         }
@@ -242,7 +242,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -274,7 +274,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -284,7 +284,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  "
                         }
@@ -303,7 +303,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -314,7 +314,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -351,7 +351,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -361,7 +361,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  "
                         }
@@ -380,7 +380,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -397,6 +397,6 @@
                 "name": " "
             }
         },
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/getter-setter.json
+++ b/test/syntax/json/getter-setter.json
@@ -30,14 +30,14 @@
                     },
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "propertyCount",
                 "escapedName": "propertyCount",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -59,7 +59,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": " "
                         }
@@ -77,7 +77,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -88,7 +88,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -102,7 +102,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -124,7 +124,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": " "
                         }
@@ -142,7 +142,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -153,7 +153,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -172,7 +172,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -183,7 +183,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": " "
                                 }
@@ -197,7 +197,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -208,6 +208,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/identifier-qualified-names.json
+++ b/test/syntax/json/identifier-qualified-names.json
@@ -11,13 +11,13 @@
             "prefix": null,
             "postfix": null,
             "separator": null,
-            "extAttrs": [],
+            "extAttrs": null,
             "trivia": {
                 "base": " "
             }
         },
         "name": "number",
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -42,7 +42,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n\n    // Operation identifier:          \"createObject\"\n    // Operation argument identifier: \"interface\"\n    "
                         }
@@ -64,7 +64,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -75,7 +75,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -89,7 +89,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -111,7 +111,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": " "
                         }
@@ -129,7 +129,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -140,7 +140,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -154,7 +154,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -165,7 +165,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -193,14 +193,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "const",
                 "escapedName": "_const",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -225,14 +225,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "value",
                 "escapedName": "_value",
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -243,7 +243,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -268,7 +268,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  // Argument names allow some selected keywords\n  "
                         }
@@ -290,7 +290,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -303,7 +303,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -317,7 +317,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -328,6 +328,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/implements.json
+++ b/test/syntax/json/implements.json
@@ -30,14 +30,14 @@
                     },
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "nodeType",
                 "escapedName": "nodeType",
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -48,7 +48,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -73,7 +73,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n    "
                         }
@@ -95,7 +95,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -106,7 +106,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -125,7 +125,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -136,7 +136,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": "\n                          "
                                 }
@@ -155,7 +155,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -166,7 +166,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": "\n                          "
                                 }
@@ -180,7 +180,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -191,12 +191,12 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "implements",
         "target": "Node",
         "implements": "EventTarget",
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/indexed-properties.json
+++ b/test/syntax/json/indexed-properties.json
@@ -30,14 +30,14 @@
                     },
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "size",
                 "escapedName": "size",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -59,7 +59,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": " "
                         }
@@ -81,7 +81,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -95,7 +95,7 @@
                                 },
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": " "
                                 }
@@ -109,7 +109,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -131,7 +131,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": " "
                         }
@@ -153,7 +153,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -167,7 +167,7 @@
                                 },
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": " "
                                 }
@@ -186,7 +186,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -197,7 +197,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": " "
                                 }
@@ -211,7 +211,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -233,7 +233,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": " "
                         }
@@ -255,7 +255,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -269,7 +269,7 @@
                                 },
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": " "
                                 }
@@ -283,7 +283,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -305,7 +305,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": " "
                         }
@@ -327,7 +327,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -338,7 +338,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -352,7 +352,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -374,7 +374,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": " "
                         }
@@ -396,7 +396,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -407,7 +407,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -426,7 +426,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -437,7 +437,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": " "
                                 }
@@ -451,7 +451,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -473,7 +473,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": " "
                         }
@@ -495,7 +495,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -506,7 +506,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -520,7 +520,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -531,6 +531,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/inherits-getter.json
+++ b/test/syntax/json/inherits-getter.json
@@ -27,14 +27,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "name",
                 "escapedName": "name",
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -45,7 +45,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -78,14 +78,14 @@
                     },
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "age",
                 "escapedName": "age",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -110,14 +110,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "name",
                 "escapedName": "name",
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -134,7 +134,7 @@
                 "name": " "
             }
         },
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -166,14 +166,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "name",
                 "escapedName": "name",
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -190,6 +190,6 @@
                 "name": " "
             }
         },
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/interface-inherits.json
+++ b/test/syntax/json/interface-inherits.json
@@ -25,14 +25,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "name",
                 "escapedName": "name",
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -43,7 +43,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -71,14 +71,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "pet",
                 "escapedName": "pet",
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -95,7 +95,7 @@
                 "name": " "
             }
         },
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -123,14 +123,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "owner",
                 "escapedName": "owner",
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -147,6 +147,6 @@
                 "name": " "
             }
         },
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/iterable.json
+++ b/test/syntax/json/iterable.json
@@ -17,7 +17,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": ""
                         }
@@ -29,7 +29,7 @@
                     "close": "",
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -40,7 +40,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -63,7 +63,7 @@
                             "value": ",",
                             "trivia": ""
                         },
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": ""
                         }
@@ -80,7 +80,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": " "
                         }
@@ -92,7 +92,7 @@
                     "close": "",
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -103,7 +103,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -123,14 +123,24 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [
-                            {
-                                "name": "XAttr",
-                                "arguments": null,
-                                "type": "extended-attribute",
-                                "rhs": null
-                            }
-                        ],
+                        "extAttrs": {
+                            "trivia": {
+                                "open": "",
+                                "close": ""
+                            },
+                            "items": [
+                                {
+                                    "name": "XAttr",
+                                    "signature": null,
+                                    "type": "extended-attribute",
+                                    "rhs": null,
+                                    "trivia": {
+                                        "name": ""
+                                    },
+                                    "separator": null
+                                }
+                            ]
+                        },
                         "trivia": {
                             "base": " "
                         }
@@ -142,7 +152,7 @@
                     "close": "",
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -153,6 +163,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/legacyiterable.json
+++ b/test/syntax/json/legacyiterable.json
@@ -17,7 +17,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": ""
                         }
@@ -29,7 +29,7 @@
                     "close": "",
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -40,6 +40,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/maplike.json
+++ b/test/syntax/json/maplike.json
@@ -20,7 +20,7 @@
                             "value": ",",
                             "trivia": ""
                         },
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": ""
                         }
@@ -35,7 +35,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": " "
                         }
@@ -48,7 +48,7 @@
                     "close": "",
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -59,7 +59,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -82,7 +82,7 @@
                             "value": ",",
                             "trivia": ""
                         },
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": ""
                         }
@@ -97,7 +97,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": " "
                         }
@@ -112,7 +112,7 @@
                     "close": "",
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -123,7 +123,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -146,14 +146,24 @@
                             "value": ",",
                             "trivia": ""
                         },
-                        "extAttrs": [
-                            {
-                                "name": "XAttr2",
-                                "arguments": null,
-                                "type": "extended-attribute",
-                                "rhs": null
-                            }
-                        ],
+                        "extAttrs": {
+                            "trivia": {
+                                "open": "",
+                                "close": ""
+                            },
+                            "items": [
+                                {
+                                    "name": "XAttr2",
+                                    "signature": null,
+                                    "type": "extended-attribute",
+                                    "rhs": null,
+                                    "trivia": {
+                                        "name": ""
+                                    },
+                                    "separator": null
+                                }
+                            ]
+                        },
                         "trivia": {
                             "base": " "
                         }
@@ -168,14 +178,24 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [
-                            {
-                                "name": "XAttr3",
-                                "arguments": null,
-                                "type": "extended-attribute",
-                                "rhs": null
-                            }
-                        ],
+                        "extAttrs": {
+                            "trivia": {
+                                "open": " ",
+                                "close": ""
+                            },
+                            "items": [
+                                {
+                                    "name": "XAttr3",
+                                    "signature": null,
+                                    "type": "extended-attribute",
+                                    "rhs": null,
+                                    "trivia": {
+                                        "name": ""
+                                    },
+                                    "separator": null
+                                }
+                            ]
+                        },
                         "trivia": {
                             "base": " "
                         }
@@ -188,7 +208,7 @@
                     "close": "",
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -199,6 +219,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/mixin.json
+++ b/test/syntax/json/mixin.json
@@ -27,33 +27,33 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "crypto",
                 "escapedName": "crypto",
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
             "base": "// Extracted from https://heycam.github.io/webidl/#using-mixins-and-partials on 2017-11-02\n\n",
             "mixin": " "
         },
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "includes",
         "target": "Window",
         "includes": "GlobalCrypto",
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "includes",
         "target": "WorkerGlobalScope",
         "includes": "GlobalCrypto",
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface mixin",
@@ -83,20 +83,20 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "crypto",
                 "escapedName": "crypto",
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
             "base": " ",
             "mixin": " "
         },
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/namedconstructor.json
+++ b/test/syntax/json/namedconstructor.json
@@ -18,53 +18,84 @@
                 "name": " "
             }
         },
-        "extAttrs": [
-            {
-                "name": "NamedConstructor",
-                "arguments": null,
-                "type": "extended-attribute",
-                "rhs": {
-                    "type": "identifier",
-                    "value": "Audio"
-                }
+        "extAttrs": {
+            "trivia": {
+                "open": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
+                "close": ""
             },
-            {
-                "name": "NamedConstructor",
-                "arguments": [
-                    {
-                        "optional": null,
-                        "variadic": null,
-                        "default": null,
+            "items": [
+                {
+                    "name": "NamedConstructor",
+                    "signature": null,
+                    "type": "extended-attribute",
+                    "rhs": {
+                        "type": "identifier",
+                        "value": "Audio",
                         "trivia": {
-                            "name": " "
-                        },
-                        "extAttrs": [],
-                        "idlType": {
-                            "type": "argument-type",
-                            "generic": null,
-                            "nullable": null,
-                            "union": false,
-                            "idlType": "DOMString",
-                            "baseName": "DOMString",
-                            "prefix": null,
-                            "postfix": null,
-                            "separator": null,
-                            "extAttrs": [],
-                            "trivia": {
-                                "base": ""
-                            }
-                        },
-                        "name": "src",
-                        "escapedName": "src",
-                        "separator": null
+                            "assign": "",
+                            "value": ""
+                        }
+                    },
+                    "trivia": {
+                        "name": ""
+                    },
+                    "separator": {
+                        "value": ",",
+                        "trivia": ""
                     }
-                ],
-                "type": "extended-attribute",
-                "rhs": {
-                    "type": "identifier",
-                    "value": "Audio"
+                },
+                {
+                    "name": "NamedConstructor",
+                    "signature": {
+                        "arguments": [
+                            {
+                                "optional": null,
+                                "variadic": null,
+                                "default": null,
+                                "trivia": {
+                                    "name": " "
+                                },
+                                "extAttrs": null,
+                                "idlType": {
+                                    "type": "argument-type",
+                                    "generic": null,
+                                    "nullable": null,
+                                    "union": false,
+                                    "idlType": "DOMString",
+                                    "baseName": "DOMString",
+                                    "prefix": null,
+                                    "postfix": null,
+                                    "separator": null,
+                                    "extAttrs": null,
+                                    "trivia": {
+                                        "base": ""
+                                    }
+                                },
+                                "name": "src",
+                                "escapedName": "src",
+                                "separator": null
+                            }
+                        ],
+                        "trivia": {
+                            "open": "",
+                            "close": ""
+                        }
+                    },
+                    "type": "extended-attribute",
+                    "rhs": {
+                        "type": "identifier",
+                        "value": "Audio",
+                        "trivia": {
+                            "assign": "",
+                            "value": ""
+                        }
+                    },
+                    "trivia": {
+                        "name": "\n "
+                    },
+                    "separator": null
                 }
-            }
-        ]
+            ]
+        }
     }
 ]

--- a/test/syntax/json/namespace.json
+++ b/test/syntax/json/namespace.json
@@ -27,14 +27,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "unit",
                 "escapedName": "unit",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -54,7 +54,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  "
                         }
@@ -76,7 +76,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -87,7 +87,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -106,7 +106,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -117,7 +117,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": " "
                                 }
@@ -131,7 +131,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -151,7 +151,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  "
                         }
@@ -173,7 +173,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -184,7 +184,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -203,7 +203,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -214,7 +214,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": " "
                                 }
@@ -228,16 +228,16 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "namespace",
         "name": "SomeNamespace",
         "partial": true,
         "members": [],
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/nointerfaceobject.json
+++ b/test/syntax/json/nointerfaceobject.json
@@ -22,7 +22,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  "
                         }
@@ -44,7 +44,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -58,7 +58,7 @@
                                 },
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": " "
                                 }
@@ -72,7 +72,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -83,13 +83,23 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": [
-            {
-                "name": "NoInterfaceObject",
-                "arguments": null,
-                "type": "extended-attribute",
-                "rhs": null
-            }
-        ]
+        "extAttrs": {
+            "trivia": {
+                "open": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
+                "close": ""
+            },
+            "items": [
+                {
+                    "name": "NoInterfaceObject",
+                    "signature": null,
+                    "type": "extended-attribute",
+                    "rhs": null,
+                    "trivia": {
+                        "name": ""
+                    },
+                    "separator": null
+                }
+            ]
+        }
     }
 ]

--- a/test/syntax/json/nullable.json
+++ b/test/syntax/json/nullable.json
@@ -18,7 +18,7 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
@@ -35,7 +35,7 @@
                     "value": " ",
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -46,7 +46,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -78,14 +78,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "namespaceURI",
                 "escapedName": "namespaceURI",
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -96,6 +96,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/nullableobjects.json
+++ b/test/syntax/json/nullableobjects.json
@@ -12,7 +12,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -27,7 +27,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -52,7 +52,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  "
                         }
@@ -74,7 +74,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -87,7 +87,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -101,7 +101,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -121,7 +121,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  "
                         }
@@ -143,7 +143,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -156,7 +156,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -170,7 +170,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -181,6 +181,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/operation-optional-arg.json
+++ b/test/syntax/json/operation-optional-arg.json
@@ -22,7 +22,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  "
                         }
@@ -44,7 +44,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -55,7 +55,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -74,7 +74,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -85,7 +85,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": " "
                                 }
@@ -104,7 +104,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -115,7 +115,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": " "
                                 }
@@ -143,7 +143,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -154,7 +154,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": " "
                                 }
@@ -168,7 +168,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -179,6 +179,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/overloading.json
+++ b/test/syntax/json/overloading.json
@@ -12,7 +12,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -27,7 +27,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -52,7 +52,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  "
                         }
@@ -74,7 +74,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -85,7 +85,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -99,7 +99,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -119,7 +119,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  "
                         }
@@ -141,7 +141,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -152,7 +152,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -166,7 +166,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -177,7 +177,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -202,7 +202,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  /* f1 */ "
                         }
@@ -224,7 +224,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -235,7 +235,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -249,7 +249,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -269,7 +269,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  /* f2 */ "
                         }
@@ -291,14 +291,24 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [
-                                {
-                                    "name": "AllowAny",
-                                    "arguments": null,
-                                    "type": "extended-attribute",
-                                    "rhs": null
-                                }
-                            ],
+                            "extAttrs": {
+                                "trivia": {
+                                    "open": "",
+                                    "close": ""
+                                },
+                                "items": [
+                                    {
+                                        "name": "AllowAny",
+                                        "signature": null,
+                                        "type": "extended-attribute",
+                                        "rhs": null,
+                                        "trivia": {
+                                            "name": ""
+                                        },
+                                        "separator": null
+                                    }
+                                ]
+                            },
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -309,7 +319,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": " "
                                 }
@@ -328,7 +338,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -339,7 +349,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": " "
                                 }
@@ -360,7 +370,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -371,7 +381,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": " "
                                 }
@@ -385,7 +395,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -405,7 +415,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  /* f3 */ "
                         }
@@ -424,7 +434,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -444,7 +454,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  /* f4 */ "
                         }
@@ -466,7 +476,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -477,7 +487,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -496,7 +506,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -507,7 +517,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": " "
                                 }
@@ -528,7 +538,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -539,7 +549,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": " "
                                 }
@@ -560,7 +570,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -571,7 +581,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": " "
                                 }
@@ -585,7 +595,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -596,6 +606,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/overridebuiltins.json
+++ b/test/syntax/json/overridebuiltins.json
@@ -30,14 +30,14 @@
                     },
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "length",
                 "escapedName": "length",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -59,7 +59,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": " "
                         }
@@ -81,7 +81,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -92,7 +92,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -106,7 +106,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -117,13 +117,23 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": [
-            {
-                "name": "OverrideBuiltins",
-                "arguments": null,
-                "type": "extended-attribute",
-                "rhs": null
-            }
-        ]
+        "extAttrs": {
+            "trivia": {
+                "open": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
+                "close": ""
+            },
+            "items": [
+                {
+                    "name": "OverrideBuiltins",
+                    "signature": null,
+                    "type": "extended-attribute",
+                    "rhs": null,
+                    "trivia": {
+                        "name": ""
+                    },
+                    "separator": null
+                }
+            ]
+        }
     }
 ]

--- a/test/syntax/json/partial-interface.json
+++ b/test/syntax/json/partial-interface.json
@@ -25,14 +25,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "bar",
                 "escapedName": "bar",
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -43,7 +43,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -71,14 +71,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "quux",
                 "escapedName": "quux",
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -88,6 +88,6 @@
             "close": "\n",
             "termination": ""
         },
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/primitives.json
+++ b/test/syntax/json/primitives.json
@@ -25,14 +25,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "truth",
                 "escapedName": "truth",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -55,14 +55,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "character",
                 "escapedName": "character",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -85,14 +85,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "value",
                 "escapedName": "value",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -115,14 +115,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "number",
                 "escapedName": "number",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -148,14 +148,14 @@
                     },
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "positive",
                 "escapedName": "positive",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -178,14 +178,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "big",
                 "escapedName": "big",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -211,14 +211,14 @@
                     },
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "bigpositive",
                 "escapedName": "bigpositive",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -244,14 +244,14 @@
                         "trivia": " "
                     },
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "bigbig",
                 "escapedName": "bigbig",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -280,14 +280,14 @@
                         "trivia": " "
                     },
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "bigbigpositive",
                 "escapedName": "bigbigpositive",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -310,14 +310,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "real",
                 "escapedName": "real",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -340,14 +340,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "bigreal",
                 "escapedName": "bigreal",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -373,14 +373,14 @@
                     },
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "realwithinfinity",
                 "escapedName": "realwithinfinity",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -406,14 +406,14 @@
                     },
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "bigrealwithinfinity",
                 "escapedName": "bigrealwithinfinity",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -436,14 +436,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "string",
                 "escapedName": "string",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -466,14 +466,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "bytes",
                 "escapedName": "bytes",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -496,14 +496,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "date",
                 "escapedName": "date",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -526,14 +526,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "regexp",
                 "escapedName": "regexp",
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -544,6 +544,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/promise-void.json
+++ b/test/syntax/json/promise-void.json
@@ -37,7 +37,7 @@
                             "prefix": null,
                             "postfix": null,
                             "separator": null,
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "trivia": {
                                 "base": ""
                             }
@@ -47,14 +47,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "meow",
                 "escapedName": "meow",
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -65,6 +65,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/prototyperoot.json
+++ b/test/syntax/json/prototyperoot.json
@@ -30,14 +30,14 @@
                     },
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "nodeType",
                 "escapedName": "nodeType",
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -48,13 +48,23 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": [
-            {
-                "name": "PrototypeRoot",
-                "arguments": null,
-                "type": "extended-attribute",
-                "rhs": null
-            }
-        ]
+        "extAttrs": {
+            "trivia": {
+                "open": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
+                "close": ""
+            },
+            "items": [
+                {
+                    "name": "PrototypeRoot",
+                    "signature": null,
+                    "type": "extended-attribute",
+                    "rhs": null,
+                    "trivia": {
+                        "name": ""
+                    },
+                    "separator": null
+                }
+            ]
+        }
     }
 ]

--- a/test/syntax/json/putforwards.json
+++ b/test/syntax/json/putforwards.json
@@ -27,24 +27,38 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "name",
                 "escapedName": "name",
-                "extAttrs": [
-                    {
-                        "name": "PutForwards",
-                        "arguments": null,
-                        "type": "extended-attribute",
-                        "rhs": {
-                            "type": "identifier",
-                            "value": "full"
+                "extAttrs": {
+                    "trivia": {
+                        "open": "\n  ",
+                        "close": ""
+                    },
+                    "items": [
+                        {
+                            "name": "PutForwards",
+                            "signature": null,
+                            "type": "extended-attribute",
+                            "rhs": {
+                                "type": "identifier",
+                                "value": "full",
+                                "trivia": {
+                                    "assign": "",
+                                    "value": ""
+                                }
+                            },
+                            "trivia": {
+                                "name": ""
+                            },
+                            "separator": null
                         }
-                    }
-                ]
+                    ]
+                }
             },
             {
                 "type": "attribute",
@@ -70,14 +84,14 @@
                     },
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "age",
                 "escapedName": "age",
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -88,6 +102,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/record.json
+++ b/test/syntax/json/record.json
@@ -22,7 +22,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  "
                         }
@@ -44,7 +44,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": {
@@ -82,7 +82,7 @@
                                                     "value": ",",
                                                     "trivia": ""
                                                 },
-                                                "extAttrs": [],
+                                                "extAttrs": null,
                                                 "trivia": {
                                                     "base": ""
                                                 }
@@ -97,7 +97,7 @@
                                                 "prefix": null,
                                                 "postfix": null,
                                                 "separator": null,
-                                                "extAttrs": [],
+                                                "extAttrs": null,
                                                 "trivia": {
                                                     "base": " "
                                                 }
@@ -107,7 +107,7 @@
                                         "prefix": null,
                                         "postfix": null,
                                         "separator": null,
-                                        "extAttrs": [],
+                                        "extAttrs": null,
                                         "trivia": {
                                             "base": ""
                                         }
@@ -117,7 +117,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -131,7 +131,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -166,7 +166,7 @@
                                     "value": ",",
                                     "trivia": ""
                                 },
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -192,7 +192,7 @@
                                             "value": "or",
                                             "trivia": " "
                                         },
-                                        "extAttrs": [],
+                                        "extAttrs": null,
                                         "trivia": {
                                             "base": ""
                                         }
@@ -207,7 +207,7 @@
                                         "prefix": null,
                                         "postfix": null,
                                         "separator": null,
-                                        "extAttrs": [],
+                                        "extAttrs": null,
                                         "trivia": {
                                             "base": " "
                                         }
@@ -217,7 +217,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "open": " ",
                                     "close": ""
@@ -228,7 +228,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  "
                         }
@@ -247,7 +247,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -258,82 +258,98 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": [
-            {
-                "name": "Constructor",
-                "arguments": [
-                    {
-                        "optional": null,
-                        "variadic": null,
-                        "default": null,
-                        "trivia": {
-                            "name": " "
-                        },
-                        "extAttrs": [],
-                        "idlType": {
-                            "type": "argument-type",
-                            "generic": {
-                                "value": "record",
+        "extAttrs": {
+            "trivia": {
+                "open": "",
+                "close": ""
+            },
+            "items": [
+                {
+                    "name": "Constructor",
+                    "signature": {
+                        "arguments": [
+                            {
+                                "optional": null,
+                                "variadic": null,
+                                "default": null,
                                 "trivia": {
-                                    "open": "",
-                                    "close": ""
-                                }
-                            },
-                            "nullable": null,
-                            "union": false,
-                            "idlType": [
-                                {
+                                    "name": " "
+                                },
+                                "extAttrs": null,
+                                "idlType": {
                                     "type": "argument-type",
-                                    "generic": null,
+                                    "generic": {
+                                        "value": "record",
+                                        "trivia": {
+                                            "open": "",
+                                            "close": ""
+                                        }
+                                    },
                                     "nullable": null,
                                     "union": false,
-                                    "idlType": "USVString",
-                                    "baseName": "USVString",
+                                    "idlType": [
+                                        {
+                                            "type": "argument-type",
+                                            "generic": null,
+                                            "nullable": null,
+                                            "union": false,
+                                            "idlType": "USVString",
+                                            "baseName": "USVString",
+                                            "prefix": null,
+                                            "postfix": null,
+                                            "separator": {
+                                                "value": ",",
+                                                "trivia": ""
+                                            },
+                                            "extAttrs": null,
+                                            "trivia": {
+                                                "base": ""
+                                            }
+                                        },
+                                        {
+                                            "type": "argument-type",
+                                            "generic": null,
+                                            "nullable": null,
+                                            "union": false,
+                                            "idlType": "USVString",
+                                            "baseName": "USVString",
+                                            "prefix": null,
+                                            "postfix": null,
+                                            "separator": null,
+                                            "extAttrs": null,
+                                            "trivia": {
+                                                "base": " "
+                                            }
+                                        }
+                                    ],
+                                    "baseName": "record",
                                     "prefix": null,
                                     "postfix": null,
-                                    "separator": {
-                                        "value": ",",
-                                        "trivia": ""
-                                    },
-                                    "extAttrs": [],
+                                    "separator": null,
+                                    "extAttrs": null,
                                     "trivia": {
                                         "base": ""
                                     }
                                 },
-                                {
-                                    "type": "argument-type",
-                                    "generic": null,
-                                    "nullable": null,
-                                    "union": false,
-                                    "idlType": "USVString",
-                                    "baseName": "USVString",
-                                    "prefix": null,
-                                    "postfix": null,
-                                    "separator": null,
-                                    "extAttrs": [],
-                                    "trivia": {
-                                        "base": " "
-                                    }
-                                }
-                            ],
-                            "baseName": "record",
-                            "prefix": null,
-                            "postfix": null,
-                            "separator": null,
-                            "extAttrs": [],
-                            "trivia": {
-                                "base": ""
+                                "name": "init",
+                                "escapedName": "init",
+                                "separator": null
                             }
-                        },
-                        "name": "init",
-                        "escapedName": "init",
-                        "separator": null
-                    }
-                ],
-                "type": "extended-attribute",
-                "rhs": null
-            }
-        ]
+                        ],
+                        "trivia": {
+                            "open": "",
+                            "close": ""
+                        }
+                    },
+                    "type": "extended-attribute",
+                    "rhs": null,
+                    "trivia": {
+                        "name": ""
+                    },
+                    "separator": null
+                }
+            ]
+        }
     },
     {
         "type": "interface",
@@ -373,7 +389,7 @@
                                     "value": ",",
                                     "trivia": ""
                                 },
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -388,14 +404,24 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [
-                                    {
-                                        "name": "XAttr",
-                                        "arguments": null,
-                                        "type": "extended-attribute",
-                                        "rhs": null
-                                    }
-                                ],
+                                "extAttrs": {
+                                    "trivia": {
+                                        "open": " ",
+                                        "close": ""
+                                    },
+                                    "items": [
+                                        {
+                                            "name": "XAttr",
+                                            "signature": null,
+                                            "type": "extended-attribute",
+                                            "rhs": null,
+                                            "trivia": {
+                                                "name": ""
+                                            },
+                                            "separator": null
+                                        }
+                                    ]
+                                },
                                 "trivia": {
                                     "base": " "
                                 }
@@ -405,7 +431,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  "
                         }
@@ -424,7 +450,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -435,6 +461,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/reg-operations.json
+++ b/test/syntax/json/reg-operations.json
@@ -28,14 +28,14 @@
                     },
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "width",
                 "escapedName": "width",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -61,14 +61,14 @@
                     },
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "height",
                 "escapedName": "height",
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -79,7 +79,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -104,7 +104,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n\n  // An operation that takes no arguments, returns a boolean\n  "
                         }
@@ -123,7 +123,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -143,7 +143,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n\n  // Overloaded operations.\n  "
                         }
@@ -165,7 +165,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -176,7 +176,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -190,7 +190,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -210,7 +210,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  "
                         }
@@ -232,7 +232,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -246,7 +246,7 @@
                                 },
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": " "
                                 }
@@ -265,7 +265,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -279,7 +279,7 @@
                                 },
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": " "
                                 }
@@ -293,7 +293,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -304,6 +304,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/replaceable.json
+++ b/test/syntax/json/replaceable.json
@@ -30,21 +30,31 @@
                     },
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "value",
                 "escapedName": "value",
-                "extAttrs": [
-                    {
-                        "name": "Replaceable",
-                        "arguments": null,
-                        "type": "extended-attribute",
-                        "rhs": null
-                    }
-                ]
+                "extAttrs": {
+                    "trivia": {
+                        "open": "\n  ",
+                        "close": ""
+                    },
+                    "items": [
+                        {
+                            "name": "Replaceable",
+                            "signature": null,
+                            "type": "extended-attribute",
+                            "rhs": null,
+                            "trivia": {
+                                "name": ""
+                            },
+                            "separator": null
+                        }
+                    ]
+                }
             },
             {
                 "type": "operation",
@@ -64,7 +74,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  "
                         }
@@ -83,7 +93,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -94,6 +104,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/sequence.json
+++ b/test/syntax/json/sequence.json
@@ -22,7 +22,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  "
                         }
@@ -44,7 +44,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": {
@@ -67,7 +67,7 @@
                                         "prefix": null,
                                         "postfix": null,
                                         "separator": null,
-                                        "extAttrs": [],
+                                        "extAttrs": null,
                                         "trivia": {
                                             "base": ""
                                         }
@@ -77,7 +77,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -91,7 +91,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -123,7 +123,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -133,7 +133,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  "
                         }
@@ -152,7 +152,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -163,7 +163,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -188,7 +188,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n    "
                         }
@@ -210,7 +210,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": {
@@ -233,14 +233,24 @@
                                         "prefix": null,
                                         "postfix": null,
                                         "separator": null,
-                                        "extAttrs": [
-                                            {
-                                                "name": "XAttr",
-                                                "arguments": null,
-                                                "type": "extended-attribute",
-                                                "rhs": null
-                                            }
-                                        ],
+                                        "extAttrs": {
+                                            "trivia": {
+                                                "open": "",
+                                                "close": ""
+                                            },
+                                            "items": [
+                                                {
+                                                    "name": "XAttr",
+                                                    "signature": null,
+                                                    "type": "extended-attribute",
+                                                    "rhs": null,
+                                                    "trivia": {
+                                                        "name": ""
+                                                    },
+                                                    "separator": null
+                                                }
+                                            ]
+                                        },
                                         "trivia": {
                                             "base": " "
                                         }
@@ -250,7 +260,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -264,7 +274,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -275,6 +285,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/setlike.json
+++ b/test/syntax/json/setlike.json
@@ -17,7 +17,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": ""
                         }
@@ -30,7 +30,7 @@
                     "close": "",
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -41,7 +41,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -61,7 +61,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": ""
                         }
@@ -76,7 +76,7 @@
                     "close": "",
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -87,7 +87,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -107,14 +107,24 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [
-                            {
-                                "name": "XAttr",
-                                "arguments": null,
-                                "type": "extended-attribute",
-                                "rhs": null
-                            }
-                        ],
+                        "extAttrs": {
+                            "trivia": {
+                                "open": "",
+                                "close": ""
+                            },
+                            "items": [
+                                {
+                                    "name": "XAttr",
+                                    "signature": null,
+                                    "type": "extended-attribute",
+                                    "rhs": null,
+                                    "trivia": {
+                                        "name": ""
+                                    },
+                                    "separator": null
+                                }
+                            ]
+                        },
                         "trivia": {
                             "base": " "
                         }
@@ -127,7 +137,7 @@
                     "close": "",
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -138,6 +148,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/static.json
+++ b/test/syntax/json/static.json
@@ -12,7 +12,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -40,14 +40,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "cx",
                 "escapedName": "cx",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -70,14 +70,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "cy",
                 "escapedName": "cy",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -100,14 +100,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "radius",
                 "escapedName": "radius",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -134,14 +134,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "triangulationCount",
                 "escapedName": "triangulationCount",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -163,7 +163,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": " "
                         }
@@ -185,7 +185,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -196,7 +196,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -215,7 +215,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -226,7 +226,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": " "
                                 }
@@ -245,7 +245,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -256,7 +256,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": " "
                                 }
@@ -270,7 +270,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -281,6 +281,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/stringifier-attribute.json
+++ b/test/syntax/json/stringifier-attribute.json
@@ -28,14 +28,14 @@
                     },
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "id",
                 "escapedName": "id",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -60,14 +60,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "name",
                 "escapedName": "name",
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -78,13 +78,23 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": [
-            {
-                "name": "Constructor",
-                "arguments": null,
-                "type": "extended-attribute",
-                "rhs": null
-            }
-        ]
+        "extAttrs": {
+            "trivia": {
+                "open": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
+                "close": ""
+            },
+            "items": [
+                {
+                    "name": "Constructor",
+                    "signature": null,
+                    "type": "extended-attribute",
+                    "rhs": null,
+                    "trivia": {
+                        "name": ""
+                    },
+                    "separator": null
+                }
+            ]
+        }
     }
 ]

--- a/test/syntax/json/stringifier-custom.json
+++ b/test/syntax/json/stringifier-custom.json
@@ -28,14 +28,14 @@
                     },
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "id",
                 "escapedName": "id",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -60,14 +60,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "familyName",
                 "escapedName": "familyName",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -90,14 +90,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "givenName",
                 "escapedName": "givenName",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -119,7 +119,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": " "
                         }
@@ -134,7 +134,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -145,13 +145,23 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": [
-            {
-                "name": "Constructor",
-                "arguments": null,
-                "type": "extended-attribute",
-                "rhs": null
-            }
-        ]
+        "extAttrs": {
+            "trivia": {
+                "open": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
+                "close": ""
+            },
+            "items": [
+                {
+                    "name": "Constructor",
+                    "signature": null,
+                    "type": "extended-attribute",
+                    "rhs": null,
+                    "trivia": {
+                        "name": ""
+                    },
+                    "separator": null
+                }
+            ]
+        }
     }
 ]

--- a/test/syntax/json/stringifier.json
+++ b/test/syntax/json/stringifier.json
@@ -24,7 +24,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": " "
                         }
@@ -39,7 +39,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -50,7 +50,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -70,7 +70,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -81,6 +81,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/treatasnull.json
+++ b/test/syntax/json/treatasnull.json
@@ -25,14 +25,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "name",
                 "escapedName": "name",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -55,14 +55,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "owner",
                 "escapedName": "owner",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -82,7 +82,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n\n  "
                         }
@@ -104,17 +104,31 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [
-                                {
-                                    "name": "TreatNullAs",
-                                    "arguments": null,
-                                    "type": "extended-attribute",
-                                    "rhs": {
-                                        "type": "identifier",
-                                        "value": "EmptyString"
+                            "extAttrs": {
+                                "trivia": {
+                                    "open": "",
+                                    "close": ""
+                                },
+                                "items": [
+                                    {
+                                        "name": "TreatNullAs",
+                                        "signature": null,
+                                        "type": "extended-attribute",
+                                        "rhs": {
+                                            "type": "identifier",
+                                            "value": "EmptyString",
+                                            "trivia": {
+                                                "assign": "",
+                                                "value": ""
+                                            }
+                                        },
+                                        "trivia": {
+                                            "name": ""
+                                        },
+                                        "separator": null
                                     }
-                                }
-                            ],
+                                ]
+                            },
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -125,7 +139,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": " "
                                 }
@@ -139,7 +153,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -150,6 +164,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/treatasundefined.json
+++ b/test/syntax/json/treatasundefined.json
@@ -25,14 +25,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "name",
                 "escapedName": "name",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -55,14 +55,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "owner",
                 "escapedName": "owner",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -82,7 +82,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n\n  "
                         }
@@ -104,17 +104,31 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [
-                                {
-                                    "name": "TreatUndefinedAs",
-                                    "arguments": null,
-                                    "type": "extended-attribute",
-                                    "rhs": {
-                                        "type": "identifier",
-                                        "value": "EmptyString"
+                            "extAttrs": {
+                                "trivia": {
+                                    "open": "",
+                                    "close": ""
+                                },
+                                "items": [
+                                    {
+                                        "name": "TreatUndefinedAs",
+                                        "signature": null,
+                                        "type": "extended-attribute",
+                                        "rhs": {
+                                            "type": "identifier",
+                                            "value": "EmptyString",
+                                            "trivia": {
+                                                "assign": "",
+                                                "value": ""
+                                            }
+                                        },
+                                        "trivia": {
+                                            "name": ""
+                                        },
+                                        "separator": null
                                     }
-                                }
-                            ],
+                                ]
+                            },
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -125,7 +139,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": " "
                                 }
@@ -139,7 +153,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -150,6 +164,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/typedef-union.json
+++ b/test/syntax/json/typedef-union.json
@@ -20,7 +20,7 @@
                         "value": "or",
                         "trivia": " "
                     },
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": ""
                     }
@@ -38,7 +38,7 @@
                         "value": "or",
                         "trivia": " "
                     },
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": "\n           "
                     }
@@ -56,7 +56,7 @@
                         "value": "or",
                         "trivia": " "
                     },
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": "\n           "
                     }
@@ -71,7 +71,7 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": "\n           "
                     }
@@ -81,13 +81,13 @@
             "prefix": null,
             "postfix": null,
             "separator": null,
-            "extAttrs": [],
+            "extAttrs": null,
             "trivia": {
                 "open": " ",
                 "close": ""
             }
         },
         "name": "TexImageSource",
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/typedef.json
+++ b/test/syntax/json/typedef.json
@@ -25,14 +25,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "x",
                 "escapedName": "x",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -55,14 +55,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "y",
                 "escapedName": "y",
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -73,7 +73,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "typedef",
@@ -99,7 +99,7 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": ""
                     }
@@ -109,13 +109,13 @@
             "prefix": null,
             "postfix": null,
             "separator": null,
-            "extAttrs": [],
+            "extAttrs": null,
             "trivia": {
                 "base": " "
             }
         },
         "name": "PointSequence",
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -143,14 +143,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "topleft",
                 "escapedName": "topleft",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -173,14 +173,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "bottomright",
                 "escapedName": "bottomright",
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -191,7 +191,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -221,14 +221,14 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "bounds",
                 "escapedName": "bounds",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -248,7 +248,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n\n    "
                         }
@@ -270,7 +270,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -281,7 +281,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -295,7 +295,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -315,7 +315,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n    "
                         }
@@ -337,7 +337,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -348,7 +348,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -362,7 +362,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -373,7 +373,7 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     },
     {
         "type": "typedef",
@@ -387,19 +387,29 @@
             "prefix": null,
             "postfix": null,
             "separator": null,
-            "extAttrs": [
-                {
-                    "name": "Clamp",
-                    "arguments": null,
-                    "type": "extended-attribute",
-                    "rhs": null
-                }
-            ],
+            "extAttrs": {
+                "trivia": {
+                    "open": " ",
+                    "close": ""
+                },
+                "items": [
+                    {
+                        "name": "Clamp",
+                        "signature": null,
+                        "type": "extended-attribute",
+                        "rhs": null,
+                        "trivia": {
+                            "name": ""
+                        },
+                        "separator": null
+                    }
+                ]
+            },
             "trivia": {
                 "base": " "
             }
         },
         "name": "value",
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/typesuffixes.json
+++ b/test/syntax/json/typesuffixes.json
@@ -22,7 +22,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  "
                         }
@@ -44,7 +44,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": {
@@ -71,7 +71,7 @@
                                         "prefix": null,
                                         "postfix": null,
                                         "separator": null,
-                                        "extAttrs": [],
+                                        "extAttrs": null,
                                         "trivia": {
                                             "base": ""
                                         }
@@ -81,7 +81,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -95,7 +95,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -106,6 +106,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/uniontype.json
+++ b/test/syntax/json/uniontype.json
@@ -34,7 +34,7 @@
                                 "value": "or",
                                 "trivia": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "trivia": {
                                 "base": ""
                             }
@@ -58,7 +58,7 @@
                                         "value": "or",
                                         "trivia": " "
                                     },
-                                    "extAttrs": [],
+                                    "extAttrs": null,
                                     "trivia": {
                                         "base": ""
                                     }
@@ -73,7 +73,7 @@
                                     "prefix": null,
                                     "postfix": null,
                                     "separator": null,
-                                    "extAttrs": [],
+                                    "extAttrs": null,
                                     "trivia": {
                                         "base": " "
                                     }
@@ -86,7 +86,7 @@
                                 "value": "or",
                                 "trivia": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "trivia": {
                                 "open": " ",
                                 "close": ""
@@ -113,7 +113,7 @@
                                         "value": "or",
                                         "trivia": " "
                                     },
-                                    "extAttrs": [],
+                                    "extAttrs": null,
                                     "trivia": {
                                         "base": ""
                                     }
@@ -128,7 +128,7 @@
                                     "prefix": null,
                                     "postfix": null,
                                     "separator": null,
-                                    "extAttrs": [],
+                                    "extAttrs": null,
                                     "trivia": {
                                         "base": " "
                                     }
@@ -138,7 +138,7 @@
                             "prefix": null,
                             "postfix": null,
                             "separator": null,
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "trivia": {
                                 "open": " ",
                                 "close": ""
@@ -149,7 +149,7 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "open": " ",
                         "close": ""
@@ -157,7 +157,7 @@
                 },
                 "name": "test",
                 "escapedName": "test",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "attribute",
@@ -189,14 +189,24 @@
                                 "value": "or",
                                 "trivia": " "
                             },
-                            "extAttrs": [
-                                {
-                                    "name": "EnforceRange",
-                                    "arguments": null,
-                                    "type": "extended-attribute",
-                                    "rhs": null
-                                }
-                            ],
+                            "extAttrs": {
+                                "trivia": {
+                                    "open": "",
+                                    "close": ""
+                                },
+                                "items": [
+                                    {
+                                        "name": "EnforceRange",
+                                        "signature": null,
+                                        "type": "extended-attribute",
+                                        "rhs": null,
+                                        "trivia": {
+                                            "name": ""
+                                        },
+                                        "separator": null
+                                    }
+                                ]
+                            },
                             "trivia": {
                                 "base": " "
                             }
@@ -211,7 +221,7 @@
                             "prefix": null,
                             "postfix": null,
                             "separator": null,
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "trivia": {
                                 "base": " "
                             }
@@ -221,7 +231,7 @@
                     "prefix": null,
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "open": " ",
                         "close": ""
@@ -229,7 +239,7 @@
                 },
                 "name": "test2",
                 "escapedName": "test2",
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -240,6 +250,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]

--- a/test/syntax/json/variadic-operations.json
+++ b/test/syntax/json/variadic-operations.json
@@ -30,14 +30,14 @@
                     },
                     "postfix": null,
                     "separator": null,
-                    "extAttrs": [],
+                    "extAttrs": null,
                     "trivia": {
                         "base": " "
                     }
                 },
                 "name": "cardinality",
                 "escapedName": "cardinality",
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -57,7 +57,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n\n  "
                         }
@@ -81,7 +81,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -92,7 +92,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -106,7 +106,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             },
             {
                 "type": "operation",
@@ -126,7 +126,7 @@
                         "prefix": null,
                         "postfix": null,
                         "separator": null,
-                        "extAttrs": [],
+                        "extAttrs": null,
                         "trivia": {
                             "base": "\n  "
                         }
@@ -150,7 +150,7 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": [],
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -161,7 +161,7 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": [],
+                                "extAttrs": null,
                                 "trivia": {
                                     "base": ""
                                 }
@@ -175,7 +175,7 @@
                 "trivia": {
                     "termination": ""
                 },
-                "extAttrs": []
+                "extAttrs": null
             }
         ],
         "trivia": {
@@ -186,6 +186,6 @@
             "termination": ""
         },
         "inheritance": null,
-        "extAttrs": []
+        "extAttrs": null
     }
 ]


### PR DESCRIPTION
1. The field `extAttrs` now gives an object with `items` and `trivia` field.
2. `arguments` list are now moved into the new field `signature` which also has `trivia` for parentheses.