### PR TITLE
fix(lib/webidl2): restore enum value string form in error

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -1111,12 +1111,14 @@
           error("No comma between enum values");
         }
         const val = consume(STR) || error("Unexpected value in enum");
-        val.type = "enum-value";
-        val.value = val.value.slice(1, -1);
-        val.separator = untyped_consume(",") || null;
-
-        ret.values.push(val);
-        value_expected = !!val.separator;
+        const separator = untyped_consume(",") || null;
+        ret.values.push({
+          type: "enum-value",
+          value: val.value.slice(1, -1),
+          trivia: val.trivia,
+          separator
+        });
+        value_expected = !!separator;
       }
     }
 

--- a/test/invalid/baseline/enum-wo-comma.txt
+++ b/test/invalid/baseline/enum-wo-comma.txt
@@ -1,3 +1,3 @@
 Syntax error at line 1, since `enum NoComma`:
-enum NoComma { value1 "value2" };
-                      ^ No comma between enum values
+enum NoComma { "value1" "value2" };
+                        ^ No comma between enum values


### PR DESCRIPTION
Modifying token object causes side effect 😄