### PR TITLE
[WIP] write() with optional templates

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -98,7 +98,7 @@
       const optional = token(arg.optional, "optional");
       const typePart = type(arg.idlType);
       const variadic = token(arg.variadic, "...");
-      const name = wrap`${ts.trivia(arg.trivia.name)}${ts.name(arg.escapedName)}`;
+      const name = wrap`${ts.trivia(arg.trivia.name)}${ts.name(arg.escapedName, { data: arg })}`;
       const defaultValue = default_(arg.default);
       const separator = token(arg.separator);
       return ts.argument(
@@ -136,7 +136,7 @@
         const { body } = it;
         const trivia = extract_trivia(it.body);
         const typePart = type(body.idlType);
-        const name = token(body.name, body.name && ts.name(body.name.escaped));
+        const name = token(body.name, body.name && ts.name(body.name.escaped, { data: it, parent }));
         const args = wrap`${trivia.open}(${ts.wrap(body.arguments.map(argument))}${trivia.close})`;
         bodyPart = wrap`${typePart}${name}${args}`;
       }
@@ -151,7 +151,7 @@
       const special = token(it.special);
       const readonly = token(it.readonly, "readonly");
       const prefixes = wrap`${ext}${special}${readonly}`;
-      const name = ts.name(it.escapedName);
+      const name = ts.name(it.escapedName, { data: it, parent });
       const trivia = extract_trivia(it);
       return ts.attribute(
         wrap`${prefixes}${trivia.base}attribute${type(it.idlType)}${trivia.name}${name};`,
@@ -172,7 +172,7 @@
         const trivia = extract_trivia(it);
         const ext = extended_attributes(it.extAttrs);
         const partial = token(it.partial, "partial");
-        const name = ts.name(it.escapedName);
+        const name = ts.name(it.escapedName, { data: it });
         const head = wrap`${trivia.base}${type}${trivia.name}${name}`;
         const inherit = inheritance(it.inheritance);
         const body = wrap`${trivia.open}{${iterate(it.members, it)}${trivia.close}}${trivia.termination};`;
@@ -187,7 +187,7 @@
       const trivia = extract_trivia(it);
       const ext = extended_attributes(it.extAttrs);
       const partial = token(it.partial, "partial");
-      const name = ts.name(it.escapedName);
+      const name = ts.name(it.escapedName, { data: it });
       const head = wrap`${trivia.base}interface${trivia.mixin}mixin${trivia.name}${name}`;
       const body = wrap`${trivia.open}{${iterate(it.members, it)}${trivia.close}}${trivia.termination};`;
       return ts.mixin(
@@ -199,7 +199,7 @@
       const trivia = extract_trivia(it);
       const ext = extended_attributes(it.extAttrs);
       const required = token(it.required, "required");
-      const name = ts.name(it.escapedName);
+      const name = ts.name(it.escapedName, { data: it, parent });
       const body = wrap`${type(it.idlType)}${trivia.name}${name}`;
       const defaultValue = default_(it.default);
       return ts.field(
@@ -210,7 +210,7 @@
     function const_(it, parent) {
       const trivia = extract_trivia(it);
       const ret = extended_attributes(it.extAttrs);
-      const name = ts.name(it.name);
+      const name = ts.name(it.name, { data: it, parent });
       return ts.const(
         wrap`${ret}${trivia.base}const${type(it.idlType)}${trivia.name}${name}${trivia.assign}=${trivia.value}${const_value(it.value)}${trivia.termination};`,
         { data: it, parent }
@@ -219,7 +219,7 @@
     function typedef(it) {
       const trivia = extract_trivia(it);
       const ret = extended_attributes(it.extAttrs);
-      const name = ts.name(it.escapedName);
+      const name = ts.name(it.escapedName, { data: it });
       return ts.typedef(
         wrap`${ret}${trivia.base}typedef${type(it.idlType)}${trivia.name}${name}${trivia.termination};`,
         { data: it }
@@ -238,7 +238,7 @@
     function callback(it) {
       const trivia = extract_trivia(it);
       const ext = extended_attributes(it.extAttrs);
-      const name = ts.name(it.name);
+      const name = ts.name(it.name, { data: it });
       const head = wrap`${trivia.base}callback${trivia.name}${name}`;
       const args = ts.wrap(it.arguments.map(argument));
       const signature = wrap`${type(it.idlType)}${trivia.open}(${args}${trivia.close})`;
@@ -250,7 +250,7 @@
     function enum_(it) {
       const trivia = extract_trivia(it);
       const ext = extended_attributes(it.extAttrs);
-      const name = ts.name(it.escapedName);
+      const name = ts.name(it.escapedName, { data: it });
       const values = iterate(it.values, it);
       return ts.enum(
         wrap`${ext}${trivia.base}enum${trivia.name}${name}${trivia.open}{${values}${trivia.close}}${trivia.termination};`,
@@ -259,7 +259,7 @@
     }
     function enum_value(v, parent) {
       return ts.enumValue(
-        wrap`${ts.trivia(v.trivia)}"${ts.name(v.value)}"${token(v.separator)}`,
+        wrap`${ts.trivia(v.trivia)}"${ts.name(v.value, { data: it, parent })}"${token(v.separator)}`,
         { data: v, parent }
       );
     }

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -110,7 +110,7 @@
         const { body } = it;
         const typePart = type(body.idlType);
         const name = body.name ? ts.wrap`${body.name.trivia}${ts.name(body.name.escaped)}` : "";
-        const args = ts.wrap`${body.trivia.open}(${body.arguments.map(argument).join("")}${body.trivia.close})`;
+        const args = ts.wrap`${body.trivia.open}(${collect(body.arguments.map(argument))}${body.trivia.close})`;
         bodyPart = ts.wrap`${typePart}${name}${args}`;
       }
       return ts.wrap`${ext}${modifier}${bodyPart}${it.trivia.termination};`;
@@ -182,7 +182,7 @@
       const ext = extended_attributes(it.extAttrs);
       const name = ts.name(it.name);
       const head = ts.wrap`${it.trivia.base}callback${it.trivia.name}${name}`;
-      const args = it.arguments.map(argument).join("");
+      const args = collect(it.arguments.map(argument));
       const signature = ts.wrap`${type(it.idlType)}${it.trivia.open}(${args}${it.trivia.close})`;
       return ts.wrap`${ext}${head}${it.trivia.assign}=${signature}${it.trivia.termination};`;
     }
@@ -197,7 +197,7 @@
     }
     function iterable_like(it) {
       const readonly = it.readonly ? ts.wrap`${it.readonly.trivia}readonly` : "";
-      const bracket = ts.wrap`${it.trivia.open}<${it.idlType.map(type).join("")}${it.trivia.close}>`;
+      const bracket = ts.wrap`${it.trivia.open}<${collect(it.idlType.map(type))}${it.trivia.close}>`;
       return ts.wrap`${readonly}${it.trivia.base}${it.type}${bracket}${it.trivia.termination};`;
     }
     function callbackInterface(it) {

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -157,26 +157,29 @@
     }
 
     function field(it) {
-      let ret = extended_attributes(it.extAttrs);
-      ret += token(it.required, "required");
-      ret += ts.wrap`${type(it.idlType)}${it.trivia.name}${it.escapedName}`;
-      ret += default_(it.default);
-      ret += ts.wrap`${it.trivia.termination};`;
-      return ret;
+      const ext = extended_attributes(it.extAttrs);
+      const required = token(it.required, "required");
+      const name = ts.name(it.escapedName);
+      const body = ts.wrap`${type(it.idlType)}${it.trivia.name}${name}`;
+      const defaultValue = default_(it.default);
+      return ts.wrap`${ext}${required}${body}${defaultValue}${it.trivia.termination};`;
     }
     function const_(it) {
       const ret = extended_attributes(it.extAttrs);
-      return ts.wrap`${ret}${it.trivia.base}const${type(it.idlType)}${it.trivia.name}${it.name}${it.trivia.assign}=${it.trivia.value}${const_value(it.value)}${it.trivia.termination};`;
+      const name = ts.name(it.name);
+      return ts.wrap`${ret}${it.trivia.base}const${type(it.idlType)}${it.trivia.name}${name}${it.trivia.assign}=${it.trivia.value}${const_value(it.value)}${it.trivia.termination};`;
     }
     function typedef(it) {
       const ret = extended_attributes(it.extAttrs);
-      return ts.wrap`${ret}${it.trivia.base}typedef${type(it.idlType)}${it.trivia.name}${it.escapedName}${it.trivia.termination};`;
+      const name = ts.name(it.escapedName);
+      return ts.wrap`${ret}${it.trivia.base}typedef${type(it.idlType)}${it.trivia.name}${name}${it.trivia.termination};`;
     }
     function includes(it) {
       const ret = extended_attributes(it.extAttrs);
       const target = ts.name(it.target);
       const mixin = ts.name(it.includes);
       return ts.includes(
+        it,
         ts.wrap
           `${ret}${it.trivia.target}${target}${it.trivia.includes}includes${it.trivia.mixin}${mixin}${it.trivia.termination};`
       );

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -16,6 +16,7 @@
   const templates = {
     wrap: noopTag,
     name: noop,
+    reference: noop,
     includes: noop
   };
 
@@ -35,13 +36,13 @@
         const subtypes = collect(it.idlType.map(type));
         return ts.wrap`${it.trivia.open}(${subtypes}${it.trivia.close})`;
       } else if (it.generic) {
-        const genericName = ts.wrap`${it.trivia.base}${ts.name(it.generic.value)}`;
+        const genericName = ts.wrap`${it.trivia.base}${ts.reference(it.generic.value)}`;
         const subtypes = collect(it.idlType.map(type));
         const { trivia } = it.generic;
         return ts.wrap`${genericName}${trivia.open}<${subtypes}${trivia.close}>`;
       }
       const prefix = token(it.prefix);
-      const base = ts.wrap`${it.trivia.base}${ts.name(it.baseName)}`;
+      const base = ts.wrap`${it.trivia.base}${ts.reference(it.baseName)}`;
       const postfix = token(it.postfix);
       return ts.wrap`${prefix}${base}${postfix}`;
     }
@@ -82,14 +83,14 @@
       return ts.wrap`${ext}${optional}${typePart}${variadic}${name}${defaultValue}${separator}`;
     }
     function identifier(id) {
-      return ts.wrap`${id.trivia}${ts.name(id.value)}${token(id.separator)}`;
+      return ts.wrap`${id.trivia}${ts.reference(id.value)}${token(id.separator)}`;
     }
     function make_ext_at(it) {
-      const name = ts.wrap`${it.trivia.name}${ts.name(it.name)}`;
+      const name = ts.wrap`${it.trivia.name}${ts.reference(it.name)}`;
       let rhs = "";
       if (it.rhs) {
         if (it.rhs.type === "identifier-list") rhs = ts.wrap`${it.rhs.trivia.assign}=${it.rhs.trivia.open}(${collect(it.rhs.value.map(identifier))}${it.rhs.trivia.close})`;
-        else rhs = ts.wrap`${it.rhs.trivia.assign}=${it.rhs.trivia.value}${ts.name(it.rhs.value)}`;
+        else rhs = ts.wrap`${it.rhs.trivia.assign}=${it.rhs.trivia.value}${ts.reference(it.rhs.value)}`;
       }
       const signature = it.signature ? ts.wrap`${it.signature.trivia.open}(${collect(it.signature.arguments.map(argument))}${it.signature.trivia.close})` : "";
       const separator = token(it.separator);
@@ -128,7 +129,7 @@
       if (!inh) {
         return "";
       }
-      return ts.wrap`${inh.trivia.colon}:${inh.trivia.name}${ts.name(inh.name)}`;
+      return ts.wrap`${inh.trivia.colon}:${inh.trivia.name}${ts.reference(inh.name)}`;
     }
 
     function container(type) {
@@ -171,8 +172,8 @@
     }
     function includes(it) {
       const ret = extended_attributes(it.extAttrs);
-      const target = ts.name(it.target);
-      const mixin = ts.name(it.includes);
+      const target = ts.reference(it.target);
+      const mixin = ts.reference(it.includes);
       return ts.includes(
         ts.wrap`${ret}${it.trivia.target}${target}${it.trivia.includes}includes${it.trivia.mixin}${mixin}${it.trivia.termination};`
       );

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -48,7 +48,7 @@
       } else if (it.generic) {
         const genericName = ts.wrap`${trivia.base}${ts.reference(it.generic.value)}`;
         const subtypes = collect(it.idlType.map(type));
-        const { trivia: gTrivia } = it.generic;
+        const gTrivia = it.generic;
         return ts.wrap`${genericName}${gTrivia.open}<${subtypes}${gTrivia.close}>`;
       }
       const base = ts.wrap`${trivia.base}${ts.reference(it.baseName)}`;
@@ -74,40 +74,43 @@
       if (!def) {
         return "";
       }
-      const assign = ts.wrap`${def.trivia.assign}=`;
+      const trivia = extract_trivia(def);
+      const assign = ts.wrap`${trivia.assign}=`;
       if (def.type === "sequence") {
-        return ts.wrap`${assign}${def.trivia.open}[${def.trivia.close}]`;
+        return ts.wrap`${assign}${trivia.open}[${trivia.close}]`;
       }
-      return ts.wrap`${assign}${def.trivia.value}${const_value(def)}`;
+      return ts.wrap`${assign}${trivia.value}${const_value(def)}`;
     }
     function argument(arg) {
       const ext = extended_attributes(arg.extAttrs);
       const optional = token(arg.optional, "optional");
       const typePart = type(arg.idlType);
       const variadic = token(arg.variadic, "...");
-      const name = ts.wrap`${arg.trivia.name}${ts.name(arg.escapedName)}`;
+      const name = ts.wrap`${ts.trivia(arg.trivia.name)}${ts.name(arg.escapedName)}`;
       const defaultValue = default_(arg.default);
       const separator = token(arg.separator);
       return ts.wrap`${ext}${optional}${typePart}${variadic}${name}${defaultValue}${separator}`;
     }
     function identifier(id) {
-      return ts.wrap`${id.trivia}${ts.reference(id.value)}${token(id.separator)}`;
+      return ts.wrap`${ts.trivia(id.trivia)}${ts.reference(id.value)}${token(id.separator)}`;
     }
     function make_ext_at(it) {
-      const name = ts.wrap`${it.trivia.name}${ts.reference(it.name)}`;
+      const name = ts.wrap`${ts.trivia(it.trivia.name)}${ts.reference(it.name)}`;
       let rhs = "";
       if (it.rhs) {
-        if (it.rhs.type === "identifier-list") rhs = ts.wrap`${it.rhs.trivia.assign}=${it.rhs.trivia.open}(${collect(it.rhs.value.map(identifier))}${it.rhs.trivia.close})`;
-        else rhs = ts.wrap`${it.rhs.trivia.assign}=${it.rhs.trivia.value}${ts.reference(it.rhs.value)}`;
+        const trivia = extract_trivia(it.rhs);
+        if (it.rhs.type === "identifier-list") rhs = ts.wrap`${trivia.assign}=${trivia.open}(${collect(it.rhs.value.map(identifier))}${trivia.close})`;
+        else rhs = ts.wrap`${trivia.assign}=${trivia.value}${ts.reference(it.rhs.value)}`;
       }
-      const signature = it.signature ? ts.wrap`${it.signature.trivia.open}(${collect(it.signature.arguments.map(argument))}${it.signature.trivia.close})` : "";
+      const signature = it.signature ? ts.wrap`${ts.trivia(it.signature.trivia.open)}(${collect(it.signature.arguments.map(argument))}${ts.trivia(it.signature.trivia.close)})` : "";
       const separator = token(it.separator);
       return ts.wrap`${name}${rhs}${signature}${separator}`;
     }
     function extended_attributes(eats) {
       if (!eats) return "";
       const members = collect(eats.items.map(make_ext_at));
-      return ts.wrap`${eats.trivia.open}[${members}${eats.trivia.close}]`;
+      const trivia = extract_trivia(eats);
+      return ts.wrap`${trivia.open}[${members}${trivia.close}]`;
     }
 
     function operation(it) {
@@ -116,12 +119,13 @@
       let bodyPart = "";
       if (it.body) {
         const { body } = it;
+        const trivia = extract_trivia(it.body);
         const typePart = type(body.idlType);
-        const name = body.name ? ts.wrap`${body.name.trivia}${ts.name(body.name.escaped)}` : "";
-        const args = ts.wrap`${body.trivia.open}(${collect(body.arguments.map(argument))}${body.trivia.close})`;
+        const name = token(body.name, body.name && ts.name(body.name.escaped));
+        const args = ts.wrap`${trivia.open}(${collect(body.arguments.map(argument))}${trivia.close})`;
         bodyPart = ts.wrap`${typePart}${name}${args}`;
       }
-      return ts.wrap`${ext}${modifier}${bodyPart}${it.trivia.termination};`;
+      return ts.wrap`${ext}${modifier}${bodyPart}${ts.trivia(it.trivia.termination)};`;
     }
 
     function attribute(it) {
@@ -130,89 +134,100 @@
       const readonly = token(it.readonly, "readonly");
       const prefixes = ts.wrap`${ext}${special}${readonly}`;
       const name = ts.name(it.escapedName);
-      return ts.wrap`${prefixes}${it.trivia.base}attribute${type(it.idlType)}${it.trivia.name}${name};`;
+      const trivia = extract_trivia(it);
+      return ts.wrap`${prefixes}${trivia.base}attribute${type(it.idlType)}${trivia.name}${name};`;
     }
 
     function inheritance(inh) {
       if (!inh) {
         return "";
       }
-      return ts.wrap`${inh.trivia.colon}:${inh.trivia.name}${ts.reference(inh.name)}`;
+      const trivia = extract_trivia(inh);
+      return ts.wrap`${trivia.colon}:${trivia.name}${ts.reference(inh.name)}`;
     }
 
     function container(type) {
       return it => {
+        const trivia = extract_trivia(it);
         const ext = extended_attributes(it.extAttrs);
         const partial = token(it.partial, "partial");
         const name = ts.name(it.escapedName);
-        const head = ts.wrap`${it.trivia.base}${type}${it.trivia.name}${name}`;
+        const head = ts.wrap`${trivia.base}${type}${trivia.name}${name}`;
         const inherit = inheritance(it.inheritance);
-        const body = ts.wrap`${it.trivia.open}{${iterate(it.members)}${it.trivia.close}}${it.trivia.termination};`;
+        const body = ts.wrap`${trivia.open}{${iterate(it.members)}${trivia.close}}${trivia.termination};`;
         return ts.wrap`${ext}${partial}${head}${inherit}${body}`;
       };
     }
 
     function interface_mixin(it) {
+      const trivia = extract_trivia(it);
       const ext = extended_attributes(it.extAttrs);
       const partial = token(it.partial, "partial");
       const name = ts.name(it.escapedName);
-      const head = ts.wrap`${it.trivia.base}interface${it.trivia.mixin}mixin${it.trivia.name}${name}`;
-      const body = ts.wrap`${it.trivia.open}{${iterate(it.members)}${it.trivia.close}}${it.trivia.termination};`;
+      const head = ts.wrap`${trivia.base}interface${trivia.mixin}mixin${trivia.name}${name}`;
+      const body = ts.wrap`${trivia.open}{${iterate(it.members)}${trivia.close}}${trivia.termination};`;
       return ts.wrap`${ext}${partial}${head}${body}`;
     }
     function field(it) {
+      const trivia = extract_trivia(it);
       const ext = extended_attributes(it.extAttrs);
       const required = token(it.required, "required");
       const name = ts.name(it.escapedName);
-      const body = ts.wrap`${type(it.idlType)}${it.trivia.name}${name}`;
+      const body = ts.wrap`${type(it.idlType)}${trivia.name}${name}`;
       const defaultValue = default_(it.default);
-      return ts.wrap`${ext}${required}${body}${defaultValue}${it.trivia.termination};`;
+      return ts.wrap`${ext}${required}${body}${defaultValue}${trivia.termination};`;
     }
     function const_(it) {
+      const trivia = extract_trivia(it);
       const ret = extended_attributes(it.extAttrs);
       const name = ts.name(it.name);
-      return ts.wrap`${ret}${it.trivia.base}const${type(it.idlType)}${it.trivia.name}${name}${it.trivia.assign}=${it.trivia.value}${const_value(it.value)}${it.trivia.termination};`;
+      return ts.wrap`${ret}${trivia.base}const${type(it.idlType)}${trivia.name}${name}${trivia.assign}=${trivia.value}${const_value(it.value)}${trivia.termination};`;
     }
     function typedef(it) {
+      const trivia = extract_trivia(it);
       const ret = extended_attributes(it.extAttrs);
       const name = ts.name(it.escapedName);
-      return ts.wrap`${ret}${it.trivia.base}typedef${type(it.idlType)}${it.trivia.name}${name}${it.trivia.termination};`;
+      return ts.wrap`${ret}${trivia.base}typedef${type(it.idlType)}${trivia.name}${name}${trivia.termination};`;
     }
     function includes(it) {
+      const trivia = extract_trivia(it);
       const ret = extended_attributes(it.extAttrs);
       const target = ts.reference(it.target);
       const mixin = ts.reference(it.includes);
       return ts.includes(
-        ts.wrap`${ret}${it.trivia.target}${target}${it.trivia.includes}includes${it.trivia.mixin}${mixin}${it.trivia.termination};`
+        ts.wrap`${ret}${trivia.target}${target}${trivia.includes}includes${trivia.mixin}${mixin}${trivia.termination};`
       );
     }
     function callback(it) {
+      const trivia = extract_trivia(it);
       const ext = extended_attributes(it.extAttrs);
       const name = ts.name(it.name);
-      const head = ts.wrap`${it.trivia.base}callback${it.trivia.name}${name}`;
+      const head = ts.wrap`${trivia.base}callback${trivia.name}${name}`;
       const args = collect(it.arguments.map(argument));
-      const signature = ts.wrap`${type(it.idlType)}${it.trivia.open}(${args}${it.trivia.close})`;
-      return ts.wrap`${ext}${head}${it.trivia.assign}=${signature}${it.trivia.termination};`;
+      const signature = ts.wrap`${type(it.idlType)}${trivia.open}(${args}${trivia.close})`;
+      return ts.wrap`${ext}${head}${trivia.assign}=${signature}${trivia.termination};`;
     }
     function enum_(it) {
+      const trivia = extract_trivia(it);
       const ext = extended_attributes(it.extAttrs);
       const name = ts.name(it.escapedName);
       const values = iterate(it.values);
-      return ts.wrap`${ext}${it.trivia.base}enum${it.trivia.name}${name}${it.trivia.open}{${values}${it.trivia.close}}${it.trivia.termination};`;
+      return ts.wrap`${ext}${trivia.base}enum${trivia.name}${name}${trivia.open}{${values}${trivia.close}}${trivia.termination};`;
     }
     function enum_value(v) {
-      return ts.wrap`${v.trivia}"${ts.name(v.value)}"${token(v.separator)}`;
+      return ts.wrap`${ts.trivia(v.trivia)}"${ts.name(v.value)}"${token(v.separator)}`;
     }
     function iterable_like(it) {
-      const readonly = it.readonly ? ts.wrap`${it.readonly.trivia}readonly` : "";
-      const bracket = ts.wrap`${it.trivia.open}<${collect(it.idlType.map(type))}${it.trivia.close}>`;
-      return ts.wrap`${readonly}${it.trivia.base}${it.type}${bracket}${it.trivia.termination};`;
+      const trivia = extract_trivia(it);
+      const readonly = token(it.readonly, "readonly");
+      const bracket = ts.wrap`${trivia.open}<${collect(it.idlType.map(type))}${trivia.close}>`;
+      return ts.wrap`${readonly}${trivia.base}${it.type}${bracket}${trivia.termination};`;
     }
     function callbackInterface(it) {
-      return ts.wrap`${it.trivia.callback}callback${container("interface")(it)}`;
+      return ts.wrap`${ts.trivia(it.trivia.callback)}callback${container("interface")(it)}`;
     }
     function eof(it) {
-      return it.trivia;
+      return ts.trivia(it.trivia);
     }
 
     const table = {

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -107,7 +107,7 @@
       return wrap`${ts.trivia(id.trivia)}${reference(id.value)}${token(id.separator)}`;
     }
     function make_ext_at(it) {
-      const name = wrap`${ts.trivia(it.trivia.name)}${ts.extendedAttributeReference(it.name)}`;
+      const name = ts.extendedAttributeReference(it.name);
       let rhs = "";
       if (it.rhs) {
         const trivia = extract_trivia(it.rhs);
@@ -116,7 +116,7 @@
       }
       const signature = it.signature ? wrap`${ts.trivia(it.signature.trivia.open)}(${ts.wrap(it.signature.arguments.map(argument))}${ts.trivia(it.signature.trivia.close)})` : "";
       const separator = token(it.separator);
-      return ts.extendedAttribute(wrap`${name}${rhs}${signature}${separator}`);
+      return wrap`${ts.trivia(it.trivia.name)}${ts.extendedAttribute(wrap`${name}${rhs}${signature}`)}${separator}`;
     }
     function extended_attributes(eats) {
       if (!eats) return "";

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -15,6 +15,7 @@
 
   const templates = {
     wrap: noopTag,
+    trivia: noop,
     name: noop,
     reference: noop,
     includes: noop
@@ -27,24 +28,31 @@
       return ts.wrap(new Array(args.length + 1).fill(""), ...args);
     }
 
+    function extract_trivia(object) {
+      const batch = {};
+      for (const key in object.trivia) {
+        batch[key] = ts.trivia(object.trivia[key]);
+      }
+      return batch;
+    }
+
     function token(t, value) {
-      return t ? t.trivia + (value || t.escaped || t.value) : "";
+      return t ? ts.wrap`${ts.trivia(t.trivia)}${value || t.value}` : "";
     }
 
     function type_body(it) {
+      const trivia = extract_trivia(it);
       if (it.union) {
         const subtypes = collect(it.idlType.map(type));
-        return ts.wrap`${it.trivia.open}(${subtypes}${it.trivia.close})`;
+        return ts.wrap`${trivia.open}(${subtypes}${trivia.close})`;
       } else if (it.generic) {
-        const genericName = ts.wrap`${it.trivia.base}${ts.reference(it.generic.value)}`;
+        const genericName = ts.wrap`${trivia.base}${ts.reference(it.generic.value)}`;
         const subtypes = collect(it.idlType.map(type));
-        const { trivia } = it.generic;
-        return ts.wrap`${genericName}${trivia.open}<${subtypes}${trivia.close}>`;
+        const { trivia: gTrivia } = it.generic;
+        return ts.wrap`${genericName}${gTrivia.open}<${subtypes}${gTrivia.close}>`;
       }
-      const prefix = token(it.prefix);
-      const base = ts.wrap`${it.trivia.base}${ts.reference(it.baseName)}`;
-      const postfix = token(it.postfix);
-      return ts.wrap`${prefix}${base}${postfix}`;
+      const base = ts.wrap`${trivia.base}${ts.reference(it.baseName)}`;
+      return ts.wrap`${token(it.prefix)}${base}${token(it.postfix)}`;
     }
     function type(it) {
       const ext = extended_attributes(it.extAttrs);

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -259,7 +259,7 @@
     }
     function enum_value(v, parent) {
       return ts.enumValue(
-        wrap`${ts.trivia(v.trivia)}"${ts.name(v.value, { data: it, parent })}"${token(v.separator)}`,
+        wrap`${ts.trivia(v.trivia)}"${ts.name(v.value, { data: v, parent })}"${token(v.separator)}`,
         { data: v, parent }
       );
     }

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -260,7 +260,7 @@
     function enum_value(v, parent) {
       return ts.enumValue(
         wrap`${ts.trivia(v.trivia)}"${ts.name(v.value)}"${token(v.separator)}`,
-        { data: it, parent }
+        { data: v, parent }
       );
     }
     function iterable_like(it, parent) {

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -152,9 +152,13 @@
       const name = ts.name(it.escapedName, { data: it, parent });
       const trivia = extract_trivia(it);
       return ts.definition(
-        wrap`${prefixes}${trivia.base}attribute${ts.type(type(it.idlType))}${trivia.name}${name}${trivia.termination};`,
+        wrap`${prefixes}${typed_head(trivia, it, name)}${trivia.termination};`,
         { data: it, parent }
       );
+    }
+
+    function typed_head(trivia, it, name) {
+      return wrap`${trivia.base}${it.type}${ts.type(type(it.idlType))}${trivia.name}${name}`;
     }
 
     function inheritance(inh) {
@@ -213,7 +217,7 @@
       const trivia = extract_trivia(it);
       const ext = extended_attributes(it.extAttrs);
       const name = ts.name(it.name, { data: it, parent });
-      const head = wrap`${trivia.base}const${ts.type(type(it.idlType))}${trivia.name}${name}`;
+      const head = typed_head(trivia, it, name);
       const assign = wrap`${trivia.assign}=${trivia.value}${ts.valueLiteral(const_value(it.value), it)}`;
       return ts.definition(
         wrap`${ext}${head}${assign}${trivia.termination};`,
@@ -225,7 +229,7 @@
       const ret = extended_attributes(it.extAttrs);
       const name = ts.name(it.escapedName, { data: it });
       return ts.definition(
-        wrap`${ret}${trivia.base}typedef${ts.type(type(it.idlType))}${trivia.name}${name}${trivia.termination};`,
+        wrap`${ret}${typed_head(trivia, it, name)}${trivia.termination};`,
         { data: it }
       );
     }

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -1,7 +1,40 @@
 "use strict";
 
 (() => {
-  function write(ast) {
+  /**
+   * @param {string[]} strings 
+   * @param  {...any} args 
+   */
+  function noopTag(strings, ...args) {
+    return strings.map((s, i) => s + (args[i] || "")).join("");
+  }
+
+  function noopArray(args) {
+    return args.join("");
+  }
+
+  function noop(arg) {
+    return arg;
+  }
+
+  const templates = {
+    wrap: noopTag,
+    name: noop,
+    includes: noop
+  };
+
+  /**
+   * @param {any[]} args 
+   */
+  function arrayToStringTagAdapter(args) {
+    return [
+      new Array(args.length + 1).fill(""),
+      ...args
+    ];
+  }
+  function write(ast, { templates: ts = templates } = {}) {
+    ts = { ...templates, ...ts };
+
     function token(t, value) {
       return t ? t.trivia + (value || t.escaped || t.value) : "";
     }
@@ -9,25 +42,25 @@
     function type_body(it) {
       if (it.union) {
         const subtypes = it.idlType.map(type).join("");
-        return `${it.trivia.open}(${subtypes}${it.trivia.close})`;
+        return ts.wrap`${it.trivia.open}(${subtypes}${it.trivia.close})`;
       } else if (it.generic) {
-        const genericName = `${it.trivia.base}${it.generic.value}`;
+        const genericName = ts.wrap`${it.trivia.base}${it.generic.value}`;
         const subtypes = it.idlType.map(type).join("");
         const { trivia } = it.generic;
-        const bracket = `${trivia.open}<${subtypes}${trivia.close}>`;
-        return `${genericName}${bracket}`;
+        const bracket = ts.wrap`${trivia.open}<${subtypes}${trivia.close}>`;
+        return ts.wrap`${genericName}${bracket}`;
       }
       const prefix = token(it.prefix);
       const base = it.trivia.base + it.baseName;
       const postfix = token(it.postfix);
-      return `${prefix}${base}${postfix}`;
+      return ts.wrap`${prefix}${base}${postfix}`;
     }
     function type(it) {
       const ext = extended_attributes(it.extAttrs);
       const body = type_body(it);
       const nullable = token(it.nullable, "?");
       const separator = token(it.separator);
-      return `${ext}${body}${nullable}${separator}`;
+      return ts.wrap`${ext}${body}${nullable}${separator}`;
     }
     function const_value(it) {
       const tp = it.type;
@@ -36,24 +69,24 @@
       else if (tp === "Infinity") return (it.negative ? "-" : "") + "Infinity";
       else if (tp === "NaN") return "NaN";
       else if (tp === "number") return it.value;
-      else return `"${it.value}"`;
+      else return ts.wrap`"${it.value}"`;
     }
     function default_(def) {
       if (!def) {
         return "";
       }
-      const assign = `${def.trivia.assign}=`;
+      const assign = ts.wrap`${def.trivia.assign}=`;
       if (def.type === "sequence") {
-        return `${assign}${def.trivia.open}[${def.trivia.close}]`;
+        return ts.wrap`${assign}${def.trivia.open}[${def.trivia.close}]`;
       }
-      return `${assign}${def.trivia.value}${const_value(def)}`;
+      return ts.wrap`${assign}${def.trivia.value}${const_value(def)}`;
     }
     function argument(arg) {
       let ret = extended_attributes(arg.extAttrs);
       ret += token(arg.optional, "optional");
       ret += type(arg.idlType);
       ret += token(arg.variadic, "...");
-      ret += `${arg.trivia.name}${arg.escapedName}`;
+      ret += ts.wrap`${arg.trivia.name}${arg.escapedName}`;
       ret += default_(arg.default);
       ret += token(arg.separator);
       return ret;
@@ -64,16 +97,16 @@
     function make_ext_at(it) {
       let ret = it.trivia.name + it.name;
       if (it.rhs) {
-        if (it.rhs.type === "identifier-list") ret += `${it.rhs.trivia.assign}=${it.rhs.trivia.open}(${it.rhs.value.map(identifier).join("")}${it.rhs.trivia.close})`;
-        else ret += `${it.rhs.trivia.assign}=${it.rhs.trivia.value}${it.rhs.value}`;
+        if (it.rhs.type === "identifier-list") ret += ts.wrap`${it.rhs.trivia.assign}=${it.rhs.trivia.open}(${it.rhs.value.map(identifier).join("")}${it.rhs.trivia.close})`;
+        else ret += ts.wrap`${it.rhs.trivia.assign}=${it.rhs.trivia.value}${it.rhs.value}`;
       }
-      if (it.signature) ret += `${it.signature.trivia.open}(${it.signature.arguments.map(argument).join("")}${it.signature.trivia.close})`;
+      if (it.signature) ret += ts.wrap`${it.signature.trivia.open}(${it.signature.arguments.map(argument).join("")}${it.signature.trivia.close})`;
       ret += token(it.separator);
       return ret;
     }
     function extended_attributes(eats) {
       if (!eats) return "";
-      return `${eats.trivia.open}[${eats.items.map(make_ext_at).join("")}${eats.trivia.close}]`;
+      return ts.wrap`${eats.trivia.open}[${eats.items.map(make_ext_at).join("")}${eats.trivia.close}]`;
     }
 
     function operation(it) {
@@ -83,7 +116,7 @@
         const { body } = it;
         ret += type(body.idlType);
         ret += token(body.name);
-        ret += `${body.trivia.open}(${body.arguments.map(argument).join("")}${body.trivia.close})`;
+        ret += ts.wrap`${body.trivia.open}(${body.arguments.map(argument).join("")}${body.trivia.close})`;
       }
       ret += it.trivia.termination + ";";
       return ret;
@@ -93,7 +126,7 @@
       let ret = extended_attributes(it.extAttrs);
       ret += token(it.special);
       ret += token(it.readonly, "readonly");
-      ret += `${it.trivia.base}attribute${type(it.idlType)}${it.trivia.name}${it.escapedName};`;
+      ret += ts.wrap`${it.trivia.base}attribute${type(it.idlType)}${it.trivia.name}${it.escapedName};`;
       return ret;
     }
 
@@ -101,16 +134,16 @@
       if (!inh) {
         return "";
       }
-      return `${inh.trivia.colon}:${inh.trivia.name}${inh.name}`;
+      return ts.wrap`${inh.trivia.colon}:${inh.trivia.name}${inh.name}`;
     }
 
     function container(type) {
       return it => {
         let ret = extended_attributes(it.extAttrs);
         ret += token(it.partial, "partial");
-        ret += `${it.trivia.base}${type}${it.trivia.name}${it.escapedName}`;
+        ret += ts.wrap`${it.trivia.base}${type}${it.trivia.name}${it.escapedName}`;
         ret += inheritance(it.inheritance);
-        ret += `${it.trivia.open}{${iterate(it.members)}${it.trivia.close}}${it.trivia.termination};`;
+        ret += ts.wrap`${it.trivia.open}{${iterate(it.members)}${it.trivia.close}}${it.trivia.termination};`;
         return ret;
       };
     }
@@ -118,53 +151,57 @@
     function interface_mixin(it) {
       let ret = extended_attributes(it.extAttrs);
       ret += token(it.partial, "partial");
-      ret += `${it.trivia.base}interface${it.trivia.mixin}mixin${it.trivia.name}${it.escapedName}`;
-      ret += `${it.trivia.open}{${iterate(it.members)}${it.trivia.close}}${it.trivia.termination};`;
+      ret += ts.wrap`${it.trivia.base}interface${it.trivia.mixin}mixin${it.trivia.name}${it.escapedName}`;
+      ret += ts.wrap`${it.trivia.open}{${iterate(it.members)}${it.trivia.close}}${it.trivia.termination};`;
       return ret;
     }
 
     function field(it) {
       let ret = extended_attributes(it.extAttrs);
       ret += token(it.required, "required");
-      ret += `${type(it.idlType)}${it.trivia.name}${it.escapedName}`;
+      ret += ts.wrap`${type(it.idlType)}${it.trivia.name}${it.escapedName}`;
       ret += default_(it.default);
-      ret += `${it.trivia.termination};`;
+      ret += ts.wrap`${it.trivia.termination};`;
       return ret;
     }
     function const_(it) {
       const ret = extended_attributes(it.extAttrs);
-      return `${ret}${it.trivia.base}const${type(it.idlType)}${it.trivia.name}${it.name}${it.trivia.assign}=${it.trivia.value}${const_value(it.value)}${it.trivia.termination};`;
+      return ts.wrap`${ret}${it.trivia.base}const${type(it.idlType)}${it.trivia.name}${it.name}${it.trivia.assign}=${it.trivia.value}${const_value(it.value)}${it.trivia.termination};`;
     }
     function typedef(it) {
       const ret = extended_attributes(it.extAttrs);
-      return `${ret}${it.trivia.base}typedef${type(it.idlType)}${it.trivia.name}${it.escapedName}${it.trivia.termination};`;
+      return ts.wrap`${ret}${it.trivia.base}typedef${type(it.idlType)}${it.trivia.name}${it.escapedName}${it.trivia.termination};`;
     }
     function includes(it) {
       const ret = extended_attributes(it.extAttrs);
-      return `${ret}${it.trivia.target}${it.target}${it.trivia.includes}includes${it.trivia.mixin}${it.includes}${it.trivia.termination};`;
+      const target = ts.name(it.target);
+      const mixin = ts.name(it.includes);
+      return ts.includes(
+        ts.wrap
+          `${ret}${it.trivia.target}${target}${it.trivia.includes}includes${it.trivia.mixin}${mixin}${it.trivia.termination};`
+      );
     }
     function callback(it) {
       const ext = extended_attributes(it.extAttrs);
-      const head = `${it.trivia.base}callback${it.trivia.name}${it.name}`;
+      const head = ts.wrap`${it.trivia.base}callback${it.trivia.name}${it.name}`;
       const args = it.arguments.map(argument).join("");
-      const signature = `${type(it.idlType)}${it.trivia.open}(${args}${it.trivia.close})`;
-      return `${ext}${head}${it.trivia.assign}=${signature}${it.trivia.termination};`;
+      const signature = ts.wrap`${type(it.idlType)}${it.trivia.open}(${args}${it.trivia.close})`;
+      return ts.wrap`${ext}${head}${it.trivia.assign}=${signature}${it.trivia.termination};`;
     }
     function enum_(it) {
       const ext = extended_attributes(it.extAttrs);
-      const values = it.values.map(v => {
-        const body = `${v.trivia}"${v.value}"`;
-        return body + token(v.separator);
-      }).join("");
-      return `${ext}${it.trivia.base}enum${it.trivia.name}${it.escapedName}${it.trivia.open}{${values}${it.trivia.close}}${it.trivia.termination};`;
+      const values = it.values.map(
+        v => ts.wrap`${v.trivia}"${v.value}"${token(v.separator)}`
+      ).join("");
+      return ts.wrap`${ext}${it.trivia.base}enum${it.trivia.name}${it.escapedName}${it.trivia.open}{${values}${it.trivia.close}}${it.trivia.termination};`;
     }
     function iterable_like(it) {
-      const readonly = it.readonly ? `${it.readonly.trivia}readonly` : "";
-      const bracket = `${it.trivia.open}<${it.idlType.map(type).join("")}${it.trivia.close}>`;
-      return `${readonly}${it.trivia.base}${it.type}${bracket}${it.trivia.termination};`;
+      const readonly = it.readonly ? ts.wrap`${it.readonly.trivia}readonly` : "";
+      const bracket = ts.wrap`${it.trivia.open}<${it.idlType.map(type).join("")}${it.trivia.close}>`;
+      return ts.wrap`${readonly}${it.trivia.base}${it.type}${bracket}${it.trivia.termination};`;
     }
     function callbackInterface(it) {
-      return `${it.trivia.callback}callback${container("interface")(it)}`;
+      return ts.wrap`${it.trivia.callback}callback${container("interface")(it)}`;
     }
     function eof(it) {
       return it.trivia;
@@ -199,13 +236,11 @@
     }
     function iterate(things) {
       if (!things) return;
-      let ret = "";
-      for (const thing of things) ret += dispatch(thing);
-      return ret;
+      const results = things.map(dispatch);
+      return ts.wrap(...arrayToStringTagAdapter(results));
     }
     return iterate(ast);
   }
-
 
   const obj = {
     write

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -14,22 +14,9 @@
     valueLiteral: noop,
     inheritance: noop,
 
-    interface: noop,
-    const: noop,
-    operation: noop,
+    definition: noop,
+    member: noop,
     argument: noop,
-    attribute: noop,
-    iterator: noop,
-    callbackInterface: noop,
-    mixin: noop,
-    includes: noop,
-    namespace: noop,
-    dictionary: noop,
-    field: noop,
-    enum: noop,
-    enumValue: noop,
-    callbackFunction: noop,
-    typedef: noop,
 
     extendedAttribute: noop
   };
@@ -154,7 +141,7 @@
         const args = wrap`${trivia.open}(${ts.wrap(body.arguments.map(argument))}${trivia.close})`;
         bodyPart = wrap`${typePart}${name}${args}`;
       }
-      return ts.operation(
+      return ts.member(
         wrap`${ext}${modifier}${bodyPart}${ts.trivia(it.trivia.termination)};`,
         { data: it, parent }
       );
@@ -167,7 +154,7 @@
       const prefixes = wrap`${ext}${special}${readonly}`;
       const name = ts.name(it.escapedName, { data: it, parent });
       const trivia = extract_trivia(it);
-      return ts.attribute(
+      return ts.member(
         wrap`${prefixes}${trivia.base}attribute${ts.type(type(it.idlType))}${trivia.name}${name};`,
         { data: it, parent }
       );
@@ -181,7 +168,7 @@
       return wrap`${trivia.colon}:${trivia.name}${ts.inheritance(reference(inh.name))}`;
     }
 
-    function container(type, template) {
+    function container(type) {
       return it => {
         const trivia = extract_trivia(it);
         const ext = extended_attributes(it.extAttrs);
@@ -190,7 +177,7 @@
         const head = wrap`${trivia.base}${type}${trivia.name}${name}`;
         const inherit = inheritance(it.inheritance);
         const body = wrap`${trivia.open}{${iterate(it.members, it)}${trivia.close}}${trivia.termination};`;
-        return template(
+        return ts.definition(
           wrap`${ext}${partial}${head}${inherit}${body}`,
           { data: it }
         );
@@ -204,7 +191,7 @@
       const name = ts.name(it.escapedName, { data: it });
       const head = wrap`${trivia.base}interface${trivia.mixin}mixin${trivia.name}${name}`;
       const body = wrap`${trivia.open}{${iterate(it.members, it)}${trivia.close}}${trivia.termination};`;
-      return ts.mixin(
+      return ts.definition(
         wrap`${ext}${partial}${head}${body}`,
         { data: it }
       );
@@ -216,7 +203,7 @@
       const name = ts.name(it.escapedName, { data: it, parent });
       const body = wrap`${ts.type(type(it.idlType))}${trivia.name}${name}`;
       const defaultValue = default_(it.default, it);
-      return ts.field(
+      return ts.member(
         wrap`${ext}${required}${body}${defaultValue}${trivia.termination};`,
         { data: it, parent }
       );
@@ -225,7 +212,7 @@
       const trivia = extract_trivia(it);
       const ret = extended_attributes(it.extAttrs);
       const name = ts.name(it.name, { data: it, parent });
-      return ts.const(
+      return ts.member(
         wrap`${ret}${trivia.base}const${ts.type(type(it.idlType))}${trivia.name}${name}${trivia.assign}=${trivia.value}${ts.valueLiteral(const_value(it.value), it)}${trivia.termination};`,
         { data: it, parent }
       );
@@ -234,7 +221,7 @@
       const trivia = extract_trivia(it);
       const ret = extended_attributes(it.extAttrs);
       const name = ts.name(it.escapedName, { data: it });
-      return ts.typedef(
+      return ts.definition(
         wrap`${ret}${trivia.base}typedef${ts.type(type(it.idlType))}${trivia.name}${name}${trivia.termination};`,
         { data: it }
       );
@@ -244,7 +231,7 @@
       const ret = extended_attributes(it.extAttrs);
       const target = reference(it.target);
       const mixin = reference(it.includes);
-      return ts.includes(
+      return ts.definition(
         wrap`${ret}${trivia.target}${target}${trivia.includes}includes${trivia.mixin}${mixin}${trivia.termination};`,
         { data: it }
       );
@@ -256,7 +243,7 @@
       const head = wrap`${trivia.base}callback${trivia.name}${name}`;
       const args = ts.wrap(it.arguments.map(argument));
       const signature = wrap`${ts.type(type(it.idlType))}${trivia.open}(${args}${trivia.close})`;
-      return ts.callbackFunction(
+      return ts.definition(
         wrap`${ext}${head}${trivia.assign}=${signature}${trivia.termination};`,
         { data: it }
       );
@@ -266,27 +253,27 @@
       const ext = extended_attributes(it.extAttrs);
       const name = ts.name(it.escapedName, { data: it });
       const values = iterate(it.values, it);
-      return ts.enum(
+      return ts.definition(
         wrap`${ext}${trivia.base}enum${trivia.name}${name}${trivia.open}{${values}${trivia.close}}${trivia.termination};`,
         { data: it }
       );
     }
     function enum_value(v, parent) {
       return wrap`${ts.trivia(v.trivia)}${
-        ts.enumValue(`"${ts.name(v.value, { data: v, parent })}"`, { data: v, parent })
+        ts.member(`"${ts.name(v.value, { data: v, parent })}"`, { data: v, parent })
       }${token(v.separator)}`;
     }
     function iterable_like(it, parent) {
       const trivia = extract_trivia(it);
       const readonly = token(it.readonly, "readonly");
       const bracket = wrap`${trivia.open}<${ts.wrap(it.idlType.map(type))}${trivia.close}>`;
-      return ts.iterator(
+      return ts.member(
         wrap`${readonly}${trivia.base}${it.type}${bracket}${trivia.termination};`,
         { data: it, parent }
       );
     }
     function callbackInterface(it) {
-      return ts.callbackInterface(
+      return ts.definition(
         wrap`${ts.trivia(it.trivia.callback)}callback${container("interface", noop)(it)}`,
         { data: it }
       );
@@ -296,12 +283,12 @@
     }
 
     const table = {
-      interface: container("interface", ts.interface),
+      interface: container("interface"),
       "interface mixin": interface_mixin,
-      namespace: container("namespace", ts.namespace),
+      namespace: container("namespace"),
       operation,
       attribute,
-      dictionary: container("dictionary", ts.dictionary),
+      dictionary: container("dictionary"),
       field,
       const: const_,
       typedef,

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -10,6 +10,8 @@
     trivia: noop,
     name: noop,
     reference: noop,
+    type: noop,
+    valueLiteral: noop,
 
     interface: noop,
     const: noop,
@@ -27,6 +29,8 @@
     enumValue: noop,
     callbackFunction: noop,
     typedef: noop,
+
+    extendedAttribute: noop
   };
 
   function write(ast, { templates: ts = templates } = {}) {
@@ -91,7 +95,7 @@
       else if (tp === "number") return it.value;
       else return `"${it.value}"`;
     }
-    function default_(def) {
+    function default_(def, parent) {
       if (!def) {
         return "";
       }
@@ -100,15 +104,15 @@
       if (def.type === "sequence") {
         return wrap`${assign}${trivia.open}[${trivia.close}]`;
       }
-      return wrap`${assign}${trivia.value}${const_value(def)}`;
+      return wrap`${assign}${trivia.value}${ts.valueLiteral(const_value(def), parent)}`;
     }
     function argument(arg) {
       const ext = extended_attributes(arg.extAttrs);
       const optional = token(arg.optional, "optional");
-      const typePart = type(arg.idlType);
+      const typePart = ts.type(type(arg.idlType));
       const variadic = token(arg.variadic, "...");
       const name = wrap`${ts.trivia(arg.trivia.name)}${ts.name(arg.escapedName, { data: arg })}`;
-      const defaultValue = default_(arg.default);
+      const defaultValue = default_(arg.default, arg);
       const separator = token(arg.separator);
       return ts.argument(
         wrap`${ext}${optional}${typePart}${variadic}${name}${defaultValue}${separator}`,
@@ -128,7 +132,7 @@
       }
       const signature = it.signature ? wrap`${ts.trivia(it.signature.trivia.open)}(${ts.wrap(it.signature.arguments.map(argument))}${ts.trivia(it.signature.trivia.close)})` : "";
       const separator = token(it.separator);
-      return wrap`${name}${rhs}${signature}${separator}`;
+      return ts.extendedAttribute(wrap`${name}${rhs}${signature}${separator}`);
     }
     function extended_attributes(eats) {
       if (!eats) return "";
@@ -144,7 +148,7 @@
       if (it.body) {
         const { body } = it;
         const trivia = extract_trivia(it.body);
-        const typePart = type(body.idlType);
+        const typePart = ts.type(type(body.idlType));
         const name = token(body.name, body.name && ts.name(body.name.escaped, { data: it, parent }));
         const args = wrap`${trivia.open}(${ts.wrap(body.arguments.map(argument))}${trivia.close})`;
         bodyPart = wrap`${typePart}${name}${args}`;
@@ -163,7 +167,7 @@
       const name = ts.name(it.escapedName, { data: it, parent });
       const trivia = extract_trivia(it);
       return ts.attribute(
-        wrap`${prefixes}${trivia.base}attribute${type(it.idlType)}${trivia.name}${name};`,
+        wrap`${prefixes}${trivia.base}attribute${ts.type(type(it.idlType))}${trivia.name}${name};`,
         { data: it, parent }
       );
     }
@@ -209,8 +213,8 @@
       const ext = extended_attributes(it.extAttrs);
       const required = token(it.required, "required");
       const name = ts.name(it.escapedName, { data: it, parent });
-      const body = wrap`${type(it.idlType)}${trivia.name}${name}`;
-      const defaultValue = default_(it.default);
+      const body = wrap`${ts.type(type(it.idlType))}${trivia.name}${name}`;
+      const defaultValue = default_(it.default, it);
       return ts.field(
         wrap`${ext}${required}${body}${defaultValue}${trivia.termination};`,
         { data: it, parent }
@@ -221,7 +225,7 @@
       const ret = extended_attributes(it.extAttrs);
       const name = ts.name(it.name, { data: it, parent });
       return ts.const(
-        wrap`${ret}${trivia.base}const${type(it.idlType)}${trivia.name}${name}${trivia.assign}=${trivia.value}${const_value(it.value)}${trivia.termination};`,
+        wrap`${ret}${trivia.base}const${ts.type(type(it.idlType))}${trivia.name}${name}${trivia.assign}=${trivia.value}${ts.valueLiteral(const_value(it.value), it)}${trivia.termination};`,
         { data: it, parent }
       );
     }
@@ -230,7 +234,7 @@
       const ret = extended_attributes(it.extAttrs);
       const name = ts.name(it.escapedName, { data: it });
       return ts.typedef(
-        wrap`${ret}${trivia.base}typedef${type(it.idlType)}${trivia.name}${name}${trivia.termination};`,
+        wrap`${ret}${trivia.base}typedef${ts.type(type(it.idlType))}${trivia.name}${name}${trivia.termination};`,
         { data: it }
       );
     }
@@ -250,7 +254,7 @@
       const name = ts.name(it.name, { data: it });
       const head = wrap`${trivia.base}callback${trivia.name}${name}`;
       const args = ts.wrap(it.arguments.map(argument));
-      const signature = wrap`${type(it.idlType)}${trivia.open}(${args}${trivia.close})`;
+      const signature = wrap`${ts.type(type(it.idlType))}${trivia.open}(${args}${trivia.close})`;
       return ts.callbackFunction(
         wrap`${ext}${head}${trivia.assign}=${signature}${trivia.termination};`,
         { data: it }

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -152,7 +152,7 @@
       const name = ts.name(it.escapedName, { data: it, parent });
       const trivia = extract_trivia(it);
       return ts.definition(
-        wrap`${prefixes}${trivia.base}attribute${ts.type(type(it.idlType))}${trivia.name}${name};`,
+        wrap`${prefixes}${trivia.base}attribute${ts.type(type(it.idlType))}${trivia.name}${name}${trivia.termination};`,
         { data: it, parent }
       );
     }

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -16,7 +16,8 @@
 
     definition: noop,
 
-    extendedAttribute: noop
+    extendedAttribute: noop,
+    extendedAttributeReference: noop
   };
 
   function write(ast, { templates: ts = templates } = {}) {
@@ -106,7 +107,7 @@
       return wrap`${ts.trivia(id.trivia)}${reference(id.value)}${token(id.separator)}`;
     }
     function make_ext_at(it) {
-      const name = wrap`${ts.trivia(it.trivia.name)}${reference(it.name)}`;
+      const name = wrap`${ts.trivia(it.trivia.name)}${ts.extendedAttributeReference(it.name)}`;
       let rhs = "";
       if (it.rhs) {
         const trivia = extract_trivia(it.rhs);

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -1,23 +1,32 @@
 "use strict";
 
 (() => {
-  /**
-   * @param {any[]} items
-   */
-  function noopTag(items) {
-    return items.join("");
-  }
-
   function noop(arg) {
     return arg;
   }
 
   const templates = {
-    wrap: noopTag,
+    wrap: items => items.join(""),
     trivia: noop,
     name: noop,
     reference: noop,
-    includes: noop
+
+    interface: noop,
+    const: noop,
+    operation: noop,
+    argument: noop,
+    attribute: noop,
+    iterator: noop,
+    callbackInterface: noop,
+    mixin: noop,
+    includes: noop,
+    namespace: noop,
+    dictionary: noop,
+    field: noop,
+    enum: noop,
+    enumValue: noop,
+    callbackFunction: noop,
+    typedef: noop,
   };
 
   function write(ast, { templates: ts = templates } = {}) {
@@ -71,7 +80,7 @@
       else if (tp === "Infinity") return (it.negative ? "-" : "") + "Infinity";
       else if (tp === "NaN") return "NaN";
       else if (tp === "number") return it.value;
-      else return wrap`"${it.value}"`;
+      else return `"${it.value}"`;
     }
     function default_(def) {
       if (!def) {
@@ -92,7 +101,10 @@
       const name = wrap`${ts.trivia(arg.trivia.name)}${ts.name(arg.escapedName)}`;
       const defaultValue = default_(arg.default);
       const separator = token(arg.separator);
-      return wrap`${ext}${optional}${typePart}${variadic}${name}${defaultValue}${separator}`;
+      return ts.argument(
+        wrap`${ext}${optional}${typePart}${variadic}${name}${defaultValue}${separator}`,
+        { data: arg }
+      );
     }
     function identifier(id) {
       return wrap`${ts.trivia(id.trivia)}${ts.reference(id.value)}${token(id.separator)}`;
@@ -116,7 +128,7 @@
       return wrap`${trivia.open}[${members}${trivia.close}]`;
     }
 
-    function operation(it) {
+    function operation(it, parent) {
       const ext = extended_attributes(it.extAttrs);
       const modifier = token(it.special);
       let bodyPart = "";
@@ -128,17 +140,23 @@
         const args = wrap`${trivia.open}(${ts.wrap(body.arguments.map(argument))}${trivia.close})`;
         bodyPart = wrap`${typePart}${name}${args}`;
       }
-      return wrap`${ext}${modifier}${bodyPart}${ts.trivia(it.trivia.termination)};`;
+      return ts.operation(
+        wrap`${ext}${modifier}${bodyPart}${ts.trivia(it.trivia.termination)};`,
+        { data: it, parent }
+      );
     }
 
-    function attribute(it) {
+    function attribute(it, parent) {
       const ext = extended_attributes(it.extAttrs);
       const special = token(it.special);
       const readonly = token(it.readonly, "readonly");
       const prefixes = wrap`${ext}${special}${readonly}`;
       const name = ts.name(it.escapedName);
       const trivia = extract_trivia(it);
-      return wrap`${prefixes}${trivia.base}attribute${type(it.idlType)}${trivia.name}${name};`;
+      return ts.attribute(
+        wrap`${prefixes}${trivia.base}attribute${type(it.idlType)}${trivia.name}${name};`,
+        { data: it, parent }
+      );
     }
 
     function inheritance(inh) {
@@ -149,7 +167,7 @@
       return wrap`${trivia.colon}:${trivia.name}${ts.reference(inh.name)}`;
     }
 
-    function container(type) {
+    function container(type, template) {
       return it => {
         const trivia = extract_trivia(it);
         const ext = extended_attributes(it.extAttrs);
@@ -157,8 +175,11 @@
         const name = ts.name(it.escapedName);
         const head = wrap`${trivia.base}${type}${trivia.name}${name}`;
         const inherit = inheritance(it.inheritance);
-        const body = wrap`${trivia.open}{${iterate(it.members)}${trivia.close}}${trivia.termination};`;
-        return wrap`${ext}${partial}${head}${inherit}${body}`;
+        const body = wrap`${trivia.open}{${iterate(it.members, it)}${trivia.close}}${trivia.termination};`;
+        return template(
+          wrap`${ext}${partial}${head}${inherit}${body}`,
+          { data: it }
+        );
       };
     }
 
@@ -168,29 +189,41 @@
       const partial = token(it.partial, "partial");
       const name = ts.name(it.escapedName);
       const head = wrap`${trivia.base}interface${trivia.mixin}mixin${trivia.name}${name}`;
-      const body = wrap`${trivia.open}{${iterate(it.members)}${trivia.close}}${trivia.termination};`;
-      return wrap`${ext}${partial}${head}${body}`;
+      const body = wrap`${trivia.open}{${iterate(it.members, it)}${trivia.close}}${trivia.termination};`;
+      return ts.mixin(
+        wrap`${ext}${partial}${head}${body}`,
+        { data: it }
+      );
     }
-    function field(it) {
+    function field(it, parent) {
       const trivia = extract_trivia(it);
       const ext = extended_attributes(it.extAttrs);
       const required = token(it.required, "required");
       const name = ts.name(it.escapedName);
       const body = wrap`${type(it.idlType)}${trivia.name}${name}`;
       const defaultValue = default_(it.default);
-      return wrap`${ext}${required}${body}${defaultValue}${trivia.termination};`;
+      return ts.field(
+        wrap`${ext}${required}${body}${defaultValue}${trivia.termination};`,
+        { data: it, parent }
+      );
     }
-    function const_(it) {
+    function const_(it, parent) {
       const trivia = extract_trivia(it);
       const ret = extended_attributes(it.extAttrs);
       const name = ts.name(it.name);
-      return wrap`${ret}${trivia.base}const${type(it.idlType)}${trivia.name}${name}${trivia.assign}=${trivia.value}${const_value(it.value)}${trivia.termination};`;
+      return ts.const(
+        wrap`${ret}${trivia.base}const${type(it.idlType)}${trivia.name}${name}${trivia.assign}=${trivia.value}${const_value(it.value)}${trivia.termination};`,
+        { data: it, parent }
+      );
     }
     function typedef(it) {
       const trivia = extract_trivia(it);
       const ret = extended_attributes(it.extAttrs);
       const name = ts.name(it.escapedName);
-      return wrap`${ret}${trivia.base}typedef${type(it.idlType)}${trivia.name}${name}${trivia.termination};`;
+      return ts.typedef(
+        wrap`${ret}${trivia.base}typedef${type(it.idlType)}${trivia.name}${name}${trivia.termination};`,
+        { data: it }
+      );
     }
     function includes(it) {
       const trivia = extract_trivia(it);
@@ -198,7 +231,8 @@
       const target = ts.reference(it.target);
       const mixin = ts.reference(it.includes);
       return ts.includes(
-        wrap`${ret}${trivia.target}${target}${trivia.includes}includes${trivia.mixin}${mixin}${trivia.termination};`
+        wrap`${ret}${trivia.target}${target}${trivia.includes}includes${trivia.mixin}${mixin}${trivia.termination};`,
+        { data: it }
       );
     }
     function callback(it) {
@@ -208,38 +242,53 @@
       const head = wrap`${trivia.base}callback${trivia.name}${name}`;
       const args = ts.wrap(it.arguments.map(argument));
       const signature = wrap`${type(it.idlType)}${trivia.open}(${args}${trivia.close})`;
-      return wrap`${ext}${head}${trivia.assign}=${signature}${trivia.termination};`;
+      return ts.callbackFunction(
+        wrap`${ext}${head}${trivia.assign}=${signature}${trivia.termination};`,
+        { data: it }
+      );
     }
     function enum_(it) {
       const trivia = extract_trivia(it);
       const ext = extended_attributes(it.extAttrs);
       const name = ts.name(it.escapedName);
-      const values = iterate(it.values);
-      return wrap`${ext}${trivia.base}enum${trivia.name}${name}${trivia.open}{${values}${trivia.close}}${trivia.termination};`;
+      const values = iterate(it.values, it);
+      return ts.enum(
+        wrap`${ext}${trivia.base}enum${trivia.name}${name}${trivia.open}{${values}${trivia.close}}${trivia.termination};`,
+        { data: it }
+      );
     }
-    function enum_value(v) {
-      return wrap`${ts.trivia(v.trivia)}"${ts.name(v.value)}"${token(v.separator)}`;
+    function enum_value(v, parent) {
+      return ts.enumValue(
+        wrap`${ts.trivia(v.trivia)}"${ts.name(v.value)}"${token(v.separator)}`,
+        { data: it, parent }
+      );
     }
-    function iterable_like(it) {
+    function iterable_like(it, parent) {
       const trivia = extract_trivia(it);
       const readonly = token(it.readonly, "readonly");
       const bracket = wrap`${trivia.open}<${ts.wrap(it.idlType.map(type))}${trivia.close}>`;
-      return wrap`${readonly}${trivia.base}${it.type}${bracket}${trivia.termination};`;
+      return ts.iterator(
+        wrap`${readonly}${trivia.base}${it.type}${bracket}${trivia.termination};`,
+        { data: it, parent }
+      );
     }
     function callbackInterface(it) {
-      return wrap`${ts.trivia(it.trivia.callback)}callback${container("interface")(it)}`;
+      return ts.callbackInterface(
+        wrap`${ts.trivia(it.trivia.callback)}callback${container("interface", noop)(it)}`,
+        { data: it }
+      );
     }
     function eof(it) {
       return ts.trivia(it.trivia);
     }
 
     const table = {
-      interface: container("interface"),
+      interface: container("interface", ts.interface),
       "interface mixin": interface_mixin,
-      namespace: container("namespace"),
+      namespace: container("namespace", ts.namespace),
       operation,
       attribute,
-      dictionary: container("dictionary"),
+      dictionary: container("dictionary", ts.dictionary),
       field,
       const: const_,
       typedef,
@@ -254,16 +303,16 @@
       "callback interface": callbackInterface,
       eof
     };
-    function dispatch(it) {
+    function dispatch(it, parent) {
       const dispatcher = table[it.type];
       if (!dispatcher) {
         throw new Error(`Type "${it.type}" is unsupported`);
       }
-      return table[it.type](it);
+      return table[it.type](it, parent);
     }
-    function iterate(things) {
+    function iterate(things, parent) {
       if (!things) return;
-      const results = things.map(dispatch);
+      const results = things.map(thing => dispatch(thing, parent));
       return ts.wrap(results);
     }
     return iterate(ast);

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -9,10 +9,6 @@
     return strings.map((s, i) => s + (args[i] || "")).join("");
   }
 
-  function noopArray(args) {
-    return args.join("");
-  }
-
   function noop(arg) {
     return arg;
   }
@@ -23,17 +19,12 @@
     includes: noop
   };
 
-  /**
-   * @param {any[]} args 
-   */
-  function arrayToStringTagAdapter(args) {
-    return [
-      new Array(args.length + 1).fill(""),
-      ...args
-    ];
-  }
   function write(ast, { templates: ts = templates } = {}) {
-    ts = { ...templates, ...ts };
+    ts = Object.assign({}, templates, ts);
+
+    function collect(args) {
+      return ts.wrap(new Array(args.length + 1).fill(""), ...args);
+    }
 
     function token(t, value) {
       return t ? t.trivia + (value || t.escaped || t.value) : "";
@@ -41,17 +32,16 @@
 
     function type_body(it) {
       if (it.union) {
-        const subtypes = it.idlType.map(type).join("");
+        const subtypes = collect(it.idlType.map(type));
         return ts.wrap`${it.trivia.open}(${subtypes}${it.trivia.close})`;
       } else if (it.generic) {
-        const genericName = ts.wrap`${it.trivia.base}${it.generic.value}`;
-        const subtypes = it.idlType.map(type).join("");
+        const genericName = ts.wrap`${it.trivia.base}${ts.name(it.generic.value)}`;
+        const subtypes = collect(it.idlType.map(type));
         const { trivia } = it.generic;
-        const bracket = ts.wrap`${trivia.open}<${subtypes}${trivia.close}>`;
-        return ts.wrap`${genericName}${bracket}`;
+        return ts.wrap`${genericName}${trivia.open}<${subtypes}${trivia.close}>`;
       }
       const prefix = token(it.prefix);
-      const base = it.trivia.base + it.baseName;
+      const base = ts.wrap`${it.trivia.base}${ts.name(it.baseName)}`;
       const postfix = token(it.postfix);
       return ts.wrap`${prefix}${base}${postfix}`;
     }
@@ -82,80 +72,85 @@
       return ts.wrap`${assign}${def.trivia.value}${const_value(def)}`;
     }
     function argument(arg) {
-      let ret = extended_attributes(arg.extAttrs);
-      ret += token(arg.optional, "optional");
-      ret += type(arg.idlType);
-      ret += token(arg.variadic, "...");
-      ret += ts.wrap`${arg.trivia.name}${arg.escapedName}`;
-      ret += default_(arg.default);
-      ret += token(arg.separator);
-      return ret;
+      const ext = extended_attributes(arg.extAttrs);
+      const optional = token(arg.optional, "optional");
+      const typePart = type(arg.idlType);
+      const variadic = token(arg.variadic, "...");
+      const name = ts.wrap`${arg.trivia.name}${ts.name(arg.escapedName)}`;
+      const defaultValue = default_(arg.default);
+      const separator = token(arg.separator);
+      return ts.wrap`${ext}${optional}${typePart}${variadic}${name}${defaultValue}${separator}`;
     }
     function identifier(id) {
-      return id.trivia + id.value + token(id.separator);
+      return ts.wrap`${id.trivia}${ts.name(id.value)}${token(id.separator)}`;
     }
     function make_ext_at(it) {
-      let ret = it.trivia.name + it.name;
+      const name = ts.wrap`${it.trivia.name}${ts.name(it.name)}`;
+      let rhs = "";
       if (it.rhs) {
-        if (it.rhs.type === "identifier-list") ret += ts.wrap`${it.rhs.trivia.assign}=${it.rhs.trivia.open}(${it.rhs.value.map(identifier).join("")}${it.rhs.trivia.close})`;
-        else ret += ts.wrap`${it.rhs.trivia.assign}=${it.rhs.trivia.value}${it.rhs.value}`;
+        if (it.rhs.type === "identifier-list") rhs = ts.wrap`${it.rhs.trivia.assign}=${it.rhs.trivia.open}(${collect(it.rhs.value.map(identifier))}${it.rhs.trivia.close})`;
+        else rhs = ts.wrap`${it.rhs.trivia.assign}=${it.rhs.trivia.value}${ts.name(it.rhs.value)}`;
       }
-      if (it.signature) ret += ts.wrap`${it.signature.trivia.open}(${it.signature.arguments.map(argument).join("")}${it.signature.trivia.close})`;
-      ret += token(it.separator);
-      return ret;
+      const signature = it.signature ? ts.wrap`${it.signature.trivia.open}(${collect(it.signature.arguments.map(argument))}${it.signature.trivia.close})` : "";
+      const separator = token(it.separator);
+      return ts.wrap`${name}${rhs}${signature}${separator}`;
     }
     function extended_attributes(eats) {
       if (!eats) return "";
-      return ts.wrap`${eats.trivia.open}[${eats.items.map(make_ext_at).join("")}${eats.trivia.close}]`;
+      const members = collect(eats.items.map(make_ext_at));
+      return ts.wrap`${eats.trivia.open}[${members}${eats.trivia.close}]`;
     }
 
     function operation(it) {
-      let ret = extended_attributes(it.extAttrs);
-      ret += token(it.special);
+      const ext = extended_attributes(it.extAttrs);
+      const modifier = token(it.special);
+      let bodyPart = "";
       if (it.body) {
         const { body } = it;
-        ret += type(body.idlType);
-        ret += token(body.name);
-        ret += ts.wrap`${body.trivia.open}(${body.arguments.map(argument).join("")}${body.trivia.close})`;
+        const typePart = type(body.idlType);
+        const name = body.name ? ts.wrap`${body.name.trivia}${ts.name(body.name.escaped)}` : "";
+        const args = ts.wrap`${body.trivia.open}(${body.arguments.map(argument).join("")}${body.trivia.close})`;
+        bodyPart = ts.wrap`${typePart}${name}${args}`;
       }
-      ret += it.trivia.termination + ";";
-      return ret;
+      return ts.wrap`${ext}${modifier}${bodyPart}${it.trivia.termination};`;
     }
 
     function attribute(it) {
-      let ret = extended_attributes(it.extAttrs);
-      ret += token(it.special);
-      ret += token(it.readonly, "readonly");
-      ret += ts.wrap`${it.trivia.base}attribute${type(it.idlType)}${it.trivia.name}${it.escapedName};`;
-      return ret;
+      const ext = extended_attributes(it.extAttrs);
+      const special = token(it.special);
+      const readonly = token(it.readonly, "readonly");
+      const prefixes = ts.wrap`${ext}${special}${readonly}`;
+      const name = ts.name(it.escapedName);
+      return ts.wrap`${prefixes}${it.trivia.base}attribute${type(it.idlType)}${it.trivia.name}${name};`;
     }
 
     function inheritance(inh) {
       if (!inh) {
         return "";
       }
-      return ts.wrap`${inh.trivia.colon}:${inh.trivia.name}${inh.name}`;
+      return ts.wrap`${inh.trivia.colon}:${inh.trivia.name}${ts.name(inh.name)}`;
     }
 
     function container(type) {
       return it => {
-        let ret = extended_attributes(it.extAttrs);
-        ret += token(it.partial, "partial");
-        ret += ts.wrap`${it.trivia.base}${type}${it.trivia.name}${it.escapedName}`;
-        ret += inheritance(it.inheritance);
-        ret += ts.wrap`${it.trivia.open}{${iterate(it.members)}${it.trivia.close}}${it.trivia.termination};`;
-        return ret;
+        const ext = extended_attributes(it.extAttrs);
+        const partial = token(it.partial, "partial");
+        const name = ts.name(it.escapedName);
+        const head = ts.wrap`${it.trivia.base}${type}${it.trivia.name}${name}`;
+        const inherit = inheritance(it.inheritance);
+        const body = ts.wrap`${it.trivia.open}{${iterate(it.members)}${it.trivia.close}}${it.trivia.termination};`;
+        return ts.wrap`${ext}${partial}${head}${inherit}${body}`;
       };
     }
 
     function interface_mixin(it) {
-      let ret = extended_attributes(it.extAttrs);
-      ret += token(it.partial, "partial");
-      ret += ts.wrap`${it.trivia.base}interface${it.trivia.mixin}mixin${it.trivia.name}${it.escapedName}`;
-      ret += ts.wrap`${it.trivia.open}{${iterate(it.members)}${it.trivia.close}}${it.trivia.termination};`;
-      return ret;
+      const ext = extended_attributes(it.extAttrs);
+      const partial = token(it.partial, "partial");
+      const name = ts.name(it.escapedName);
+      const head = ts.wrap`${it.trivia.base}interface${it.trivia.mixin}mixin${it.trivia.name}${name}`;
+      const body = ts.wrap`${it.trivia.open}{${iterate(it.members)}${it.trivia.close}}${it.trivia.termination};`;
+      return ts.wrap`${ext}${partial}${head}${body}`;
     }
-
     function field(it) {
       const ext = extended_attributes(it.extAttrs);
       const required = token(it.required, "required");
@@ -179,24 +174,25 @@
       const target = ts.name(it.target);
       const mixin = ts.name(it.includes);
       return ts.includes(
-        it,
-        ts.wrap
-          `${ret}${it.trivia.target}${target}${it.trivia.includes}includes${it.trivia.mixin}${mixin}${it.trivia.termination};`
+        ts.wrap`${ret}${it.trivia.target}${target}${it.trivia.includes}includes${it.trivia.mixin}${mixin}${it.trivia.termination};`
       );
     }
     function callback(it) {
       const ext = extended_attributes(it.extAttrs);
-      const head = ts.wrap`${it.trivia.base}callback${it.trivia.name}${it.name}`;
+      const name = ts.name(it.name);
+      const head = ts.wrap`${it.trivia.base}callback${it.trivia.name}${name}`;
       const args = it.arguments.map(argument).join("");
       const signature = ts.wrap`${type(it.idlType)}${it.trivia.open}(${args}${it.trivia.close})`;
       return ts.wrap`${ext}${head}${it.trivia.assign}=${signature}${it.trivia.termination};`;
     }
     function enum_(it) {
       const ext = extended_attributes(it.extAttrs);
-      const values = it.values.map(
-        v => ts.wrap`${v.trivia}"${v.value}"${token(v.separator)}`
-      ).join("");
-      return ts.wrap`${ext}${it.trivia.base}enum${it.trivia.name}${it.escapedName}${it.trivia.open}{${values}${it.trivia.close}}${it.trivia.termination};`;
+      const name = ts.name(it.escapedName);
+      const values = iterate(it.values);
+      return ts.wrap`${ext}${it.trivia.base}enum${it.trivia.name}${name}${it.trivia.open}{${values}${it.trivia.close}}${it.trivia.termination};`;
+    }
+    function enum_value(v) {
+      return ts.wrap`${v.trivia}"${ts.name(v.value)}"${token(v.separator)}`;
     }
     function iterable_like(it) {
       const readonly = it.readonly ? ts.wrap`${it.readonly.trivia}readonly` : "";
@@ -223,6 +219,7 @@
       includes,
       callback,
       enum: enum_,
+      "enum-value": enum_value,
       iterable: iterable_like,
       legacyiterable: iterable_like,
       maplike: iterable_like,
@@ -240,7 +237,7 @@
     function iterate(things) {
       if (!things) return;
       const results = things.map(dispatch);
-      return ts.wrap(...arrayToStringTagAdapter(results));
+      return collect(results);
     }
     return iterate(ast);
   }

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -13,9 +13,7 @@
     type: noop,
     valueLiteral: noop,
     inheritance: noop,
-
     definition: noop,
-
     extendedAttribute: noop,
     extendedAttributeReference: noop
   };
@@ -111,8 +109,9 @@
       let rhs = "";
       if (it.rhs) {
         const trivia = extract_trivia(it.rhs);
-        if (it.rhs.type === "identifier-list") rhs = wrap`${trivia.assign}=${trivia.open}(${ts.wrap(it.rhs.value.map(identifier))}${trivia.close})`;
-        else rhs = wrap`${trivia.assign}=${trivia.value}${reference(it.rhs.value)}`;
+        rhs = (it.rhs.type === "identifier-list") ? 
+          wrap`${trivia.assign}=${trivia.open}(${ts.wrap(it.rhs.value.map(identifier))}${trivia.close})` : 
+          wrap`${trivia.assign}=${trivia.value}${reference(it.rhs.value)}`;
       }
       const signature = it.signature ? wrap`${ts.trivia(it.signature.trivia.open)}(${ts.wrap(it.signature.arguments.map(argument))}${ts.trivia(it.signature.trivia.close)})` : "";
       const separator = token(it.separator);
@@ -133,7 +132,9 @@
         const { body } = it;
         const trivia = extract_trivia(it.body);
         const typePart = ts.type(type(body.idlType));
-        const name = token(body.name, body.name && ts.name(body.name.escaped, { data: it, parent }));
+        const name = body.name ?
+          token(body.name, ts.name(body.name.escaped, { data: it, parent })) :
+          "";
         const args = wrap`${trivia.open}(${ts.wrap(body.arguments.map(argument))}${trivia.close})`;
         bodyPart = wrap`${typePart}${name}${args}`;
       }
@@ -172,12 +173,16 @@
         const name = ts.name(it.escapedName, { data: it });
         const head = wrap`${trivia.base}${type}${trivia.name}${name}`;
         const inherit = inheritance(it.inheritance);
-        const body = wrap`${trivia.open}{${iterate(it.members, it)}${trivia.close}}${trivia.termination};`;
+        const body = brace_body(trivia, iterate(it.members, it));
         return ts.definition(
           wrap`${ext}${partial}${head}${inherit}${body}`,
           { data: it }
         );
       };
+    }
+
+    function brace_body(trivia, members) {
+      return wrap`${trivia.open}{${members}${trivia.close}}${trivia.termination};`;
     }
 
     function interface_mixin(it) {
@@ -186,7 +191,7 @@
       const partial = token(it.partial, "partial");
       const name = ts.name(it.escapedName, { data: it });
       const head = wrap`${trivia.base}interface${trivia.mixin}mixin${trivia.name}${name}`;
-      const body = wrap`${trivia.open}{${iterate(it.members, it)}${trivia.close}}${trivia.termination};`;
+      const body = brace_body(trivia, iterate(it.members, it));
       return ts.definition(
         wrap`${ext}${partial}${head}${body}`,
         { data: it }
@@ -206,10 +211,12 @@
     }
     function const_(it, parent) {
       const trivia = extract_trivia(it);
-      const ret = extended_attributes(it.extAttrs);
+      const ext = extended_attributes(it.extAttrs);
       const name = ts.name(it.name, { data: it, parent });
+      const head = wrap`${trivia.base}const${ts.type(type(it.idlType))}${trivia.name}${name}`;
+      const assign = wrap`${trivia.assign}=${trivia.value}${ts.valueLiteral(const_value(it.value), it)}`;
       return ts.definition(
-        wrap`${ret}${trivia.base}const${ts.type(type(it.idlType))}${trivia.name}${name}${trivia.assign}=${trivia.value}${ts.valueLiteral(const_value(it.value), it)}${trivia.termination};`,
+        wrap`${ext}${head}${assign}${trivia.termination};`,
         { data: it, parent }
       );
     }
@@ -250,7 +257,7 @@
       const name = ts.name(it.escapedName, { data: it });
       const values = iterate(it.values, it);
       return ts.definition(
-        wrap`${ext}${trivia.base}enum${trivia.name}${name}${trivia.open}{${values}${trivia.close}}${trivia.termination};`,
+        wrap`${ext}${trivia.base}enum${trivia.name}${name}${brace_body(trivia, values)}`,
         { data: it }
       );
     }

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -39,6 +39,10 @@
     function wrap(strings, ...args) {
       return ts.wrap([].concat(...strings.map((s, i) => [s, args[i] || ""])));
     }
+    
+    function reference(wrapped, normalized) {
+      return ts.reference(wrapped, normalized || wrapped);
+    }
 
     function extract_trivia(object) {
       const batch = {};
@@ -58,18 +62,18 @@
         const subtypes = ts.wrap(it.idlType.map(type));
         return wrap`${trivia.open}(${subtypes}${trivia.close})`;
       } else if (it.generic) {
-        const genericName = wrap`${trivia.base}${ts.reference(it.generic.value)}`;
+        const genericName = wrap`${trivia.base}${reference(it.generic.value)}`;
         const subtypes = ts.wrap(it.idlType.map(type));
         const gTrivia = it.generic;
         return wrap`${genericName}${gTrivia.open}<${subtypes}${gTrivia.close}>`;
       }
       if (!it.prefix && !it.postfix) {
-        return wrap`${trivia.base}${ts.reference(it.baseName)}`;
+        return wrap`${trivia.base}${reference(it.baseName)}`;
       }
       const precedingTrivia = it.prefix ? ts.trivia(it.prefix.trivia) : trivia.base;
       const prefix = it.prefix ? wrap`${it.prefix.value}${trivia.base}` : "";
-      const reference = ts.reference(wrap`${prefix}${it.baseName}${token(it.postfix)}`, it.idlType);
-      return wrap`${precedingTrivia}${reference}`;
+      const ref = reference(wrap`${prefix}${it.baseName}${token(it.postfix)}`, it.idlType);
+      return wrap`${precedingTrivia}${ref}`;
     }
     function type(it) {
       const ext = extended_attributes(it.extAttrs);
@@ -112,15 +116,15 @@
       );
     }
     function identifier(id) {
-      return wrap`${ts.trivia(id.trivia)}${ts.reference(id.value)}${token(id.separator)}`;
+      return wrap`${ts.trivia(id.trivia)}${reference(id.value)}${token(id.separator)}`;
     }
     function make_ext_at(it) {
-      const name = wrap`${ts.trivia(it.trivia.name)}${ts.reference(it.name)}`;
+      const name = wrap`${ts.trivia(it.trivia.name)}${reference(it.name)}`;
       let rhs = "";
       if (it.rhs) {
         const trivia = extract_trivia(it.rhs);
         if (it.rhs.type === "identifier-list") rhs = wrap`${trivia.assign}=${trivia.open}(${ts.wrap(it.rhs.value.map(identifier))}${trivia.close})`;
-        else rhs = wrap`${trivia.assign}=${trivia.value}${ts.reference(it.rhs.value)}`;
+        else rhs = wrap`${trivia.assign}=${trivia.value}${reference(it.rhs.value)}`;
       }
       const signature = it.signature ? wrap`${ts.trivia(it.signature.trivia.open)}(${ts.wrap(it.signature.arguments.map(argument))}${ts.trivia(it.signature.trivia.close)})` : "";
       const separator = token(it.separator);
@@ -169,7 +173,7 @@
         return "";
       }
       const trivia = extract_trivia(inh);
-      return wrap`${trivia.colon}:${trivia.name}${ts.reference(inh.name)}`;
+      return wrap`${trivia.colon}:${trivia.name}${reference(inh.name)}`;
     }
 
     function container(type, template) {
@@ -233,8 +237,8 @@
     function includes(it) {
       const trivia = extract_trivia(it);
       const ret = extended_attributes(it.extAttrs);
-      const target = ts.reference(it.target);
-      const mixin = ts.reference(it.includes);
+      const target = reference(it.target);
+      const mixin = reference(it.includes);
       return ts.includes(
         wrap`${ret}${trivia.target}${target}${trivia.includes}includes${trivia.mixin}${mixin}${trivia.termination};`,
         { data: it }

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -15,8 +15,6 @@
     inheritance: noop,
 
     definition: noop,
-    member: noop,
-    argument: noop,
 
     extendedAttribute: noop
   };
@@ -102,10 +100,7 @@
       const name = wrap`${ts.trivia(arg.trivia.name)}${ts.name(arg.escapedName, { data: arg })}`;
       const defaultValue = default_(arg.default, arg);
       const separator = token(arg.separator);
-      return ts.argument(
-        wrap`${ext}${optional}${typePart}${variadic}${name}${defaultValue}${separator}`,
-        { data: arg }
-      );
+      return wrap`${ext}${optional}${typePart}${variadic}${name}${defaultValue}${separator}`;
     }
     function identifier(id) {
       return wrap`${ts.trivia(id.trivia)}${reference(id.value)}${token(id.separator)}`;
@@ -141,7 +136,7 @@
         const args = wrap`${trivia.open}(${ts.wrap(body.arguments.map(argument))}${trivia.close})`;
         bodyPart = wrap`${typePart}${name}${args}`;
       }
-      return ts.member(
+      return ts.definition(
         wrap`${ext}${modifier}${bodyPart}${ts.trivia(it.trivia.termination)};`,
         { data: it, parent }
       );
@@ -154,7 +149,7 @@
       const prefixes = wrap`${ext}${special}${readonly}`;
       const name = ts.name(it.escapedName, { data: it, parent });
       const trivia = extract_trivia(it);
-      return ts.member(
+      return ts.definition(
         wrap`${prefixes}${trivia.base}attribute${ts.type(type(it.idlType))}${trivia.name}${name};`,
         { data: it, parent }
       );
@@ -203,7 +198,7 @@
       const name = ts.name(it.escapedName, { data: it, parent });
       const body = wrap`${ts.type(type(it.idlType))}${trivia.name}${name}`;
       const defaultValue = default_(it.default, it);
-      return ts.member(
+      return ts.definition(
         wrap`${ext}${required}${body}${defaultValue}${trivia.termination};`,
         { data: it, parent }
       );
@@ -212,7 +207,7 @@
       const trivia = extract_trivia(it);
       const ret = extended_attributes(it.extAttrs);
       const name = ts.name(it.name, { data: it, parent });
-      return ts.member(
+      return ts.definition(
         wrap`${ret}${trivia.base}const${ts.type(type(it.idlType))}${trivia.name}${name}${trivia.assign}=${trivia.value}${ts.valueLiteral(const_value(it.value), it)}${trivia.termination};`,
         { data: it, parent }
       );
@@ -260,14 +255,14 @@
     }
     function enum_value(v, parent) {
       return wrap`${ts.trivia(v.trivia)}${
-        ts.member(`"${ts.name(v.value, { data: v, parent })}"`, { data: v, parent })
+        ts.definition(`"${ts.name(v.value, { data: v, parent })}"`, { data: v, parent })
       }${token(v.separator)}`;
     }
     function iterable_like(it, parent) {
       const trivia = extract_trivia(it);
       const readonly = token(it.readonly, "readonly");
       const bracket = wrap`${trivia.open}<${ts.wrap(it.idlType.map(type))}${trivia.close}>`;
-      return ts.member(
+      return ts.definition(
         wrap`${readonly}${trivia.base}${it.type}${bracket}${trivia.termination};`,
         { data: it, parent }
       );

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -12,6 +12,7 @@
     reference: noop,
     type: noop,
     valueLiteral: noop,
+    inheritance: noop,
 
     interface: noop,
     const: noop,
@@ -177,7 +178,7 @@
         return "";
       }
       const trivia = extract_trivia(inh);
-      return wrap`${trivia.colon}:${trivia.name}${reference(inh.name)}`;
+      return wrap`${trivia.colon}:${trivia.name}${ts.inheritance(reference(inh.name))}`;
     }
 
     function container(type, template) {

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -63,8 +63,13 @@
         const gTrivia = it.generic;
         return wrap`${genericName}${gTrivia.open}<${subtypes}${gTrivia.close}>`;
       }
-      const base = wrap`${trivia.base}${ts.reference(it.baseName)}`;
-      return wrap`${token(it.prefix)}${base}${token(it.postfix)}`;
+      if (!it.prefix && !it.postfix) {
+        return wrap`${trivia.base}${ts.reference(it.baseName)}`;
+      }
+      const precedingTrivia = it.prefix ? ts.trivia(it.prefix.trivia) : trivia.base;
+      const prefix = it.prefix ? wrap`${it.prefix.value}${trivia.base}` : "";
+      const reference = ts.reference(wrap`${prefix}${it.baseName}${token(it.postfix)}`, it.idlType);
+      return wrap`${precedingTrivia}${reference}`;
     }
     function type(it) {
       const ext = extended_attributes(it.extAttrs);

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -2,11 +2,10 @@
 
 (() => {
   /**
-   * @param {string[]} strings 
-   * @param  {...any} args 
+   * @param {any[]} items
    */
-  function noopTag(strings, ...args) {
-    return strings.map((s, i) => s + (args[i] || "")).join("");
+  function noopTag(items) {
+    return items.join("");
   }
 
   function noop(arg) {
@@ -24,8 +23,12 @@
   function write(ast, { templates: ts = templates } = {}) {
     ts = Object.assign({}, templates, ts);
 
-    function collect(args) {
-      return ts.wrap(new Array(args.length + 1).fill(""), ...args);
+    /**
+     * @param {string[]} strings 
+     * @param  {...any} args 
+     */
+    function wrap(strings, ...args) {
+      return ts.wrap([].concat(...strings.map((s, i) => [s, args[i] || ""])));
     }
 
     function extract_trivia(object) {
@@ -37,29 +40,29 @@
     }
 
     function token(t, value) {
-      return t ? ts.wrap`${ts.trivia(t.trivia)}${value || t.value}` : "";
+      return t ? wrap`${ts.trivia(t.trivia)}${value || t.value}` : "";
     }
 
     function type_body(it) {
       const trivia = extract_trivia(it);
       if (it.union) {
-        const subtypes = collect(it.idlType.map(type));
-        return ts.wrap`${trivia.open}(${subtypes}${trivia.close})`;
+        const subtypes = ts.wrap(it.idlType.map(type));
+        return wrap`${trivia.open}(${subtypes}${trivia.close})`;
       } else if (it.generic) {
-        const genericName = ts.wrap`${trivia.base}${ts.reference(it.generic.value)}`;
-        const subtypes = collect(it.idlType.map(type));
+        const genericName = wrap`${trivia.base}${ts.reference(it.generic.value)}`;
+        const subtypes = ts.wrap(it.idlType.map(type));
         const gTrivia = it.generic;
-        return ts.wrap`${genericName}${gTrivia.open}<${subtypes}${gTrivia.close}>`;
+        return wrap`${genericName}${gTrivia.open}<${subtypes}${gTrivia.close}>`;
       }
-      const base = ts.wrap`${trivia.base}${ts.reference(it.baseName)}`;
-      return ts.wrap`${token(it.prefix)}${base}${token(it.postfix)}`;
+      const base = wrap`${trivia.base}${ts.reference(it.baseName)}`;
+      return wrap`${token(it.prefix)}${base}${token(it.postfix)}`;
     }
     function type(it) {
       const ext = extended_attributes(it.extAttrs);
       const body = type_body(it);
       const nullable = token(it.nullable, "?");
       const separator = token(it.separator);
-      return ts.wrap`${ext}${body}${nullable}${separator}`;
+      return wrap`${ext}${body}${nullable}${separator}`;
     }
     function const_value(it) {
       const tp = it.type;
@@ -68,49 +71,49 @@
       else if (tp === "Infinity") return (it.negative ? "-" : "") + "Infinity";
       else if (tp === "NaN") return "NaN";
       else if (tp === "number") return it.value;
-      else return ts.wrap`"${it.value}"`;
+      else return wrap`"${it.value}"`;
     }
     function default_(def) {
       if (!def) {
         return "";
       }
       const trivia = extract_trivia(def);
-      const assign = ts.wrap`${trivia.assign}=`;
+      const assign = wrap`${trivia.assign}=`;
       if (def.type === "sequence") {
-        return ts.wrap`${assign}${trivia.open}[${trivia.close}]`;
+        return wrap`${assign}${trivia.open}[${trivia.close}]`;
       }
-      return ts.wrap`${assign}${trivia.value}${const_value(def)}`;
+      return wrap`${assign}${trivia.value}${const_value(def)}`;
     }
     function argument(arg) {
       const ext = extended_attributes(arg.extAttrs);
       const optional = token(arg.optional, "optional");
       const typePart = type(arg.idlType);
       const variadic = token(arg.variadic, "...");
-      const name = ts.wrap`${ts.trivia(arg.trivia.name)}${ts.name(arg.escapedName)}`;
+      const name = wrap`${ts.trivia(arg.trivia.name)}${ts.name(arg.escapedName)}`;
       const defaultValue = default_(arg.default);
       const separator = token(arg.separator);
-      return ts.wrap`${ext}${optional}${typePart}${variadic}${name}${defaultValue}${separator}`;
+      return wrap`${ext}${optional}${typePart}${variadic}${name}${defaultValue}${separator}`;
     }
     function identifier(id) {
-      return ts.wrap`${ts.trivia(id.trivia)}${ts.reference(id.value)}${token(id.separator)}`;
+      return wrap`${ts.trivia(id.trivia)}${ts.reference(id.value)}${token(id.separator)}`;
     }
     function make_ext_at(it) {
-      const name = ts.wrap`${ts.trivia(it.trivia.name)}${ts.reference(it.name)}`;
+      const name = wrap`${ts.trivia(it.trivia.name)}${ts.reference(it.name)}`;
       let rhs = "";
       if (it.rhs) {
         const trivia = extract_trivia(it.rhs);
-        if (it.rhs.type === "identifier-list") rhs = ts.wrap`${trivia.assign}=${trivia.open}(${collect(it.rhs.value.map(identifier))}${trivia.close})`;
-        else rhs = ts.wrap`${trivia.assign}=${trivia.value}${ts.reference(it.rhs.value)}`;
+        if (it.rhs.type === "identifier-list") rhs = wrap`${trivia.assign}=${trivia.open}(${ts.wrap(it.rhs.value.map(identifier))}${trivia.close})`;
+        else rhs = wrap`${trivia.assign}=${trivia.value}${ts.reference(it.rhs.value)}`;
       }
-      const signature = it.signature ? ts.wrap`${ts.trivia(it.signature.trivia.open)}(${collect(it.signature.arguments.map(argument))}${ts.trivia(it.signature.trivia.close)})` : "";
+      const signature = it.signature ? wrap`${ts.trivia(it.signature.trivia.open)}(${ts.wrap(it.signature.arguments.map(argument))}${ts.trivia(it.signature.trivia.close)})` : "";
       const separator = token(it.separator);
-      return ts.wrap`${name}${rhs}${signature}${separator}`;
+      return wrap`${name}${rhs}${signature}${separator}`;
     }
     function extended_attributes(eats) {
       if (!eats) return "";
-      const members = collect(eats.items.map(make_ext_at));
+      const members = ts.wrap(eats.items.map(make_ext_at));
       const trivia = extract_trivia(eats);
-      return ts.wrap`${trivia.open}[${members}${trivia.close}]`;
+      return wrap`${trivia.open}[${members}${trivia.close}]`;
     }
 
     function operation(it) {
@@ -122,20 +125,20 @@
         const trivia = extract_trivia(it.body);
         const typePart = type(body.idlType);
         const name = token(body.name, body.name && ts.name(body.name.escaped));
-        const args = ts.wrap`${trivia.open}(${collect(body.arguments.map(argument))}${trivia.close})`;
-        bodyPart = ts.wrap`${typePart}${name}${args}`;
+        const args = wrap`${trivia.open}(${ts.wrap(body.arguments.map(argument))}${trivia.close})`;
+        bodyPart = wrap`${typePart}${name}${args}`;
       }
-      return ts.wrap`${ext}${modifier}${bodyPart}${ts.trivia(it.trivia.termination)};`;
+      return wrap`${ext}${modifier}${bodyPart}${ts.trivia(it.trivia.termination)};`;
     }
 
     function attribute(it) {
       const ext = extended_attributes(it.extAttrs);
       const special = token(it.special);
       const readonly = token(it.readonly, "readonly");
-      const prefixes = ts.wrap`${ext}${special}${readonly}`;
+      const prefixes = wrap`${ext}${special}${readonly}`;
       const name = ts.name(it.escapedName);
       const trivia = extract_trivia(it);
-      return ts.wrap`${prefixes}${trivia.base}attribute${type(it.idlType)}${trivia.name}${name};`;
+      return wrap`${prefixes}${trivia.base}attribute${type(it.idlType)}${trivia.name}${name};`;
     }
 
     function inheritance(inh) {
@@ -143,7 +146,7 @@
         return "";
       }
       const trivia = extract_trivia(inh);
-      return ts.wrap`${trivia.colon}:${trivia.name}${ts.reference(inh.name)}`;
+      return wrap`${trivia.colon}:${trivia.name}${ts.reference(inh.name)}`;
     }
 
     function container(type) {
@@ -152,10 +155,10 @@
         const ext = extended_attributes(it.extAttrs);
         const partial = token(it.partial, "partial");
         const name = ts.name(it.escapedName);
-        const head = ts.wrap`${trivia.base}${type}${trivia.name}${name}`;
+        const head = wrap`${trivia.base}${type}${trivia.name}${name}`;
         const inherit = inheritance(it.inheritance);
-        const body = ts.wrap`${trivia.open}{${iterate(it.members)}${trivia.close}}${trivia.termination};`;
-        return ts.wrap`${ext}${partial}${head}${inherit}${body}`;
+        const body = wrap`${trivia.open}{${iterate(it.members)}${trivia.close}}${trivia.termination};`;
+        return wrap`${ext}${partial}${head}${inherit}${body}`;
       };
     }
 
@@ -164,30 +167,30 @@
       const ext = extended_attributes(it.extAttrs);
       const partial = token(it.partial, "partial");
       const name = ts.name(it.escapedName);
-      const head = ts.wrap`${trivia.base}interface${trivia.mixin}mixin${trivia.name}${name}`;
-      const body = ts.wrap`${trivia.open}{${iterate(it.members)}${trivia.close}}${trivia.termination};`;
-      return ts.wrap`${ext}${partial}${head}${body}`;
+      const head = wrap`${trivia.base}interface${trivia.mixin}mixin${trivia.name}${name}`;
+      const body = wrap`${trivia.open}{${iterate(it.members)}${trivia.close}}${trivia.termination};`;
+      return wrap`${ext}${partial}${head}${body}`;
     }
     function field(it) {
       const trivia = extract_trivia(it);
       const ext = extended_attributes(it.extAttrs);
       const required = token(it.required, "required");
       const name = ts.name(it.escapedName);
-      const body = ts.wrap`${type(it.idlType)}${trivia.name}${name}`;
+      const body = wrap`${type(it.idlType)}${trivia.name}${name}`;
       const defaultValue = default_(it.default);
-      return ts.wrap`${ext}${required}${body}${defaultValue}${trivia.termination};`;
+      return wrap`${ext}${required}${body}${defaultValue}${trivia.termination};`;
     }
     function const_(it) {
       const trivia = extract_trivia(it);
       const ret = extended_attributes(it.extAttrs);
       const name = ts.name(it.name);
-      return ts.wrap`${ret}${trivia.base}const${type(it.idlType)}${trivia.name}${name}${trivia.assign}=${trivia.value}${const_value(it.value)}${trivia.termination};`;
+      return wrap`${ret}${trivia.base}const${type(it.idlType)}${trivia.name}${name}${trivia.assign}=${trivia.value}${const_value(it.value)}${trivia.termination};`;
     }
     function typedef(it) {
       const trivia = extract_trivia(it);
       const ret = extended_attributes(it.extAttrs);
       const name = ts.name(it.escapedName);
-      return ts.wrap`${ret}${trivia.base}typedef${type(it.idlType)}${trivia.name}${name}${trivia.termination};`;
+      return wrap`${ret}${trivia.base}typedef${type(it.idlType)}${trivia.name}${name}${trivia.termination};`;
     }
     function includes(it) {
       const trivia = extract_trivia(it);
@@ -195,36 +198,36 @@
       const target = ts.reference(it.target);
       const mixin = ts.reference(it.includes);
       return ts.includes(
-        ts.wrap`${ret}${trivia.target}${target}${trivia.includes}includes${trivia.mixin}${mixin}${trivia.termination};`
+        wrap`${ret}${trivia.target}${target}${trivia.includes}includes${trivia.mixin}${mixin}${trivia.termination};`
       );
     }
     function callback(it) {
       const trivia = extract_trivia(it);
       const ext = extended_attributes(it.extAttrs);
       const name = ts.name(it.name);
-      const head = ts.wrap`${trivia.base}callback${trivia.name}${name}`;
-      const args = collect(it.arguments.map(argument));
-      const signature = ts.wrap`${type(it.idlType)}${trivia.open}(${args}${trivia.close})`;
-      return ts.wrap`${ext}${head}${trivia.assign}=${signature}${trivia.termination};`;
+      const head = wrap`${trivia.base}callback${trivia.name}${name}`;
+      const args = ts.wrap(it.arguments.map(argument));
+      const signature = wrap`${type(it.idlType)}${trivia.open}(${args}${trivia.close})`;
+      return wrap`${ext}${head}${trivia.assign}=${signature}${trivia.termination};`;
     }
     function enum_(it) {
       const trivia = extract_trivia(it);
       const ext = extended_attributes(it.extAttrs);
       const name = ts.name(it.escapedName);
       const values = iterate(it.values);
-      return ts.wrap`${ext}${trivia.base}enum${trivia.name}${name}${trivia.open}{${values}${trivia.close}}${trivia.termination};`;
+      return wrap`${ext}${trivia.base}enum${trivia.name}${name}${trivia.open}{${values}${trivia.close}}${trivia.termination};`;
     }
     function enum_value(v) {
-      return ts.wrap`${ts.trivia(v.trivia)}"${ts.name(v.value)}"${token(v.separator)}`;
+      return wrap`${ts.trivia(v.trivia)}"${ts.name(v.value)}"${token(v.separator)}`;
     }
     function iterable_like(it) {
       const trivia = extract_trivia(it);
       const readonly = token(it.readonly, "readonly");
-      const bracket = ts.wrap`${trivia.open}<${collect(it.idlType.map(type))}${trivia.close}>`;
-      return ts.wrap`${readonly}${trivia.base}${it.type}${bracket}${trivia.termination};`;
+      const bracket = wrap`${trivia.open}<${ts.wrap(it.idlType.map(type))}${trivia.close}>`;
+      return wrap`${readonly}${trivia.base}${it.type}${bracket}${trivia.termination};`;
     }
     function callbackInterface(it) {
-      return ts.wrap`${ts.trivia(it.trivia.callback)}callback${container("interface")(it)}`;
+      return wrap`${ts.trivia(it.trivia.callback)}callback${container("interface")(it)}`;
     }
     function eof(it) {
       return ts.trivia(it.trivia);
@@ -261,7 +264,7 @@
     function iterate(things) {
       if (!things) return;
       const results = things.map(dispatch);
-      return collect(results);
+      return ts.wrap(results);
     }
     return iterate(ast);
   }

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -64,7 +64,7 @@
       } else if (it.generic) {
         const genericName = wrap`${trivia.base}${reference(it.generic.value)}`;
         const subtypes = ts.wrap(it.idlType.map(type));
-        const gTrivia = it.generic;
+        const gTrivia = extract_trivia(it.generic);
         return wrap`${genericName}${gTrivia.open}<${subtypes}${gTrivia.close}>`;
       }
       if (!it.prefix && !it.postfix) {
@@ -267,10 +267,9 @@
       );
     }
     function enum_value(v, parent) {
-      return ts.enumValue(
-        wrap`${ts.trivia(v.trivia)}"${ts.name(v.value, { data: v, parent })}"${token(v.separator)}`,
-        { data: v, parent }
-      );
+      return wrap`${ts.trivia(v.trivia)}${
+        ts.enumValue(`"${ts.name(v.value, { data: v, parent })}"`, { data: v, parent })
+      }${token(v.separator)}`;
     }
     function iterable_like(it, parent) {
       const trivia = extract_trivia(it);

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -255,7 +255,7 @@
     }
     function enum_value(v, parent) {
       return wrap`${ts.trivia(v.trivia)}${
-        ts.definition(`"${ts.name(v.value, { data: v, parent })}"`, { data: v, parent })
+        ts.definition(wrap`"${ts.name(v.value, { data: v, parent })}"`, { data: v, parent })
       }${token(v.separator)}`;
     }
     function iterable_like(it, parent) {

--- a/test/syntax/idl/attributes.widl
+++ b/test/syntax/idl/attributes.widl
@@ -7,5 +7,5 @@ interface Person {
   attribute unsigned short age;
 
   // required is an allowed attribute name
-  attribute any required;
+  attribute any required ;
 };

--- a/test/syntax/json/attributes.json
+++ b/test/syntax/json/attributes.json
@@ -43,7 +43,7 @@
                 "trivia": {
                     "base": "\n\n  // required is an allowed attribute name\n  ",
                     "name": " ",
-                    "termination": ""
+                    "termination": " "
                 },
                 "idlType": {
                     "type": "attribute-type",


### PR DESCRIPTION
This introduces a way to customize the output of `write()` so that tools e.g. ReSpec can add HTML tags on it. Basically what was described in https://github.com/w3c/webidl2.js/issues/210#issuecomment-400552326.

Should only be merged after [the respec side of PR](https://github.com/w3c/respec/pull/1920) gets approved, so that we can make sure that this covers everything ReSpec requires.

TODO:

- [ ] Add documentation.
- [ ] Add tests.