### PR TITLE
fix(lib/validator): validate when overloads are all from mixins

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Just the usual. For Node:
 npm install webidl2
 ```
 
-In the browser:
+In the browser without module support:
 
 ```HTML
-<script src='webidl2.js'></script>
+<script src='./webidl2/dist/webidl2.js'></script>
 ```
 
 ## Documentation
@@ -35,21 +35,26 @@ WebIDL2 provides two functions: `parse` and `write`.
 In Node, that happens with:
 
 ```JS
-var WebIDL2 = require("webidl2");
-var tree = WebIDL2.parse("string of WebIDL");
-var text = WebIDL2.write(tree);
+const { parse, write, validate } = require("webidl2");
+const tree = parse("string of WebIDL");
+const text = write(tree);
+const validation = validate(tree);
 ```
 
 In the browser:
 ```HTML
-<script src='webidl2.js'></script>
 <script>
-  var tree = WebIDL2.parse("string of WebIDL");
+  const tree = WebIDL2.parse("string of WebIDL");
+  const text = WebIDL2.write(tree);
+  const validation = WebIDL2.validate(tree);
 </script>
 
-<script src='writer.js'></script>
-<script>
-  var text = WebIDL2Writer.write(tree);
+<!-- Or when module is supported -->
+<script type="module">
+  import { parse, write, validate } from "./webidl2/index.js";
+  const tree = parse("string of WebIDL");
+  const text = write(tree);
+  const validation = validate(tree);
 </script>
 ```
 
@@ -90,11 +95,6 @@ var result = WebIDL2.write(tree, {
      */
     type: type => type,
     /**
-     * Called for each value literals, e.g. `"string"` or `3.12`.
-     * @param {string} lit The raw literal string.
-     */
-    valueLiteral: lit => lit,
-    /**
      * Receives the return value of `reference()`. String if it's absent.
      */
     inheritance: inh => inh,
@@ -120,6 +120,17 @@ var result = WebIDL2.write(tree, {
 ```
 
 "Wrapped value" here will all be raw strings when the `wrap()` callback is absent.
