### PR TITLE
chore(README): operation body always has idlType

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,7 +632,7 @@ The fields are as follows:
 
 The operation body fields are as follows:
 
-* `idlType`: An [IDL Type](#idl-type) of what the operation returns. If a stringifier, may be absent.
+* `idlType`: An [IDL Type](#idl-type) of what the operation returns.
 * `trivia`: A trivia object.
 * `name`: The name of the operation if exists.
 * `arguments`: An array of [arguments](#arguments) for the operation.


### PR DESCRIPTION
A stringifier may miss a body, but the body always includes idlType.