### PR TITLE
BREAKING CHANGE: constant as a class

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -407,29 +407,27 @@
     }
 
     function const_value() {
-      const token = consume("true", "false", "null", "Infinity", "-Infinity", "NaN", FLOAT, INT);
-      if (!token) {
-        return;
-      }
-      const { trivia } = token;
-      let data;
+      return consume("true", "false", "null", "Infinity", "-Infinity", "NaN", FLOAT, INT);
+    }
+
+    function const_data(token) {
       switch (token.type) {
         case "true":
         case "false":
-          data = { type: "boolean", value: token.type === "true" };
-          break;
+          return { type: "boolean", value: token.type === "true" };
         case "Infinity":
         case "-Infinity":
-          data = { type: "Infinity", negative: token.type.startsWith("-") };
-          break;
+          return { type: "Infinity", negative: token.type.startsWith("-") };
         case FLOAT:
         case INT:
-          data = { type: "number", value: token.value };
-          break;
+          return { type: "number", value: token.value };
+        case "[":
+          return { type: "sequence", value: [] };
+        case STR:
+          return { type: STR, value: token.value.slice(1, -1) };
         default:
-          data = { type: token.type };
+          return { type: token.type };
       }
-      return { data, trivia };
     }
 
     function type_suffix(obj) {
@@ -675,7 +673,7 @@
       const def = const_value();
       if (def) {
         trivia.value = def.trivia;
-        return Object.assign(def.data, { trivia });
+        return Object.assign(const_data(def), { trivia });
       }
 
       const open = consume("[");
@@ -696,35 +694,43 @@
       };
     }
 
