### PR TITLE
BREAKING CHANGE: merge modifier fields

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -192,11 +192,7 @@
 
     const EMPTY_OPERATION = Object.freeze({
       type: "operation",
-      getter: null,
-      setter: null,
-      deleter: null,
-      static: null,
-      stringifier: null,
+      special: null,
       body: null
     });
 
@@ -701,17 +697,12 @@
       const start_position = consume_position;
       const ret = {
         type: "attribute",
-        static: null,
-        stringifier: null,
-        inherit: null,
+        special: null,
         readonly: null,
         trivia: {}
       };
       if (!noInherit) {
-        const inherit = consume("inherit");
-        if (inherit) {
-          ret.inherit = { trivia: inherit.trivia };
-        }
+        ret.special = untyped_consume("inherit") || null;
       }
       const readonlyToken = consume("readonly");
       if (readonlyToken) {
@@ -764,10 +755,7 @@
     function operation({ regular = false } = {}) {
       const ret = Object.assign({}, EMPTY_OPERATION, { body: {} });
       if (!regular) {
-        const special = consume("getter", "setter", "deleter");
-        if (special) {
-          ret[special.type] = { trivia: special.trivia };
-        }
+        ret.special = untyped_consume("getter", "setter", "deleter") || null;
       }
       ret.body.idlType = return_type() || error("Missing return type");
       operation_rest(ret);
@@ -775,23 +763,22 @@
     }
 
     function static_member() {
-      const token = consume("static");
+      const token = untyped_consume("static");
       if (!token) return;
       const member = attribute({ noInherit: true }) ||
         operation({ regular: true }) ||
         error("No body in static member");
-      member.static = { trivia: token.trivia };
+      member.special = token;
       return member;
     }
 
     function stringifier() {
-      const token = consume("stringifier");
+      const token = untyped_consume("stringifier");
       if (!token) return;
-      const triviaObject = { trivia: token.trivia };
       const termination = consume(";");
       if (termination) {
         return Object.assign({}, EMPTY_OPERATION, {
-          stringifier: triviaObject,
+          special: token,
           trivia: {
             termination: termination.trivia
           }
@@ -800,7 +787,7 @@
       const member = attribute({ noInherit: true }) ||
         operation({ regular: true }) ||
         error("Unterminated stringifier");
-      member.stringifier = triviaObject;
+      member.special = token;
       return member;
     }
 

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -78,9 +78,7 @@
 
     function operation(it) {
       let ret = extended_attributes(it.extAttrs);
-      for (const mod of ["getter", "setter", "deleter", "stringifier", "static"]) {
-        ret += token(it[mod], mod);
-      }
+      ret += token(it.special);
       if (it.body) {
         const { body } = it;
         ret += type(body.idlType);
@@ -93,9 +91,7 @@
 
     function attribute(it) {
       let ret = extended_attributes(it.extAttrs);
-      ret += token(it.static, "static");
-      ret += token(it.stringifier, "stringifier");
-      ret += token(it.inherit, "inherit");
+      ret += token(it.special);
       ret += token(it.readonly, "readonly");
       ret += `${it.trivia.base}attribute${type(it.idlType)}${it.trivia.name}${it.escapedName};`;
       return ret;

--- a/test/syntax/json/allowany.json
+++ b/test/syntax/json/allowany.json
@@ -7,11 +7,7 @@
         "members": [
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -46,11 +42,7 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -113,11 +105,7 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",

--- a/test/syntax/json/attributes.json
+++ b/test/syntax/json/attributes.json
@@ -7,9 +7,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n\n  // A simple attribute that can be set to any value the range an unsigned\n  // short can take.\n  ",
@@ -40,9 +38,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n\n  // required is an allowed attribute name\n  ",

--- a/test/syntax/json/callback.json
+++ b/test/syntax/json/callback.json
@@ -64,11 +64,7 @@
         "members": [
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",

--- a/test/syntax/json/constructor.json
+++ b/test/syntax/json/constructor.json
@@ -7,9 +7,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -37,9 +35,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -67,9 +63,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -97,9 +91,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": {
                     "trivia": "\n  "
                 },

--- a/test/syntax/json/enum.json
+++ b/test/syntax/json/enum.json
@@ -46,9 +46,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -76,9 +74,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -106,11 +102,7 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",

--- a/test/syntax/json/equivalent-decl.json
+++ b/test/syntax/json/equivalent-decl.json
@@ -7,9 +7,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": {
                     "trivia": "\n  "
                 },
@@ -42,13 +40,10 @@
             },
             {
                 "type": "operation",
-                "getter": {
+                "special": {
+                    "value": "getter",
                     "trivia": "\n\n  "
                 },
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -111,13 +106,10 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": {
+                "special": {
+                    "value": "setter",
                     "trivia": "\n  "
                 },
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -227,9 +219,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": {
                     "trivia": "\n  "
                 },
@@ -262,11 +252,7 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -329,11 +315,7 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -426,13 +408,10 @@
             },
             {
                 "type": "operation",
-                "getter": {
+                "special": {
+                    "value": "getter",
                     "trivia": "\n\n  "
                 },
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -491,13 +470,10 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": {
+                "special": {
+                    "value": "setter",
                     "trivia": "\n  "
                 },
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",

--- a/test/syntax/json/extended-attributes.json
+++ b/test/syntax/json/extended-attributes.json
@@ -168,9 +168,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -198,9 +196,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -228,9 +224,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -258,9 +252,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": {
                     "trivia": "\n  "
                 },
@@ -371,9 +363,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n    ",

--- a/test/syntax/json/generic.json
+++ b/test/syntax/json/generic.json
@@ -7,11 +7,7 @@
         "members": [
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -114,9 +110,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": {
                     "trivia": "\n  "
                 },
@@ -185,11 +179,7 @@
         "members": [
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -248,11 +238,7 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -326,11 +312,7 @@
         "members": [
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",

--- a/test/syntax/json/getter-setter.json
+++ b/test/syntax/json/getter-setter.json
@@ -7,9 +7,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": {
                     "trivia": "\n  "
                 },
@@ -42,13 +40,10 @@
             },
             {
                 "type": "operation",
-                "getter": {
+                "special": {
+                    "value": "getter",
                     "trivia": "\n\n  "
                 },
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -107,13 +102,10 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": {
+                "special": {
+                    "value": "setter",
                     "trivia": "\n  "
                 },
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",

--- a/test/syntax/json/identifier-qualified-names.json
+++ b/test/syntax/json/identifier-qualified-names.json
@@ -33,11 +33,7 @@
         "members": [
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -100,13 +96,10 @@
             },
             {
                 "type": "operation",
-                "getter": {
+                "special": {
+                    "value": "getter",
                     "trivia": "\n\n    // Operation has no identifier; it declares a getter.\n    "
                 },
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -182,9 +175,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n\n      // Attribute identifier: \"const\"\n      ",
@@ -212,9 +203,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n\n      // Attribute identifier: \"value\"\n      ",
@@ -261,11 +250,7 @@
         "members": [
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",

--- a/test/syntax/json/indexed-properties.json
+++ b/test/syntax/json/indexed-properties.json
@@ -7,9 +7,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": {
                     "trivia": "\n  "
                 },
@@ -42,13 +40,10 @@
             },
             {
                 "type": "operation",
-                "getter": {
+                "special": {
+                    "value": "getter",
                     "trivia": "\n\n  "
                 },
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -114,13 +109,10 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": {
+                "special": {
+                    "value": "setter",
                     "trivia": "\n  "
                 },
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -216,13 +208,10 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": {
+                "special": {
+                    "value": "deleter",
                     "trivia": "\n  "
                 },
-                "static": null,
-                "stringifier": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -288,13 +277,10 @@
             },
             {
                 "type": "operation",
-                "getter": {
+                "special": {
+                    "value": "getter",
                     "trivia": "\n\n  "
                 },
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -357,13 +343,10 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": {
+                "special": {
+                    "value": "setter",
                     "trivia": "\n  "
                 },
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -456,13 +439,10 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": {
+                "special": {
+                    "value": "deleter",
                     "trivia": "\n  "
                 },
-                "static": null,
-                "stringifier": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",

--- a/test/syntax/json/inherits-getter.json
+++ b/test/syntax/json/inherits-getter.json
@@ -7,9 +7,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": {
                     "trivia": "\n\n  // A simple attribute that can be set to any string value.\n  "
                 },
@@ -56,9 +54,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": {
                     "trivia": "\n\n  // An attribute whose value cannot be assigned to.\n  "
                 },
@@ -91,9 +87,8 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": {
+                "special": {
+                    "value": "inherit",
                     "trivia": "\n\n  // An attribute that can raise an exception if it is set to an invalid value.\n  // Its getter behavior is inherited from Animal, and need not be specified\n  // the description of Person.\n  "
                 },
                 "readonly": null,
@@ -146,9 +141,8 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": {
+                "special": {
+                    "value": "inherit",
                     "trivia": "\n\n  // An attribute that only inherits the getter behavior\n  "
                 },
                 "readonly": {

--- a/test/syntax/json/interface-inherits.json
+++ b/test/syntax/json/interface-inherits.json
@@ -7,9 +7,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -54,9 +52,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -107,9 +103,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",

--- a/test/syntax/json/mixin.json
+++ b/test/syntax/json/mixin.json
@@ -7,9 +7,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": {
                     "trivia": "\n  "
                 },
@@ -82,9 +80,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": {
                     "trivia": "\n  "
                 },

--- a/test/syntax/json/namespace.json
+++ b/test/syntax/json/namespace.json
@@ -7,9 +7,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": {
                     "trivia": "\n  "
                 },
@@ -39,11 +37,7 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -136,11 +130,7 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",

--- a/test/syntax/json/nointerfaceobject.json
+++ b/test/syntax/json/nointerfaceobject.json
@@ -7,11 +7,7 @@
         "members": [
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",

--- a/test/syntax/json/nullable.json
+++ b/test/syntax/json/nullable.json
@@ -57,9 +57,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": {
                     "trivia": "\n  "
                 },

--- a/test/syntax/json/nullableobjects.json
+++ b/test/syntax/json/nullableobjects.json
@@ -39,11 +39,7 @@
         "members": [
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -108,11 +104,7 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",

--- a/test/syntax/json/operation-optional-arg.json
+++ b/test/syntax/json/operation-optional-arg.json
@@ -7,11 +7,7 @@
         "members": [
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",

--- a/test/syntax/json/overloading.json
+++ b/test/syntax/json/overloading.json
@@ -39,11 +39,7 @@
         "members": [
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -106,11 +102,7 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -190,11 +182,7 @@
         "members": [
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -257,11 +245,7 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -403,11 +387,7 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -442,11 +422,7 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",

--- a/test/syntax/json/overridebuiltins.json
+++ b/test/syntax/json/overridebuiltins.json
@@ -7,9 +7,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": {
                     "trivia": "\n  "
                 },
@@ -42,13 +40,10 @@
             },
             {
                 "type": "operation",
-                "getter": {
+                "special": {
+                    "value": "getter",
                     "trivia": "\n  "
                 },
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",

--- a/test/syntax/json/partial-interface.json
+++ b/test/syntax/json/partial-interface.json
@@ -7,9 +7,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -56,9 +54,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",

--- a/test/syntax/json/primitives.json
+++ b/test/syntax/json/primitives.json
@@ -7,9 +7,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -37,9 +35,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -67,9 +63,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -97,9 +91,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -127,9 +119,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -160,9 +150,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -190,9 +178,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -223,9 +209,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -256,9 +240,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -292,9 +274,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -322,9 +302,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -352,9 +330,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -385,9 +361,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -418,9 +392,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -448,9 +420,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -478,9 +448,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -508,9 +476,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",

--- a/test/syntax/json/promise-void.json
+++ b/test/syntax/json/promise-void.json
@@ -7,9 +7,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n    ",

--- a/test/syntax/json/prototyperoot.json
+++ b/test/syntax/json/prototyperoot.json
@@ -7,9 +7,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": {
                     "trivia": "\n  "
                 },

--- a/test/syntax/json/putforwards.json
+++ b/test/syntax/json/putforwards.json
@@ -7,9 +7,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": {
                     "trivia": " "
                 },
@@ -63,9 +61,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",

--- a/test/syntax/json/record.json
+++ b/test/syntax/json/record.json
@@ -7,11 +7,7 @@
         "members": [
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -136,11 +132,7 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -360,11 +352,7 @@
         "members": [
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",

--- a/test/syntax/json/reg-operations.json
+++ b/test/syntax/json/reg-operations.json
@@ -7,9 +7,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -40,9 +38,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -90,11 +86,7 @@
         "members": [
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -129,11 +121,7 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -196,11 +184,7 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",

--- a/test/syntax/json/replaceable.json
+++ b/test/syntax/json/replaceable.json
@@ -7,9 +7,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": {
                     "trivia": " "
                 },
@@ -59,11 +57,7 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",

--- a/test/syntax/json/sequence.json
+++ b/test/syntax/json/sequence.json
@@ -7,11 +7,7 @@
         "members": [
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -96,11 +92,7 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -174,11 +166,7 @@
         "members": [
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",

--- a/test/syntax/json/static.json
+++ b/test/syntax/json/static.json
@@ -23,9 +23,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -53,9 +51,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -83,9 +79,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -113,11 +107,10 @@
             },
             {
                 "type": "attribute",
-                "static": {
+                "special": {
+                    "value": "static",
                     "trivia": "\n\n  "
                 },
-                "stringifier": null,
-                "inherit": null,
                 "readonly": {
                     "trivia": " "
                 },
@@ -147,13 +140,10 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": {
+                "special": {
+                    "value": "static",
                     "trivia": "\n  "
                 },
-                "stringifier": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",

--- a/test/syntax/json/stringifier-attribute.json
+++ b/test/syntax/json/stringifier-attribute.json
@@ -7,9 +7,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -40,11 +38,10 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": {
+                "special": {
+                    "value": "stringifier",
                     "trivia": "\n  "
                 },
-                "inherit": null,
                 "readonly": null,
                 "trivia": {
                     "base": " ",

--- a/test/syntax/json/stringifier-custom.json
+++ b/test/syntax/json/stringifier-custom.json
@@ -7,9 +7,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -40,9 +38,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -72,9 +68,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -102,11 +96,8 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": {
+                "special": {
+                    "value": "stringifier",
                     "trivia": "\n\n  "
                 },
                 "body": {

--- a/test/syntax/json/stringifier.json
+++ b/test/syntax/json/stringifier.json
@@ -7,11 +7,8 @@
         "members": [
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": {
+                "special": {
+                    "value": "stringifier",
                     "trivia": "\n  "
                 },
                 "body": {
@@ -61,11 +58,8 @@
         "members": [
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": {
+                "special": {
+                    "value": "stringifier",
                     "trivia": "\n  "
                 },
                 "body": null,

--- a/test/syntax/json/treatasnull.json
+++ b/test/syntax/json/treatasnull.json
@@ -7,9 +7,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -37,9 +35,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -67,11 +63,7 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",

--- a/test/syntax/json/treatasundefined.json
+++ b/test/syntax/json/treatasundefined.json
@@ -7,9 +7,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -37,9 +35,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n  ",
@@ -67,11 +63,7 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",

--- a/test/syntax/json/typedef.json
+++ b/test/syntax/json/typedef.json
@@ -7,9 +7,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n        ",
@@ -37,9 +35,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n        ",
@@ -132,9 +128,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n        ",
@@ -162,9 +156,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n        ",
@@ -209,9 +201,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": {
                     "trivia": "\n\n    "
                 },
@@ -241,11 +231,7 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -308,11 +294,7 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",

--- a/test/syntax/json/typesuffixes.json
+++ b/test/syntax/json/typesuffixes.json
@@ -7,11 +7,7 @@
         "members": [
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",

--- a/test/syntax/json/uniontype.json
+++ b/test/syntax/json/uniontype.json
@@ -7,9 +7,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n ",
@@ -162,9 +160,7 @@
             },
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": null,
                 "trivia": {
                     "base": "\n ",

--- a/test/syntax/json/variadic-operations.json
+++ b/test/syntax/json/variadic-operations.json
@@ -7,9 +7,7 @@
         "members": [
             {
                 "type": "attribute",
-                "static": null,
-                "stringifier": null,
-                "inherit": null,
+                "special": null,
                 "readonly": {
                     "trivia": "\n  "
                 },
@@ -42,11 +40,7 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",
@@ -111,11 +105,7 @@
             },
             {
                 "type": "operation",
-                "getter": null,
-                "setter": null,
-                "deleter": null,
-                "static": null,
-                "stringifier": null,
+                "special": null,
                 "body": {
                     "idlType": {
                         "type": "return-type",


### PR DESCRIPTION
The IDL spec currently allows only one special modifier:

```
ReadWriteAttribute ::
    inherit ReadOnly AttributeRest
    AttributeRest

SpecialOperation ::
    Special RegularOperation

Special ::
    getter
    setter
    deleter

StaticMember ::
    static StaticMemberRest

StaticMemberRest ::
    ReadOnly AttributeRest
    RegularOperation

Stringifier ::
    stringifier StringifierRest

StringifierRest ::
    ReadOnly AttributeRest
    RegularOperation
    ;
```

No attribute or operation can get multiple special modifiers, so we can now merge them into one single field and remove the need to check one-by-one.