### PR TITLE
fix(lib/webidl2): prevent any in a union type

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -463,6 +463,7 @@
       const ret = Object.assign({ type: typeName || null }, EMPTY_IDLTYPE, { union: true, idlType: [], trivia });
       while (true) {
         const typ = type_with_extended_attributes() || error("No type after open parenthesis or 'or' in union type");
+        if (typ.idlType === "any") error("Type any cannot be included in a union type");
         ret.idlType.push(typ);
         const or = untyped_consume("or");
         if (or) {

--- a/test/invalid/baseline/union-any.txt
+++ b/test/invalid/baseline/union-any.txt
@@ -1,0 +1,3 @@
+Syntax error at line 1:
+typedef (any or any) Any;
+             ^ Type any cannot be included in a union type

--- a/test/invalid/idl/union-any.widl
+++ b/test/invalid/idl/union-any.widl
@@ -1,0 +1,1 @@
+typedef (any or any) Any;


### PR DESCRIPTION
Fixes #250 

Didn't know `git checkout -b newbranchname origin/develop` automatically sets origin/develop as the upstream branch. 😨 This is why there is a new reverting commit in our main branch...