-    function const_() {
-      const base = consume("const");
-      if (!base) return;
-      const trivia = { base: base.trivia };
-      const ret = { type: "const" };
-      let typ = primitive_type();
-      if (!typ) {
-        typ = consume(ID) || error("No type for const");
-        typ = {
-          idlType: typ.value,
-          baseName: typ.value,
-          escapedBaseName: typ.value,
-          trivia: { base: typ.trivia }
-        };
+    class Constant extends Definition {
+      static parse() {
+        const tokens = {};
+        tokens.base = consume("const");
+        if (!tokens.base) {
+          return;
+        }
+        let idlType = primitive_type();
+        if (!idlType) {
+          const base = consume(ID) || error("No type for const");
+          idlType = {
+            idlType: base.value,
+            baseName: unescape(base.value),
+            escapedBaseName: base.value,
+            trivia: { base: base.trivia }
+          };
+        }
+        idlType = Object.assign({ type: "const-type" }, EMPTY_IDLTYPE, idlType);
+        type_suffix(idlType);
+        tokens.name = consume(ID) || error("No name for const");
+        tokens.assign = consume("=") || error("No value assignment for const");
+        tokens.value = const_value() || error("No value for const");
+        tokens.termination = consume(";") || error("Unterminated const");
+        const ret = new Constant({ tokens });
+        ret.idlType = idlType;
+        return ret;
       }
-      ret.idlType = Object.assign({ type: "const-type" }, EMPTY_IDLTYPE, typ);
-      type_suffix(ret.idlType);
-      const name = consume(ID) || error("No name for const");
-      ret.name = name.value;
-      trivia.name = name.trivia;
-      const assign = consume("=") || error("No value assignment for const");
-      trivia.assign = assign.trivia;
-      const cnt = const_value() || error("No value for const");
-      ret.value = cnt.data;
-      trivia.value = cnt.trivia;
-      const termination = consume(";") || error("Unterminated const");
-      trivia.termination = termination.trivia;
-      ret.trivia = trivia;
-      return ret;
+
+      get type() {
+        return "const";
+      }
+      get name() {
+        return unescape(this.tokens.name.value);
+      }
+      get value() {
+        return const_data(this.tokens.value);
+      }
     }
 
     class CallbackFunction extends Definition {
@@ -1019,7 +1025,7 @@
           type: "interface",
           inheritable: !partial,
           allowedMembers: [
-            [const_],
+            [Constant.parse],
             [static_member],
             [stringifier],
             [IterableLike.parse],
@@ -1047,7 +1053,7 @@
         return Container.parse(new Mixin({ tokens }), {
           type: "interface mixin",
           allowedMembers: [
-            [const_],
+            [Constant.parse],
             [stringifier],
             [Attribute.parse, { noInherit: true }],
             [Operation.parse, { regular: true }]

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -11,7 +11,6 @@
     name: noop,
     reference: noop,
     type: noop,
-    valueLiteral: noop,
     inheritance: noop,
     definition: noop,
     extendedAttribute: noop,
@@ -88,7 +87,7 @@
       else if (tp === "number") return it.value;
       else return `"${it.value}"`;
     }
-    function default_(def, parent) {
+    function default_(def) {
       if (!def) {
         return "";
       }
@@ -97,7 +96,7 @@
       if (def.type === "sequence") {
         return wrap`${assign}${trivia.open}[${trivia.close}]`;
       }
-      return wrap`${assign}${trivia.value}${ts.valueLiteral(const_value(def), parent)}`;
+      return wrap`${assign}${trivia.value}${const_value(def)}`;
     }
     function argument(arg) {
       const ext = extended_attributes(arg.extAttrs);
@@ -160,10 +159,6 @@
       ]), { data: it, parent });
     }
 
-    function typed_head(trivia, it, name) {
-      return wrap`${trivia.base}${it.type}${ts.type(type(it.idlType))}${trivia.name}${name}`;
-    }
-
     function inheritance(inh) {
       if (!inh) {
         return "";
@@ -216,15 +211,15 @@
       ]), { data: it, parent });
     }
     function const_(it, parent) {
-      const trivia = extract_trivia(it);
-      const ext = extended_attributes(it.extAttrs);
-      const name = ts.name(it.name, { data: it, parent });
-      const head = typed_head(trivia, it, name);
-      const assign = wrap`${trivia.assign}=${trivia.value}${ts.valueLiteral(const_value(it.value), it)}`;
-      return ts.definition(
-        wrap`${ext}${head}${assign}${trivia.termination};`,
-        { data: it, parent }
-      );
+      return ts.definition(ts.wrap([
+        extended_attributes(it.extAttrs),
+        token(it.tokens.base),
+        ts.type(type(it.idlType)),
+        name_token(it.tokens.name, { data: it, parent }),
+        token(it.tokens.assign),
+        token(it.tokens.value),
+        token(it.tokens.termination)
+      ]), { data: it, parent });
     }
     function typedef(it) {
       return ts.definition(ts.wrap([

--- a/test/writer.js
+++ b/test/writer.js
@@ -60,6 +60,9 @@ describe("Writer template functions", () => {
 
     const operation = rewriteName("namespace Console { void log(); };");
     expect(operation).toBe("namespace <Console> { void <log>(); };");
+
+    const constant = rewriteName("interface Misaki { const short MICHELLE = 1; };");
+    expect(constant).toBe("interface <Misaki> { const short <MICHELLE> = 1; };");
   });
 
   it("catches references", () => {
@@ -91,13 +94,6 @@ describe("Writer template functions", () => {
       type: bracket
     });
     expect(result).toBe("interface Momo { attribute< Promise<unsigned long>> iro; };");
-  });
-
-  it("catches value literals", () => {
-    const result = rewrite("dictionary Nene { DOMString cpp = \"high\"; };", {
-      valueLiteral: bracket
-    });
-    expect(result).toBe("dictionary Nene { DOMString cpp = <\"high\">; };");
   });
 
   it("catches inheritances", () => {
@@ -158,5 +154,8 @@ describe("Writer template functions", () => {
 
     const attribute = rewriteDefinition("interface X { attribute short x; };");
     expect(attribute).toBe("interface[interface X {interface:attribute[ attribute short x;] };]");
+
+    const constant = rewriteDefinition("interface Misaki { const short MICHELLE = 1; };");
+    expect(constant).toBe("interface[interface Misaki {interface:const[ const short MICHELLE = 1;] };]");
   });
 });


### PR DESCRIPTION
This removes `valueLiteral` writer hook because it turns out that ReSpec doesn't need it.