### PR TITLE
Lowercase the example namespace "Console"

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ Namespaces look like this:
 ```JS
 {
   "type": "namespace",
-  "name": "Console",
+  "name": "console",
   "partial": null,
   "members": [...],
   "trivia": {


### PR DESCRIPTION
If based on a real namespace, might as well match the name:
https://console.spec.whatwg.org/#console-namespace