### PR TITLE
test(lib/webidl2): case for double extended attributes in arguments

### DIFF
--- a/test/invalid/baseline/extattr-double.txt
+++ b/test/invalid/baseline/extattr-double.txt
@@ -1,0 +1,3 @@
+Syntax error at line 1:
+[Constructor([Clamp] [Clamp
+             ^ Unexpected token in extended attribute argument list

--- a/test/invalid/idl/extattr-double.widl
+++ b/test/invalid/idl/extattr-double.widl
@@ -1,0 +1,2 @@
+[Constructor([Clamp] [Clamp] unsigned long value)] // this is invalid
+interface Foo {};


### PR DESCRIPTION
#248 fixed the issue but not added a test case.

Closes #191