### PR TITLE
feat(lib/webidl): subclass standard error

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -165,18 +165,18 @@
     }
   }
 
-  class WebIDLParseError {
+  class WebIDLParseError extends Error {
     constructor(str, line, input, tokens) {
-      this.message = str;
+      super(str);
+      this.name = this.constructor.name;
       this.line = line;
       this.input = input;
       this.tokens = tokens;
     }
 
     toString() {
-      const escapedInput = JSON.stringify(this.input);
       const tokens = JSON.stringify(this.tokens, null, 4);
-      return `${this.message}, line ${this.line} (tokens: ${escapedInput})\n${tokens}`;
+      return `${this.message}\n${tokens}`;
     }
   }
 


### PR DESCRIPTION
This makes WebIDLParseError more like standard error object.