### PR TITLE
fix(lib/webidl2): disallow null on constants

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -436,7 +436,7 @@
     }
 
     function const_value() {
-      return consume("true", "false", "null", "Infinity", "-Infinity", "NaN", FLOAT, INT);
+      return consume("true", "false", "Infinity", "-Infinity", "NaN", FLOAT, INT);
     }
 
     function const_data(token) {
@@ -721,7 +721,7 @@
         if (!assign) {
           return null;
         }
-        const def = const_value() || consume(STR, "[")  || error("No value for default");
+        const def = const_value() || consume(STR, "null", "[") || error("No value for default");
         const expression = [def];
         if (def.type === "[") {
           const close = consume("]") || error("Default sequence value must be empty");
@@ -772,7 +772,6 @@
           };
         }
         idlType = Object.assign({ type: "const-type" }, EMPTY_IDLTYPE, idlType);
-        type_suffix(idlType);
         tokens.name = consume(ID) || error("No name for const");
         tokens.assign = consume("=") || error("No value assignment for const");
         tokens.value = const_value() || error("No value for const");

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -772,6 +772,9 @@
           };
         }
         idlType = Object.assign({ type: "const-type" }, EMPTY_IDLTYPE, idlType);
+        if (probe("?")) {
+          error("Unexpected nullable constant type");
+        }
         tokens.name = consume(ID) || error("No name for const");
         tokens.assign = consume("=") || error("No value assignment for const");
         tokens.value = const_value() || error("No value for const");

--- a/test/invalid/baseline/const-null.txt
+++ b/test/invalid/baseline/const-null.txt
@@ -1,0 +1,3 @@
+Syntax error at line 2, since `interface MyConstants`:
+  const MyPrimitive MY_NULL = null;
+                              ^ No value for const

--- a/test/invalid/baseline/const-nullable.txt
+++ b/test/invalid/baseline/const-nullable.txt
@@ -1,3 +1,3 @@
 Syntax error at line 3, since `interface MyConstants`:
   const boolean? ARE_WE_THERE_YET = false;
-               ^ No name for const
+               ^ Unexpected nullable constant type

--- a/test/invalid/baseline/const-nullable.txt
+++ b/test/invalid/baseline/const-nullable.txt
@@ -1,0 +1,3 @@
+Syntax error at line 3, since `interface MyConstants`:
+  const boolean? ARE_WE_THERE_YET = false;
+               ^ No name for const

--- a/test/invalid/idl/const-null.widl
+++ b/test/invalid/idl/const-null.widl
@@ -1,0 +1,3 @@
+interface MyConstants {
+  const MyPrimitive MY_NULL = null;
+};

--- a/test/invalid/idl/const-nullable.widl
+++ b/test/invalid/idl/const-nullable.widl
@@ -1,0 +1,4 @@
+// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06
+interface MyConstants {
+  const boolean? ARE_WE_THERE_YET = false;
+};

--- a/test/syntax/baseline/nullable.json
+++ b/test/syntax/baseline/nullable.json
@@ -1,90 +1,6 @@
 [
     {
         "type": "interface",
-        "name": "MyConstants",
-        "escapedName": "MyConstants",
-        "inheritance": null,
-        "members": [
-            {
-                "type": "const",
-                "name": "ARE_WE_THERE_YET",
-                "idlType": {
-                    "type": "const-type",
-                    "generic": null,
-                    "nullable": {
-                        "trivia": ""
-                    },
-                    "union": false,
-                    "idlType": "boolean",
-                    "baseName": "boolean",
-                    "escapedBaseName": "boolean",
-                    "prefix": null,
-                    "postfix": null,
-                    "separator": null,
-                    "extAttrs": null,
-                    "trivia": {
-                        "base": " "
-                    }
-                },
-                "extAttrs": null,
-                "value": {
-                    "type": "boolean",
-                    "value": false
-                },
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "assign": " ",
-                    "value": " ",
-                    "termination": ""
-                }
-            },
-            {
-                "type": "const",
-                "name": "MY_NULL",
-                "idlType": {
-                    "type": "const-type",
-                    "generic": null,
-                    "nullable": {
-                        "trivia": ""
-                    },
-                    "union": false,
-                    "idlType": "MyPrimitive",
-                    "baseName": "MyPrimitive",
-                    "escapedBaseName": "MyPrimitive",
-                    "prefix": null,
-                    "postfix": null,
-                    "separator": null,
-                    "extAttrs": null,
-                    "trivia": {
-                        "base": " "
-                    }
-                },
-                "extAttrs": null,
-                "value": {
-                    "type": "null"
-                },
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "assign": " ",
-                    "value": " ",
-                    "termination": ""
-                }
-            }
-        ],
-        "extAttrs": null,
-        "partial": null,
-        "trivia": {
-            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
-    },
-    {
-        "type": "interface",
         "name": "Node",
         "escapedName": "Node",
         "inheritance": null,
@@ -126,7 +42,7 @@
         "extAttrs": null,
         "partial": null,
         "trivia": {
-            "base": "\n\n",
+            "base": "",
             "name": " ",
             "open": " ",
             "close": "\n  // ...\n",

--- a/test/syntax/idl/nullable.widl
+++ b/test/syntax/idl/nullable.widl
@@ -1,9 +1,3 @@
-// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06
-interface MyConstants {
-  const boolean? ARE_WE_THERE_YET = false;
-  const MyPrimitive? MY_NULL = null;
-};
-
 interface Node {
   readonly attribute DOMString? namespaceURI;
   // ...


### PR DESCRIPTION
Following https://github.com/heycam/webidl/pull/686.