### PR TITLE
fix(lib/webidl2): allow a preceding hyphen for identifiers

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -8,7 +8,7 @@
     // against integers early.
     "float": /-?(?=[0-9]*\.|[0-9]+[eE])(([0-9]+\.[0-9]*|[0-9]*\.[0-9]+)([Ee][-+]?[0-9]+)?|[0-9]+[Ee][-+]?[0-9]+)/y,
     "integer": /-?(0([Xx][0-9A-Fa-f]+|[0-7]*)|[1-9][0-9]*)/y,
-    "identifier": /_?[A-Za-z][0-9A-Z_a-z-]*/y,
+    "identifier": /[_-]?[A-Za-z][0-9A-Z_a-z-]*/y,
     "string": /"[^"]*"/y,
     "whitespace": /[\t\n\r ]+/y,
     "comment": /((\/(\/.*|\*([^*]|\*[^/])*\*\/)[\t\n\r ]*)+)/y,
@@ -46,6 +46,7 @@
   ];
 
   const nonRegexTerminals = [
+    "-Infinity",
     "FrozenArray",
     "Infinity",
     "NaN",
@@ -76,7 +77,6 @@
     "(",
     ")",
     ",",
-    "-Infinity",
     "...",
     ":",
     ";",
@@ -106,16 +106,17 @@
 
       if (result !== -1) {
         trivia += tokens.pop().value;
-      } else if (/[-0-9.]/.test(nextChar)) {
+      } else if (/[-0-9.A-Z_a-z]/.test(nextChar)) {
         result = attemptTokenMatch("float");
         if (result === -1) {
           result = attemptTokenMatch("integer");
         }
-      } else if (/[A-Z_a-z]/.test(nextChar)) {
-        result = attemptTokenMatch("identifier");
-        const token = tokens[tokens.length - 1];
-        if (result !== -1 && nonRegexTerminals.includes(token.value)) {
-          token.type = token.value;
+        if (result === -1) {   
+          result = attemptTokenMatch("identifier");
+          const token = tokens[tokens.length - 1];
+          if (result !== -1 && nonRegexTerminals.includes(token.value)) {
+            token.type = token.value;
+          }
         }
       } else if (nextChar === '"') {
         result = attemptTokenMatch("string");

--- a/test/syntax/baseline/identifier-hyphen.json
+++ b/test/syntax/baseline/identifier-hyphen.json
@@ -1,0 +1,95 @@
+[
+    {
+        "type": "interface",
+        "name": "CSSStyleDeclaration",
+        "escapedName": "CSSStyleDeclaration",
+        "partial": {
+            "trivia": ""
+        },
+        "members": [
+            {
+                "type": "attribute",
+                "special": null,
+                "readonly": null,
+                "trivia": {
+                    "base": " ",
+                    "name": " ",
+                    "termination": ""
+                },
+                "idlType": {
+                    "type": "attribute-type",
+                    "generic": null,
+                    "nullable": null,
+                    "union": false,
+                    "idlType": "CSSOMString",
+                    "baseName": "CSSOMString",
+                    "escapedBaseName": "CSSOMString",
+                    "prefix": null,
+                    "postfix": null,
+                    "separator": null,
+                    "extAttrs": {
+                        "trivia": {
+                            "open": " ",
+                            "close": ""
+                        },
+                        "items": [
+                            {
+                                "name": "TreatNullAs",
+                                "signature": null,
+                                "type": "extended-attribute",
+                                "rhs": {
+                                    "type": "identifier",
+                                    "value": "EmptyString",
+                                    "trivia": {
+                                        "assign": "",
+                                        "value": ""
+                                    }
+                                },
+                                "trivia": {
+                                    "name": ""
+                                },
+                                "separator": null
+                            }
+                        ]
+                    },
+                    "trivia": {
+                        "base": " "
+                    }
+                },
+                "name": "-will-change",
+                "escapedName": "-will-change",
+                "extAttrs": {
+                    "trivia": {
+                        "open": "\n  ",
+                        "close": ""
+                    },
+                    "items": [
+                        {
+                            "name": "CEReactions",
+                            "signature": null,
+                            "type": "extended-attribute",
+                            "rhs": null,
+                            "trivia": {
+                                "name": ""
+                            },
+                            "separator": null
+                        }
+                    ]
+                }
+            }
+        ],
+        "trivia": {
+            "base": " ",
+            "name": " ",
+            "open": " ",
+            "close": "\n",
+            "termination": ""
+        },
+        "extAttrs": null
+    },
+    {
+        "type": "eof",
+        "value": "",
+        "trivia": "\n"
+    }
+]

--- a/test/syntax/idl/identifier-hyphen.widl
+++ b/test/syntax/idl/identifier-hyphen.widl
@@ -1,0 +1,3 @@
+partial interface CSSStyleDeclaration {
+  [CEReactions] attribute [TreatNullAs=EmptyString] CSSOMString -will-change;
+};


### PR DESCRIPTION
Following https://github.com/heycam/webidl/pull/633.