### PR TITLE
fix(index): import writer from index

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,4 @@
-module.exports = require("./lib/webidl2.js");
+module.exports = {
+  ...require("./lib/webidl2.js"),
+  ...require("./lib/writer.js")
+};

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -1191,13 +1191,9 @@
   };
 
   if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
-    Object.assign(obj, require("./writer.js"));
     module.exports = obj;
   } else if (typeof define === 'function' && define.amd) {
-    define(["writer"], writer => {
-      Object.assign(obj, writer);
-      return obj;
-    });
+    define([], () => obj);
   } else {
     (self || window).WebIDL2 = obj;
   }

--- a/test/writer.js
+++ b/test/writer.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const { collect } = require("./util/collect");
-const wp = require("../lib/webidl2");
+const wp = require("..");
 const expect = require("expect");
 
 describe("Rewrite and parses all of the IDLs to produce the same ASTs", () => {


### PR DESCRIPTION
#185 breaks build environments e.g. Respec that use ./lib/webidl2.js independently so this PR fixes that.