### PR TITLE
Document trivia for iterable-likes

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,6 +657,7 @@ The fields are as follows:
 * `type`: Always one of "iterable", "legacyiterable", "maplike" or "setlike".
 * `idlType`: An array with one or more [IDL Types](#idl-type) representing the declared type arguments.
 * `readonly`: An object with a string type field `trivia` if the maplike or setlike is declared as read only.
+* `trivia`: A trivia object.
 * `extAttrs`: A list of [extended attributes](#extended-attributes).
 
 

--- a/README.md
+++ b/README.md
@@ -641,7 +641,13 @@ These appear as members of interfaces that look like this:
 {
   "type": "maplike", // or "legacyiterable" / "iterable" / "setlike"
   "idlType": /* One or two types */ ,
-  "readonly": false, // only for maplike and setlike
+  "readonly": null, // only for maplike and setlike
+  "trivia": {
+    "base": " ",
+    "open": "",
+    "close": "",
+    "termination": ""
+  },
   "extAttrs": []
 }
 ```
@@ -650,7 +656,7 @@ The fields are as follows:
 
 * `type`: Always one of "iterable", "legacyiterable", "maplike" or "setlike".
 * `idlType`: An array with one or more [IDL Types](#idl-type) representing the declared type arguments.
-* `readonly`: Whether the maplike or setlike is declared as read only.
+* `readonly`: An object with a string type field `trivia` if the maplike or setlike is declared as read only.
 * `extAttrs`: A list of [extended attributes](#extended-attributes).
 
 

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -840,7 +840,7 @@
         unconsume(start_position);
         return;
       }
-      ret.trivia.type = ittype.trivia;
+      ret.trivia.base = ittype.trivia;
 
       const secondTypeRequired = ittype.value === "maplike";
       const secondTypeAllowed = secondTypeRequired || ittype.value === "iterable";

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -167,7 +167,7 @@
     function iterable_like(it) {
       const readonly = it.readonly ? `${it.readonly.trivia}readonly` : "";
       const bracket = `${it.trivia.open}<${it.idlType.map(type).join("")}${it.trivia.close}>`;
-      return `${readonly}${it.trivia.type}${it.type}${bracket}${it.trivia.termination};`;
+      return `${readonly}${it.trivia.base}${it.type}${bracket}${it.trivia.termination};`;
     }
     function callbackInterface(it) {
       return `${it.trivia.callback}callback${interface_(it)}`;

--- a/test/syntax/json/iterable.json
+++ b/test/syntax/json/iterable.json
@@ -24,7 +24,7 @@
                     }
                 ],
                 "trivia": {
-                    "type": "\n  ",
+                    "base": "\n  ",
                     "open": "",
                     "close": "",
                     "termination": ""
@@ -87,7 +87,7 @@
                     }
                 ],
                 "trivia": {
-                    "type": "\n  ",
+                    "base": "\n  ",
                     "open": "",
                     "close": "",
                     "termination": ""
@@ -147,7 +147,7 @@
                     }
                 ],
                 "trivia": {
-                    "type": "\n  ",
+                    "base": "\n  ",
                     "open": "",
                     "close": "",
                     "termination": ""

--- a/test/syntax/json/legacyiterable.json
+++ b/test/syntax/json/legacyiterable.json
@@ -24,7 +24,7 @@
                     }
                 ],
                 "trivia": {
-                    "type": "\n  ",
+                    "base": "\n  ",
                     "open": "",
                     "close": "",
                     "termination": ""

--- a/test/syntax/json/maplike.json
+++ b/test/syntax/json/maplike.json
@@ -43,7 +43,7 @@
                 ],
                 "readonly": null,
                 "trivia": {
-                    "type": "\n  ",
+                    "base": "\n  ",
                     "open": "",
                     "close": "",
                     "termination": ""
@@ -107,7 +107,7 @@
                     "trivia": "\n  "
                 },
                 "trivia": {
-                    "type": " ",
+                    "base": " ",
                     "open": "",
                     "close": "",
                     "termination": ""
@@ -203,7 +203,7 @@
                 ],
                 "readonly": null,
                 "trivia": {
-                    "type": "\n    ",
+                    "base": "\n    ",
                     "open": "",
                     "close": "",
                     "termination": ""

--- a/test/syntax/json/setlike.json
+++ b/test/syntax/json/setlike.json
@@ -25,7 +25,7 @@
                 ],
                 "readonly": null,
                 "trivia": {
-                    "type": "\n  ",
+                    "base": "\n  ",
                     "open": "",
                     "close": "",
                     "termination": ""
@@ -71,7 +71,7 @@
                     "trivia": "\n  "
                 },
                 "trivia": {
-                    "type": " ",
+                    "base": " ",
                     "open": "",
                     "close": "",
                     "termination": ""
@@ -132,7 +132,7 @@
                 ],
                 "readonly": null,
                 "trivia": {
-                    "type": "\n  ",
+                    "base": "\n  ",
                     "open": "",
                     "close": "",
                     "termination": ""


### PR DESCRIPTION
Also including renaming from `trivia.type` to `trivia.base` for consistency with other types.