### PR TITLE
refactor(lib/writer): use interface_like()

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -108,13 +108,15 @@
       return `${inh.trivia.colon}:${inh.trivia.name}${inh.name}`;
     }
 
-    function interface_like(it, type = it.type) {
-      let ret = extended_attributes(it.extAttrs);
-      ret += token(it.partial, "partial");
-      ret += `${it.trivia.base}${type}${it.trivia.name}${it.escapedName}`;
-      ret += inheritance(it.inheritance);
-      ret += `${it.trivia.open}{${iterate(it.members)}${it.trivia.close}}${it.trivia.termination};`;
-      return ret;
+    function container(type) {
+      return it => {
+        let ret = extended_attributes(it.extAttrs);
+        ret += token(it.partial, "partial");
+        ret += `${it.trivia.base}${type}${it.trivia.name}${it.escapedName}`;
+        ret += inheritance(it.inheritance);
+        ret += `${it.trivia.open}{${iterate(it.members)}${it.trivia.close}}${it.trivia.termination};`;
+        return ret;
+      };
     }
 
     function interface_mixin(it) {
@@ -166,19 +168,19 @@
       return `${readonly}${it.trivia.base}${it.type}${bracket}${it.trivia.termination};`;
     }
     function callbackInterface(it) {
-      return `${it.trivia.callback}callback${interface_like(it, "interface")}`;
+      return `${it.trivia.callback}callback${container("interface")(it)}`;
     }
     function eof(it) {
       return it.trivia;
     }
 
     const table = {
-      interface: interface_like,
+      interface: container("interface"),
       "interface mixin": interface_mixin,
-      namespace: interface_like,
+      namespace: container("namespace"),
       operation,
       attribute,
-      dictionary: interface_like,
+      dictionary: container("dictionary"),
       field,
       const: const_,
       typedef,

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -108,10 +108,10 @@
       return `${inh.trivia.colon}:${inh.trivia.name}${inh.name}`;
     }
 
-    function interface_(it) {
+    function interface_like(it, type = it.type) {
       let ret = extended_attributes(it.extAttrs);
       ret += token(it.partial, "partial");
-      ret += `${it.trivia.base}interface${it.trivia.name}${it.escapedName}`;
+      ret += `${it.trivia.base}${type}${it.trivia.name}${it.escapedName}`;
       ret += inheritance(it.inheritance);
       ret += `${it.trivia.open}{${iterate(it.members)}${it.trivia.close}}${it.trivia.termination};`;
       return ret;
@@ -125,22 +125,6 @@
       return ret;
     }
 
-    function namespace(it) {
-      let ret = extended_attributes(it.extAttrs);
-      ret += token(it.partial, "partial");
-      ret += `${it.trivia.base}namespace${it.trivia.name}${it.escapedName}`;
-      ret += `${it.trivia.open}{${iterate(it.members)}${it.trivia.close}}${it.trivia.termination};`;
-      return ret;
-    }
-
-    function dictionary(it) {
-      let ret = extended_attributes(it.extAttrs);
-      ret += token(it.partial, "partial");
-      ret += `${it.trivia.base}dictionary${it.trivia.name}${it.escapedName}`;
-      ret += inheritance(it.inheritance);
-      ret += `${it.trivia.open}{${iterate(it.members)}${it.trivia.close}}${it.trivia.termination};`;
-      return ret;
-    }
     function field(it) {
       let ret = extended_attributes(it.extAttrs);
       ret += token(it.required, "required");
@@ -182,19 +166,19 @@
       return `${readonly}${it.trivia.base}${it.type}${bracket}${it.trivia.termination};`;
     }
     function callbackInterface(it) {
-      return `${it.trivia.callback}callback${interface_(it)}`;
+      return `${it.trivia.callback}callback${interface_like(it, "interface")}`;
     }
     function eof(it) {
       return it.trivia;
     }
 
     const table = {
-      interface: interface_,
+      interface: interface_like,
       "interface mixin": interface_mixin,
-      namespace,
+      namespace: interface_like,
       operation,
       attribute,
-      dictionary,
+      dictionary: interface_like,
       field,
       const: const_,
       typedef,


### PR DESCRIPTION
`namespace()` and `dictionary()` are so much like `interface_()` so this PR removes them.