### PR TITLE
BREAKING CHANGE: remove .extAttrs from arguments

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -493,7 +493,6 @@
     function argument() {
       const start_position = consume_position;
       const ret = { optional: null, variadic: null, default: null, trivia: {} };
-      ret.extAttrs = extended_attrs();
       const optional = consume("optional");
       if (optional) {
         ret.optional = { trivia: optional.trivia };

--- a/test/syntax/baseline/allowany.json
+++ b/test/syntax/baseline/allowany.json
@@ -76,7 +76,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -139,24 +138,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": {
-                                "trivia": {
-                                    "open": "",
-                                    "close": ""
-                                },
-                                "items": [
-                                    {
-                                        "name": "AllowAny",
-                                        "signature": null,
-                                        "type": "extended-attribute",
-                                        "rhs": null,
-                                        "trivia": {
-                                            "name": ""
-                                        },
-                                        "separator": null
-                                    }
-                                ]
-                            },
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -167,7 +148,24 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": null,
+                                "extAttrs": {
+                                    "trivia": {
+                                        "open": "",
+                                        "close": ""
+                                    },
+                                    "items": [
+                                        {
+                                            "name": "AllowAny",
+                                            "signature": null,
+                                            "type": "extended-attribute",
+                                            "rhs": null,
+                                            "trivia": {
+                                                "name": ""
+                                            },
+                                            "separator": null
+                                        }
+                                    ]
+                                },
                                 "trivia": {
                                     "base": " "
                                 }

--- a/test/syntax/baseline/callback.json
+++ b/test/syntax/baseline/callback.json
@@ -25,7 +25,6 @@
                 "trivia": {
                     "name": " "
                 },
-                "extAttrs": null,
                 "idlType": {
                     "type": "argument-type",
                     "generic": null,
@@ -98,7 +97,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -163,7 +161,6 @@
                 "trivia": {
                     "name": " "
                 },
-                "extAttrs": null,
                 "idlType": {
                     "type": "argument-type",
                     "generic": null,
@@ -193,7 +190,6 @@
                 "trivia": {
                     "name": " "
                 },
-                "extAttrs": null,
                 "idlType": {
                     "type": "argument-type",
                     "generic": null,

--- a/test/syntax/baseline/constructor.json
+++ b/test/syntax/baseline/constructor.json
@@ -158,7 +158,6 @@
                                 "trivia": {
                                     "name": " "
                                 },
-                                "extAttrs": null,
                                 "idlType": {
                                     "type": "argument-type",
                                     "generic": null,

--- a/test/syntax/baseline/enum.json
+++ b/test/syntax/baseline/enum.json
@@ -136,7 +136,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -166,7 +165,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,

--- a/test/syntax/baseline/equivalent-decl.json
+++ b/test/syntax/baseline/equivalent-decl.json
@@ -77,7 +77,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -143,7 +142,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -173,7 +171,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -286,7 +283,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -349,7 +345,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -379,7 +374,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -441,7 +435,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -503,7 +496,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -533,7 +525,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,

--- a/test/syntax/baseline/extended-attributes.json
+++ b/test/syntax/baseline/extended-attributes.json
@@ -319,7 +319,6 @@
                                 "trivia": {
                                     "name": " "
                                 },
-                                "extAttrs": null,
                                 "idlType": {
                                     "type": "argument-type",
                                     "generic": null,

--- a/test/syntax/baseline/getter-setter.json
+++ b/test/syntax/baseline/getter-setter.json
@@ -73,7 +73,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -135,7 +134,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -165,7 +163,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,

--- a/test/syntax/baseline/identifier-qualified-names.json
+++ b/test/syntax/baseline/identifier-qualified-names.json
@@ -67,7 +67,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -129,7 +128,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -284,7 +282,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,

--- a/test/syntax/baseline/indexed-properties.json
+++ b/test/syntax/baseline/indexed-properties.json
@@ -77,7 +77,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -146,7 +145,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -179,7 +177,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -245,7 +242,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -314,7 +310,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -380,7 +375,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -410,7 +404,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -476,7 +469,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,

--- a/test/syntax/baseline/namedconstructor.json
+++ b/test/syntax/baseline/namedconstructor.json
@@ -56,7 +56,6 @@
                                 "trivia": {
                                     "name": " "
                                 },
-                                "extAttrs": null,
                                 "idlType": {
                                     "type": "argument-type",
                                     "generic": null,

--- a/test/syntax/baseline/namespace.json
+++ b/test/syntax/baseline/namespace.json
@@ -71,7 +71,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -101,7 +100,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -164,7 +162,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -194,7 +191,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,

--- a/test/syntax/baseline/nointerfaceobject.json
+++ b/test/syntax/baseline/nointerfaceobject.json
@@ -41,7 +41,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,

--- a/test/syntax/baseline/nullableobjects.json
+++ b/test/syntax/baseline/nullableobjects.json
@@ -73,7 +73,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -138,7 +137,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,

--- a/test/syntax/baseline/operation-optional-arg.json
+++ b/test/syntax/baseline/operation-optional-arg.json
@@ -41,7 +41,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -71,7 +70,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -101,7 +99,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -140,7 +137,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,

--- a/test/syntax/baseline/overloading.json
+++ b/test/syntax/baseline/overloading.json
@@ -73,7 +73,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -136,7 +135,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -216,7 +214,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -279,24 +276,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": {
-                                "trivia": {
-                                    "open": "",
-                                    "close": ""
-                                },
-                                "items": [
-                                    {
-                                        "name": "AllowAny",
-                                        "signature": null,
-                                        "type": "extended-attribute",
-                                        "rhs": null,
-                                        "trivia": {
-                                            "name": ""
-                                        },
-                                        "separator": null
-                                    }
-                                ]
-                            },
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -307,7 +286,24 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": null,
+                                "extAttrs": {
+                                    "trivia": {
+                                        "open": "",
+                                        "close": ""
+                                    },
+                                    "items": [
+                                        {
+                                            "name": "AllowAny",
+                                            "signature": null,
+                                            "type": "extended-attribute",
+                                            "rhs": null,
+                                            "trivia": {
+                                                "name": ""
+                                            },
+                                            "separator": null
+                                        }
+                                    ]
+                                },
                                 "trivia": {
                                     "base": " "
                                 }
@@ -326,7 +322,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -358,7 +353,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -456,7 +450,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -486,7 +479,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -518,7 +510,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -550,7 +541,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,

--- a/test/syntax/baseline/overridebuiltins.json
+++ b/test/syntax/baseline/overridebuiltins.json
@@ -77,7 +77,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,

--- a/test/syntax/baseline/record.json
+++ b/test/syntax/baseline/record.json
@@ -41,7 +41,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": {
@@ -268,7 +267,6 @@
                                 "trivia": {
                                     "name": " "
                                 },
-                                "extAttrs": null,
                                 "idlType": {
                                     "type": "argument-type",
                                     "generic": {

--- a/test/syntax/baseline/reg-operations.json
+++ b/test/syntax/baseline/reg-operations.json
@@ -155,7 +155,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -218,7 +217,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -251,7 +249,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,

--- a/test/syntax/baseline/sequence.json
+++ b/test/syntax/baseline/sequence.json
@@ -41,7 +41,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": {
@@ -200,7 +199,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": {

--- a/test/syntax/baseline/static.json
+++ b/test/syntax/baseline/static.json
@@ -177,7 +177,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -207,7 +206,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -237,7 +235,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,

--- a/test/syntax/baseline/treatasnull.json
+++ b/test/syntax/baseline/treatasnull.json
@@ -97,31 +97,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": {
-                                "trivia": {
-                                    "open": "",
-                                    "close": ""
-                                },
-                                "items": [
-                                    {
-                                        "name": "TreatNullAs",
-                                        "signature": null,
-                                        "type": "extended-attribute",
-                                        "rhs": {
-                                            "type": "identifier",
-                                            "value": "EmptyString",
-                                            "trivia": {
-                                                "assign": "",
-                                                "value": ""
-                                            }
-                                        },
-                                        "trivia": {
-                                            "name": ""
-                                        },
-                                        "separator": null
-                                    }
-                                ]
-                            },
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -132,7 +107,31 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": null,
+                                "extAttrs": {
+                                    "trivia": {
+                                        "open": "",
+                                        "close": ""
+                                    },
+                                    "items": [
+                                        {
+                                            "name": "TreatNullAs",
+                                            "signature": null,
+                                            "type": "extended-attribute",
+                                            "rhs": {
+                                                "type": "identifier",
+                                                "value": "EmptyString",
+                                                "trivia": {
+                                                    "assign": "",
+                                                    "value": ""
+                                                }
+                                            },
+                                            "trivia": {
+                                                "name": ""
+                                            },
+                                            "separator": null
+                                        }
+                                    ]
+                                },
                                 "trivia": {
                                     "base": " "
                                 }

--- a/test/syntax/baseline/treatasundefined.json
+++ b/test/syntax/baseline/treatasundefined.json
@@ -97,31 +97,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": {
-                                "trivia": {
-                                    "open": "",
-                                    "close": ""
-                                },
-                                "items": [
-                                    {
-                                        "name": "TreatUndefinedAs",
-                                        "signature": null,
-                                        "type": "extended-attribute",
-                                        "rhs": {
-                                            "type": "identifier",
-                                            "value": "EmptyString",
-                                            "trivia": {
-                                                "assign": "",
-                                                "value": ""
-                                            }
-                                        },
-                                        "trivia": {
-                                            "name": ""
-                                        },
-                                        "separator": null
-                                    }
-                                ]
-                            },
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -132,7 +107,31 @@
                                 "prefix": null,
                                 "postfix": null,
                                 "separator": null,
-                                "extAttrs": null,
+                                "extAttrs": {
+                                    "trivia": {
+                                        "open": "",
+                                        "close": ""
+                                    },
+                                    "items": [
+                                        {
+                                            "name": "TreatUndefinedAs",
+                                            "signature": null,
+                                            "type": "extended-attribute",
+                                            "rhs": {
+                                                "type": "identifier",
+                                                "value": "EmptyString",
+                                                "trivia": {
+                                                    "assign": "",
+                                                    "value": ""
+                                                }
+                                            },
+                                            "trivia": {
+                                                "name": ""
+                                            },
+                                            "separator": null
+                                        }
+                                    ]
+                                },
                                 "trivia": {
                                     "base": " "
                                 }

--- a/test/syntax/baseline/typedef.json
+++ b/test/syntax/baseline/typedef.json
@@ -265,7 +265,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -328,7 +327,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,

--- a/test/syntax/baseline/typesuffixes.json
+++ b/test/syntax/baseline/typesuffixes.json
@@ -41,7 +41,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": {

--- a/test/syntax/baseline/variadic-operations.json
+++ b/test/syntax/baseline/variadic-operations.json
@@ -76,7 +76,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,
@@ -141,7 +140,6 @@
                             "trivia": {
                                 "name": " "
                             },
-                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "generic": null,


### PR DESCRIPTION
Fixes #246 

Previously the following example added information for `[TreatNullAs=EmptyString]` to argument objects, now it goes to IDL types as it does in attributes.

```webidl
[Exposed=Window]
interface Dog {
  attribute DOMString name;
  attribute [TreatNullAs=EmptyString] DOMString owner;

  boolean isMemberOfBreed([TreatNullAs=EmptyString] DOMString breedName);
};
```