### PR TITLE
refactor(lib/writer): horizontally shorter type()

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -2,20 +2,29 @@
 
 (() => {
   function write(ast) {
+    function type_body(it) {
+      if (it.union) {
+        const subtypes = it.idlType.map(type).join("");
+        return `${it.trivia.open}(${subtypes}${it.trivia.close})`;
+      } else if (it.generic) {
+        const genericName = `${it.trivia.base}${it.generic.value}`;
+        const subtypes = it.idlType.map(type).join("");
+        const { trivia } = it.generic;
+        const bracket = `${trivia.open}<${subtypes}${trivia.close}>`;
+        return `${genericName}${bracket}`;
+      } 
+      const prefix = it.prefix ? (it.prefix.trivia + it.prefix.value) : "";
+      const base = it.trivia.base + it.baseName;
+      const postfix = it.postfix ? (it.postfix.trivia + it.postfix.value) : "";
+      return `${prefix}${base}${postfix}`;
+    }
     function type(it) {
-      let ret = extended_attributes(it.extAttrs);
-      if (it.prefix) ret += it.prefix.trivia + it.prefix.value;
-      if (it.union) ret += `${it.trivia.open}(${it.idlType.map(type).join("")}${it.trivia.close})`;
-      else if (it.generic) ret += `${it.trivia.base}${it.generic.value}${it.generic.trivia.open}<${it.idlType.map(type).join("")}${it.generic.trivia.close}>`;
-      else {
-        ret += it.trivia.base;
-        ret += typeof it.idlType === "string" ? it.baseName : type(it.idlType);
-      }
-      if (it.postfix) ret += it.postfix.trivia + it.postfix.value;
-      if (it.nullable) ret += `${it.nullable.trivia}?`;
-      if (it.separator) ret += it.separator.trivia + it.separator.value;
+      const ext = extended_attributes(it.extAttrs);
+      const body = type_body(it);
+      const nullable = it.nullable ? `${it.nullable.trivia}?` : "";
+      const separator = it.separator ? (it.separator.trivia + it.separator.value) : "";
 
-      return ret;
+      return `${ext}${body}${nullable}${separator}`;
     }
     function const_value(it) {
       const tp = it.type;


### PR DESCRIPTION
Currently writer.js tends to be horizontally loooong, so this PR makes it shorter for `type()`.

Also named variables will probably help future refactoring.

We may ultimately enable [eslint max-len rule](https://eslint.org/docs/rules/max-len).