+
+`validate()` returns semantic errors in a string array form:
+
+```js
+const validations = validate(tree);
+for (const validation of validations) {
+  console.log(validation);
+}
+// Validation error on line X: ...
+// Validation error on line Y: ...
+```
 
 ### Errors
 

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -105,7 +105,7 @@ function* checkInterfaceMemberDuplication(defs) {
     for (const addition of additions) {
       const { name } = addition;
       if (name && existings.has(name)) {
-        const message = `The operation "${name}" has already been defined for the base interface "${base.name}"`;
+        const message = `The operation "${name}" has already been defined for the base interface "${base.name}" either in itself or in a mixin`;
         yield error(ext.source, addition.body.tokens.name, ext, message);
       }
     }

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -113,7 +113,7 @@ function* checkInterfaceMemberDuplication(defs) {
 
   function getOperations(i) {
     return i.members
-      .filter(({type}) => type === "operation")
+      .filter(({type}) => type === "operation");
   }
 
   function getIncludesMap() {

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -89,32 +89,31 @@ function* checkInterfaceMemberDuplication(defs) {
   }
 
   function* forEachInterface(i) {
-    const opNames = getOperationNames(i);
+    const opNames = new Set(getOperations(i).map(op => op.name));
     const partials = defs.partials.get(i.name) || [];
     const mixins = includesMap.get(i.name) || [];
-    for (const partial of partials) {
-      yield* forEachExtension(partial, opNames, i);
-    }
-    for (const mixin of mixins) {
-      yield* forEachExtension(mixin, opNames, i);
-    }
-  }
-
-  function* forEachExtension(ext, names, base) {
-    for (const op of ext.members.filter(mem => mem.type === "operation")) {
-      const name = (op.body && op.body.name) ? op.body.name.value : "";
-      if (name && names.has(name)) {
-        const message = `The operation "${name}" has already been defined in the base interface "${base.name}"`;
-        yield error(ext.source, op.body.tokens.name, ext, message);
+    for (const ext of [...partials, ...mixins]) {
+      const additions = getOperations(ext);
+      yield* forEachExtension(additions, opNames, ext, i);
+      for (const addition of additions) {
+        opNames.add(addition.name);
       }
     }
   }
 
-  function getOperationNames(i) {
-    const names = i.members
+  function* forEachExtension(additions, existings, ext, base) {
+    for (const addition of additions) {
+      const { name } = addition;
+      if (name && existings.has(name)) {
+        const message = `The operation "${name}" has already been defined for the base interface "${base.name}"`;
+        yield error(ext.source, addition.body.tokens.name, ext, message);
+      }
+    }
+  }
+
+  function getOperations(i) {
+    return i.members
       .filter(({type}) => type === "operation")
-      .map(op => (op.body && op.body.name) ? op.body.name.value : "");
-    return new Set(names);
   }
 
   function getIncludesMap() {

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -955,6 +955,9 @@ function parseByTokens(source) {
     get type() {
       return "operation";
     }
+    get name() {
+      return (this.body && this.body.name && this.body.name.value) || "";
+    }
     get special() {
       return untype_token(this.tokens.special);
     }

--- a/test/invalid/baseline/overloads.txt
+++ b/test/invalid/baseline/overloads.txt
@@ -1,18 +1,18 @@
 Validation error at line 7, inside `partial interface Base`:
   void unique(short num)
-       ^ The operation "unique" has already been defined for the base interface "Base"
+       ^ The operation "unique" has already been defined for the base interface "Base" either in itself or in a mixin
 Validation error at line 11, inside `interface mixin Extension`:
   void unique(string str)
-       ^ The operation "unique" has already been defined for the base interface "Base"
+       ^ The operation "unique" has already been defined for the base interface "Base" either in itself or in a mixin
 Validation error at line 21, inside `interface mixin WebGL2RenderingContextBase`:
   void bufferData(GLenum target,
-       ^ The operation "bufferData" has already been defined for the base interface "WebGL2RenderingContext"
+       ^ The operation "bufferData" has already been defined for the base interface "WebGL2RenderingContext" either in itself or in a mixin
 Validation error at line 22, inside `interface mixin WebGL2RenderingContextBase`:
   void bufferData(GLenum target,
-       ^ The operation "bufferData" has already been defined for the base interface "WebGL2RenderingContext"
+       ^ The operation "bufferData" has already been defined for the base interface "WebGL2RenderingContext" either in itself or in a mixin
 Validation error at line 23, inside `interface mixin WebGL2RenderingContextBase`:
   void bufferData(GLenum target,
-       ^ The operation "bufferData" has already been defined for the base interface "WebGL2RenderingContext"
+       ^ The operation "bufferData" has already been defined for the base interface "WebGL2RenderingContext" either in itself or in a mixin
 Validation error at line 25, inside `interface mixin WebGL2RenderingContextBase`:
   void bufferData(GLenum target,
-       ^ The operation "bufferData" has already been defined for the base interface "WebGL2RenderingContext"
+       ^ The operation "bufferData" has already been defined for the base interface "WebGL2RenderingContext" either in itself or in a mixin

--- a/test/invalid/baseline/overloads.txt
+++ b/test/invalid/baseline/overloads.txt
@@ -1,6 +1,18 @@
 Validation error at line 7, inside `partial interface Base`:
   void unique(short num)
-       ^ The operation "unique" has already been defined in the base interface "Base"
+       ^ The operation "unique" has already been defined for the base interface "Base"
 Validation error at line 11, inside `interface mixin Extension`:
   void unique(string str)
-       ^ The operation "unique" has already been defined in the base interface "Base"
+       ^ The operation "unique" has already been defined for the base interface "Base"
+Validation error at line 21, inside `interface mixin WebGL2RenderingContextBase`:
+  void bufferData(GLenum target,
+       ^ The operation "bufferData" has already been defined for the base interface "WebGL2RenderingContext"
+Validation error at line 22, inside `interface mixin WebGL2RenderingContextBase`:
+  void bufferData(GLenum target,
+       ^ The operation "bufferData" has already been defined for the base interface "WebGL2RenderingContext"
+Validation error at line 23, inside `interface mixin WebGL2RenderingContextBase`:
+  void bufferData(GLenum target,
+       ^ The operation "bufferData" has already been defined for the base interface "WebGL2RenderingContext"
+Validation error at line 25, inside `interface mixin WebGL2RenderingContextBase`:
+  void bufferData(GLenum target,
+       ^ The operation "bufferData" has already been defined for the base interface "WebGL2RenderingContext"

--- a/test/invalid/idl/overloads.widl
+++ b/test/invalid/idl/overloads.widl
@@ -12,3 +12,30 @@ interface mixin Extension {
 };
 Base includes Extension;
 Base includes Unknown;
+
+// WebGL
+
+interface mixin WebGL2RenderingContextBase
+{
+  // WebGL1:
+  void bufferData(GLenum target, GLsizeiptr size, GLenum usage);
+  void bufferData(GLenum target, ArrayBuffer? srcData, GLenum usage);
+  void bufferData(GLenum target, ArrayBufferView srcData, GLenum usage);
+  // WebGL2:
+  void bufferData(GLenum target, ArrayBufferView srcData, GLenum usage, GLuint srcOffset,
+                  optional GLuint length = 0);
+};
+
+interface mixin WebGLRenderingContextBase
+{
+  void bufferData(GLenum target, GLsizeiptr size, GLenum usage);
+  void bufferData(GLenum target, ArrayBuffer? data, GLenum usage);
+  void bufferData(GLenum target, ArrayBufferView data, GLenum usage);
+};
+
+[Exposed=(Window,Worker)]
+interface WebGL2RenderingContext
+{
+};
+WebGL2RenderingContext includes WebGLRenderingContextBase;
+WebGL2RenderingContext includes WebGL2RenderingContextBase;

--- a/test/syntax/baseline/allowany.json
+++ b/test/syntax/baseline/allowany.json
@@ -7,6 +7,7 @@
         "members": [
             {
                 "type": "operation",
+                "name": "g",
                 "body": {
                     "name": {
                         "value": "g",
@@ -43,6 +44,7 @@
             },
             {
                 "type": "operation",
+                "name": "g",
                 "body": {
                     "name": {
                         "value": "g",
@@ -107,6 +109,7 @@
             },
             {
                 "type": "operation",
+                "name": "g",
                 "body": {
                     "name": {
                         "value": "g",

--- a/test/syntax/baseline/callback.json
+++ b/test/syntax/baseline/callback.json
@@ -65,6 +65,7 @@
         "members": [
             {
                 "type": "operation",
+                "name": "eventOccurred",
                 "body": {
                     "name": {
                         "value": "eventOccurred",

--- a/test/syntax/baseline/enum.json
+++ b/test/syntax/baseline/enum.json
@@ -104,6 +104,7 @@
             },
             {
                 "type": "operation",
+                "name": "initialize",
                 "body": {
                     "name": {
                         "value": "initialize",

--- a/test/syntax/baseline/equivalent-decl.json
+++ b/test/syntax/baseline/equivalent-decl.json
@@ -41,6 +41,7 @@
             },
             {
                 "type": "operation",
+                "name": "getProperty",
                 "body": {
                     "name": {
                         "value": "getProperty",
@@ -108,6 +109,7 @@
             },
             {
                 "type": "operation",
+                "name": "setProperty",
                 "body": {
                     "name": {
                         "value": "setProperty",
@@ -256,6 +258,7 @@
             },
             {
                 "type": "operation",
+                "name": "getProperty",
                 "body": {
                     "name": {
                         "value": "getProperty",
@@ -320,6 +323,7 @@
             },
             {
                 "type": "operation",
+                "name": "setProperty",
                 "body": {
                     "name": {
                         "value": "setProperty",
@@ -414,6 +418,7 @@
             },
             {
                 "type": "operation",
+                "name": "",
                 "body": {
                     "name": null,
                     "idlType": {
@@ -477,6 +482,7 @@
             },
             {
                 "type": "operation",
+                "name": "",
                 "body": {
                     "name": null,
                     "idlType": {

--- a/test/syntax/baseline/generic.json
+++ b/test/syntax/baseline/generic.json
@@ -7,6 +7,7 @@
         "members": [
             {
                 "type": "operation",
+                "name": "bar",
                 "body": {
                     "name": {
                         "value": "bar",
@@ -185,6 +186,7 @@
         "members": [
             {
                 "type": "operation",
+                "name": "getServiced",
                 "body": {
                     "name": {
                         "value": "getServiced",
@@ -246,6 +248,7 @@
             },
             {
                 "type": "operation",
+                "name": "reloadAll",
                 "body": {
                     "name": {
                         "value": "reloadAll",
@@ -329,6 +332,7 @@
         "members": [
             {
                 "type": "operation",
+                "name": "default",
                 "body": {
                     "name": {
                         "value": "default",

--- a/test/syntax/baseline/getter-setter.json
+++ b/test/syntax/baseline/getter-setter.json
@@ -41,6 +41,7 @@
             },
             {
                 "type": "operation",
+                "name": "",
                 "body": {
                     "name": null,
                     "idlType": {
@@ -104,6 +105,7 @@
             },
             {
                 "type": "operation",
+                "name": "",
                 "body": {
                     "name": null,
                     "idlType": {

--- a/test/syntax/baseline/identifier-qualified-names.json
+++ b/test/syntax/baseline/identifier-qualified-names.json
@@ -34,6 +34,7 @@
         "members": [
             {
                 "type": "operation",
+                "name": "createObject",
                 "body": {
                     "name": {
                         "value": "createObject",
@@ -98,6 +99,7 @@
             },
             {
                 "type": "operation",
+                "name": "",
                 "body": {
                     "name": null,
                     "idlType": {
@@ -255,6 +257,7 @@
         "members": [
             {
                 "type": "operation",
+                "name": "addEventListener",
                 "body": {
                     "name": {
                         "value": "addEventListener",

--- a/test/syntax/baseline/indexed-properties.json
+++ b/test/syntax/baseline/indexed-properties.json
@@ -41,6 +41,7 @@
             },
             {
                 "type": "operation",
+                "name": "getByIndex",
                 "body": {
                     "name": {
                         "value": "getByIndex",
@@ -111,6 +112,7 @@
             },
             {
                 "type": "operation",
+                "name": "setByIndex",
                 "body": {
                     "name": {
                         "value": "setByIndex",
@@ -211,6 +213,7 @@
             },
             {
                 "type": "operation",
+                "name": "removeByIndex",
                 "body": {
                     "name": {
                         "value": "removeByIndex",
@@ -281,6 +284,7 @@
             },
             {
                 "type": "operation",
+                "name": "get",
                 "body": {
                     "name": {
                         "value": "get",
@@ -348,6 +352,7 @@
             },
             {
                 "type": "operation",
+                "name": "set",
                 "body": {
                     "name": {
                         "value": "set",
@@ -445,6 +450,7 @@
             },
             {
                 "type": "operation",
+                "name": "remove",
                 "body": {
                     "name": {
                         "value": "remove",

--- a/test/syntax/baseline/namespace.json
+++ b/test/syntax/baseline/namespace.json
@@ -37,6 +37,7 @@
             },
             {
                 "type": "operation",
+                "name": "dotProduct",
                 "body": {
                     "name": {
                         "value": "dotProduct",
@@ -131,6 +132,7 @@
             },
             {
                 "type": "operation",
+                "name": "crossProduct",
                 "body": {
                     "name": {
                         "value": "crossProduct",

--- a/test/syntax/baseline/nointerfaceobject.json
+++ b/test/syntax/baseline/nointerfaceobject.json
@@ -7,6 +7,7 @@
         "members": [
             {
                 "type": "operation",
+                "name": "lookupEntry",
                 "body": {
                     "name": {
                         "value": "lookupEntry",

--- a/test/syntax/baseline/nullableobjects.json
+++ b/test/syntax/baseline/nullableobjects.json
@@ -39,6 +39,7 @@
         "members": [
             {
                 "type": "operation",
+                "name": "f",
                 "body": {
                     "name": {
                         "value": "f",
@@ -105,6 +106,7 @@
             },
             {
                 "type": "operation",
+                "name": "f",
                 "body": {
                     "name": {
                         "value": "f",

--- a/test/syntax/baseline/operation-optional-arg.json
+++ b/test/syntax/baseline/operation-optional-arg.json
@@ -7,6 +7,7 @@
         "members": [
             {
                 "type": "operation",
+                "name": "createColor",
                 "body": {
                     "name": {
                         "value": "createColor",

--- a/test/syntax/baseline/overloading.json
+++ b/test/syntax/baseline/overloading.json
@@ -39,6 +39,7 @@
         "members": [
             {
                 "type": "operation",
+                "name": "f",
                 "body": {
                     "name": {
                         "value": "f",
@@ -103,6 +104,7 @@
             },
             {
                 "type": "operation",
+                "name": "f",
                 "body": {
                     "name": {
                         "value": "f",
@@ -184,6 +186,7 @@
         "members": [
             {
                 "type": "operation",
+                "name": "f",
                 "body": {
                     "name": {
                         "value": "f",
@@ -248,6 +251,7 @@
             },
             {
                 "type": "operation",
+                "name": "f",
                 "body": {
                     "name": {
                         "value": "f",
@@ -391,6 +395,7 @@
             },
             {
                 "type": "operation",
+                "name": "f",
                 "body": {
                     "name": {
                         "value": "f",
@@ -427,6 +432,7 @@
             },
             {
                 "type": "operation",
+                "name": "f",
                 "body": {
                     "name": {
                         "value": "f",

--- a/test/syntax/baseline/overridebuiltins.json
+++ b/test/syntax/baseline/overridebuiltins.json
@@ -41,6 +41,7 @@
             },
             {
                 "type": "operation",
+                "name": "lookup",
                 "body": {
                     "name": {
                         "value": "lookup",

--- a/test/syntax/baseline/record.json
+++ b/test/syntax/baseline/record.json
@@ -7,6 +7,7 @@
         "members": [
             {
                 "type": "operation",
+                "name": "foo",
                 "body": {
                     "name": {
                         "value": "foo",
@@ -136,6 +137,7 @@
             },
             {
                 "type": "operation",
+                "name": "bar",
                 "body": {
                     "name": {
                         "value": "bar",
@@ -363,6 +365,7 @@
         "members": [
             {
                 "type": "operation",
+                "name": "bar",
                 "body": {
                     "name": {
                         "value": "bar",

--- a/test/syntax/baseline/reg-operations.json
+++ b/test/syntax/baseline/reg-operations.json
@@ -88,6 +88,7 @@
         "members": [
             {
                 "type": "operation",
+                "name": "isMouseOver",
                 "body": {
                     "name": {
                         "value": "isMouseOver",
@@ -124,6 +125,7 @@
             },
             {
                 "type": "operation",
+                "name": "setDimensions",
                 "body": {
                     "name": {
                         "value": "setDimensions",
@@ -188,6 +190,7 @@
             },
             {
                 "type": "operation",
+                "name": "setDimensions",
                 "body": {
                     "name": {
                         "value": "setDimensions",

--- a/test/syntax/baseline/replaceable.json
+++ b/test/syntax/baseline/replaceable.json
@@ -58,6 +58,7 @@
             },
             {
                 "type": "operation",
+                "name": "increment",
                 "body": {
                     "name": {
                         "value": "increment",

--- a/test/syntax/baseline/sequence.json
+++ b/test/syntax/baseline/sequence.json
@@ -7,6 +7,7 @@
         "members": [
             {
                 "type": "operation",
+                "name": "drawPolygon",
                 "body": {
                     "name": {
                         "value": "drawPolygon",
@@ -94,6 +95,7 @@
             },
             {
                 "type": "operation",
+                "name": "getInflectionPoints",
                 "body": {
                     "name": {
                         "value": "getInflectionPoints",
@@ -170,6 +172,7 @@
         "members": [
             {
                 "type": "operation",
+                "name": "f1",
                 "body": {
                     "name": {
                         "value": "f1",

--- a/test/syntax/baseline/static.json
+++ b/test/syntax/baseline/static.json
@@ -144,6 +144,7 @@
             },
             {
                 "type": "operation",
+                "name": "triangulate",
                 "body": {
                     "name": {
                         "value": "triangulate",

--- a/test/syntax/baseline/stringifier-custom.json
+++ b/test/syntax/baseline/stringifier-custom.json
@@ -99,6 +99,7 @@
             },
             {
                 "type": "operation",
+                "name": "",
                 "body": {
                     "name": null,
                     "idlType": {

--- a/test/syntax/baseline/stringifier.json
+++ b/test/syntax/baseline/stringifier.json
@@ -7,6 +7,7 @@
         "members": [
             {
                 "type": "operation",
+                "name": "",
                 "body": {
                     "name": null,
                     "idlType": {
@@ -59,6 +60,7 @@
         "members": [
             {
                 "type": "operation",
+                "name": "",
                 "body": null,
                 "extAttrs": null,
                 "special": {

--- a/test/syntax/baseline/treatasnull.json
+++ b/test/syntax/baseline/treatasnull.json
@@ -65,6 +65,7 @@
             },
             {
                 "type": "operation",
+                "name": "isMemberOfBreed",
                 "body": {
                     "name": {
                         "value": "isMemberOfBreed",

--- a/test/syntax/baseline/treatasundefined.json
+++ b/test/syntax/baseline/treatasundefined.json
@@ -65,6 +65,7 @@
             },
             {
                 "type": "operation",
+                "name": "isMemberOfBreed",
                 "body": {
                     "name": {
                         "value": "isMemberOfBreed",

--- a/test/syntax/baseline/typedef.json
+++ b/test/syntax/baseline/typedef.json
@@ -238,6 +238,7 @@
             },
             {
                 "type": "operation",
+                "name": "pointWithinBounds",
                 "body": {
                     "name": {
                         "value": "pointWithinBounds",
@@ -302,6 +303,7 @@
             },
             {
                 "type": "operation",
+                "name": "allPointsWithinBounds",
                 "body": {
                     "name": {
                         "value": "allPointsWithinBounds",

--- a/test/syntax/baseline/typesuffixes.json
+++ b/test/syntax/baseline/typesuffixes.json
@@ -7,6 +7,7 @@
         "members": [
             {
                 "type": "operation",
+                "name": "test",
                 "body": {
                     "name": {
                         "value": "test",

--- a/test/syntax/baseline/variadic-operations.json
+++ b/test/syntax/baseline/variadic-operations.json
@@ -41,6 +41,7 @@
             },
             {
                 "type": "operation",
+                "name": "union",
                 "body": {
                     "name": {
                         "value": "union",
@@ -107,6 +108,7 @@
             },
             {
                 "type": "operation",
+                "name": "intersection",
                 "body": {
                     "name": {
                         "value": "intersection",


### PR DESCRIPTION
Turns out the previous function didn't really cover https://github.com/KhronosGroup/WebGL/issues/2216.

Also adding `name` field for operations, which existed but later replaced by `body.name`. Existence check has been painful after that so this field should help.