### PR TITLE
refactor: use module for checker

### DIFF
--- a/checker/index.html
+++ b/checker/index.html
@@ -2,31 +2,31 @@
 <html>
 
 <head>
-  <meta charset='utf-8'>
+  <meta charset="utf-8">
   <title>WebIDL 2 Checker</title>
 
-  <script type='module'>
-    import { parse, validate } from '../index.js';
+  <script type="module">
+    import { parse, validate } from "../index.js";
 
     function formatParserOutput(parserResult) {
-      const outputEl = document.getElementById('webidl-checker-output');
+      const outputEl = document.getElementById("webidl-checker-output");
       if (parserResult) {
-        const prettyPrintEl = document.getElementById('pretty-print');
+        const prettyPrintEl = document.getElementById("pretty-print");
         outputEl.textContent = JSON.stringify(parserResult, null, prettyPrintEl.checked ? 2 : null);
       } else {
-        outputEl.textContent = '';
+        outputEl.textContent = "";
       }
     }
 
     function checkWebIDL(textToCheck) {
-      const validation = document.getElementById('webidl-checker-validation');
+      const validation = document.getElementById("webidl-checker-validation");
       let parserResult = null;
       try {
         parserResult = parse(textToCheck);
         const validationResult = validate(parserResult);
-        validation.textContent = validationResult.join("\n") || 'WebIDL parsed successfully!';
+        validation.textContent = validationResult.join("\n") || "WebIDL parsed successfully!";
       } catch (e) {
-        validation.textContent = 'Exception while parsing WebIDL. See JavaScript console for more details.\n\n' + e.toString();
+        validation.textContent = "Exception while parsing WebIDL. See JavaScript console for more details.\n\n" + e.toString();
         // Pass it along to the JavaScript console.
         throw e;
       } finally {
@@ -34,11 +34,11 @@
       }
     }
 
-    document.addEventListener('DOMContentLoaded', () => {
-      document.getElementById('check-idl').addEventListener('click', () => {
-        checkWebIDL(document.getElementById('webidl-to-check').value);
+    document.addEventListener("DOMContentLoaded", () => {
+      document.getElementById("check-idl").addEventListener("click", () => {
+        checkWebIDL(document.getElementById("webidl-to-check").value);
       });
-      document.getElementById('pretty-print').addEventListener('change', formatParserOutput);
+      document.getElementById("pretty-print").addEventListener("change", formatParserOutput);
     });
   </script>
   <style>
@@ -53,15 +53,15 @@
   <p>This is an online checker for WebIDL built on the <a href="https://github.com/w3c/webidl2.js">webidl2.js</a>
     project.</p>
   <p>Enter your WebIDL to check below:</p>
-  <textarea id='webidl-to-check' rows='20' cols='80'></textarea>
+  <textarea id="webidl-to-check" rows="20" cols="80"></textarea>
   <br>
-  <input type='button' id='check-idl' value='Check WebIDL'>
+  <input type="button" id="check-idl" value="Check WebIDL">
   <p>Validation results:</p>
-  <textarea id='webidl-checker-validation' rows='20' cols='80'></textarea>
+  <textarea id="webidl-checker-validation" rows="20" cols="80"></textarea>
   <p>Parser output:</p>
-  <textarea id='webidl-checker-output' rows='20' cols='80'></textarea>
+  <textarea id="webidl-checker-output" rows="20" cols="80"></textarea>
   <br>
-  <input type='checkbox' id='pretty-print' checked='true'>Pretty Print
+  <input type="checkbox" id="pretty-print" checked="true">Pretty Print
 </body>
 
 </html>

--- a/checker/index.html
+++ b/checker/index.html
@@ -5,8 +5,9 @@
   <meta charset='utf-8'>
   <title>WebIDL 2 Checker</title>
 
-  <script src='../dist/webidl2.js'></script>
-  <script>
+  <script type='module'>
+    import { parse, validate } from '../index.js';
+
     function formatParserOutput(parserResult) {
       const outputEl = document.getElementById('webidl-checker-output');
       if (parserResult) {
@@ -21,8 +22,8 @@
       const validation = document.getElementById('webidl-checker-validation');
       let parserResult = null;
       try {
-        parserResult = WebIDL2.parse(textToCheck);
-        const validationResult = WebIDL2.validate(parserResult);
+        parserResult = parse(textToCheck);
+        const validationResult = validate(parserResult);
         validation.textContent = validationResult.join("\n") || 'WebIDL parsed successfully!';
       } catch (e) {
         validation.textContent = 'Exception while parsing WebIDL. See JavaScript console for more details.\n\n' + e.toString();
@@ -32,6 +33,13 @@
         formatParserOutput(parserResult);
       }
     }
+
+    document.addEventListener('DOMContentLoaded', () => {
+      document.getElementById('check-idl').addEventListener('click', () => {
+        checkWebIDL(document.getElementById('webidl-to-check').value);
+      });
+      document.getElementById('pretty-print').addEventListener('change', formatParserOutput);
+    });
   </script>
   <style>
     textarea {
@@ -47,13 +55,13 @@
   <p>Enter your WebIDL to check below:</p>
   <textarea id='webidl-to-check' rows='20' cols='80'></textarea>
   <br>
-  <input type='button' value='Check WebIDL' onclick='checkWebIDL(document.getElementById("webidl-to-check").value)'>
+  <input type='button' id='check-idl' value='Check WebIDL'>
   <p>Validation results:</p>
   <textarea id='webidl-checker-validation' rows='20' cols='80'></textarea>
   <p>Parser output:</p>
   <textarea id='webidl-checker-output' rows='20' cols='80'></textarea>
   <br>
-  <input type='checkbox' id='pretty-print' checked='true' onchange='formatParserOutput()'>Pretty Print
+  <input type='checkbox' id='pretty-print' checked='true'>Pretty Print
 </body>
 
 </html>

--- a/index.js
+++ b/index.js
@@ -1,9 +1,3 @@
-import parse from "./lib/webidl2.js";
-import write from "./lib/writer.js";
-import validate from "./lib/validator.js";
-
-export default {
-  parse,
-  write,
-  validate
-};
+export { parse } from "./lib/webidl2.js";
+export { write } from "./lib/writer.js";
+export { validate } from "./lib/validator.js";

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -136,7 +136,7 @@ function* checkInterfaceMemberDuplication(defs) {
   }
 }
 
-export default function validate(ast) {
+export function validate(ast) {
   const defs = groupDefinitions(ast);
   return [
     ...checkDuplicatedNames(defs),

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -1363,7 +1363,7 @@ function parseByTokens(source) {
   return res;
 }
 
-export default function parse(str) {
+export function parse(str) {
   const tokens = tokenise(str);
   return parseByTokens(tokens);
 }

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -16,7 +16,7 @@ const templates = {
   extendedAttributeReference: noop
 };
 
-export default function write(ast, { templates: ts = templates } = {}) {
+export function write(ast, { templates: ts = templates } = {}) {
   ts = Object.assign({}, templates, ts);
 
   /**

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
   },
   "repository": "git://github.com/w3c/webidl2.js",
   "main": "dist/webidl2.js",
+  "module": "index.js",
   "files": [
-    "dist/*"
+    "dist/*",
+    "lib/*"
   ]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,6 @@ module.exports = {
     filename: "webidl2.js",
     path: path.resolve(__dirname, "dist"),
     library: "WebIDL2",
-    libraryExport: "default",
     libraryTarget: "umd",
     globalObject: "this"
   },


### PR DESCRIPTION
Because modules everywhere 😄

Also replacing default export with named exports, which will allow `import { parse } from "webidl2"`.