### PR TITLE
BREAKING CHANGE: remove baseName and escaped* fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,6 @@ attached to a field called `idlType`:
   "idlType": "unsigned short",
   "nullable": false,
   "union": false,
-  "baseName": "short",
   "trivia": {
     "base": " "
   },
@@ -386,7 +385,6 @@ A callback looks like this:
     "nullable": false,
     "union": false,
     "idlType": "void",
-    "baseName": "void",
     "extAttrs": null,
     "trivia": {
       "base": " "
@@ -426,7 +424,6 @@ A dictionary looks like this:
   "members": [{
     "type": "field",
     "name": "fillPattern",
-    "escapedName": "fillPattern",
     "required": false,
     "idlType": {
       "type": "dictionary-type",
@@ -434,7 +431,6 @@ A dictionary looks like this:
       "nullable": true
       "union": false,
       "idlType": "DOMString",
-      "baseName": "DOMString",
       "extAttrs": [...],
       "trivia": {
         "base": "\n  "
@@ -466,7 +462,6 @@ The fields are as follows:
 
 * `type`: Always "dictionary".
 * `name`: The dictionary name.
-* `escapedName`: The dictionary name including possible escaping underscore.
 * `partial`: `true` if the type is a partial dictionary.
 * `members`: An array of members (see below).
 * `trivia`: A trivia object.
@@ -545,7 +540,6 @@ A typedef looks like this:
         "nullable": false,
         "union": false,
         "idlType": "Point",
-        "baseName": "Point",
         "extAttrs": [...]
         "trivia": {
             "base": ""
@@ -608,7 +602,6 @@ An operation looks like this:
       "nullable": false,
       "union": false,
       "idlType": "void",
-      "baseName": "void",
       "extAttrs": null,
       "trivia": {
         "base": "\n  "
@@ -620,7 +613,6 @@ An operation looks like this:
     },
     "name": {
       "value": "intersection",
-      "escaped": "intersection",
       "trivia": " "
     },
     "arguments": [{
@@ -682,14 +674,12 @@ An attribute member looks like this:
     "nullable": false,
     "union": false,
     "idlType": "any",
-    "baseName": "any",
     "extAttrs": [...],
     "trivia": {
       "base": " "
     }
   },
   "name": "regexp",
-  "escapedName": "regexp",
   "extAttrs": null
 }
 ```
@@ -698,7 +688,6 @@ The fields are as follows:
 
 * `type`: Always "attribute".
 * `name`: The attribute's name.
-* `escapedName`: The attribute's name including possible escaping underscore.
 * `special`: One of `"static"`, `"stringifier"`, `"inherit"`, or `null`.
 * `readonly`: `true` if the attribute is read-only.
 * `trivia`: A trivia object.
@@ -718,7 +707,6 @@ A constant member looks like this:
     "nullable": false,
     "union": false,
     "idlType": "boolean",
-    "baseName": "boolean",
     "extAttrs": null,
     "trivia": {
       "base": " "
@@ -768,14 +756,12 @@ The arguments (e.g. for an operation) look like this:
       "nullable": false,
       "union": false,
       "idlType": "float",
-      "baseName": "float",
       "extAttrs": [...],
       "trivia": {
         "base": " "
       }
     },
     "name": "ints",
-    "escapedName": "ints"
   }]
 }
 ```
@@ -786,7 +772,6 @@ The fields are as follows:
 * `variadic`: `true` if the argument is variadic.
 * `idlType`: An [IDL Type](#idl-type) describing the type of the argument.
 * `name`: The argument's name.
-* `escapedName`: The argument's name including possible escaping underscore.
 * `separator`: An object with the following fields if a separator follows:
   * `value`: Always ",".
   * `trivia`: Whitespaces or comments preceding separator token.

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -282,7 +282,7 @@ function parseByTokens(source) {
     }
 
     toJSON() {
-      const json = { type: undefined, name: undefined, escapedName: undefined };
+      const json = { type: undefined, name: undefined };
       let proto = this;
       while (proto !== Object.prototype) {
         const descMap = Object.getOwnPropertyDescriptors(proto);
@@ -385,19 +385,6 @@ function parseByTokens(source) {
       ].filter(t => t).map(t => t.value).join(" ");
       return unescape(name);
     }
-    get baseName() {
-      const { escapedBaseName } = this;
-      if (!escapedBaseName) {
-        return null;
-      }
-      return unescape(escapedBaseName);
-    }
-    get escapedBaseName() {
-      if (!this.tokens.base) {
-        return null;
-      }
-      return this.tokens.base.value;
-    }
   }
 
   class GenericType extends Type {
@@ -439,7 +426,7 @@ function parseByTokens(source) {
 
     get generic() {
       return {
-        value: this.baseName,
+        value: this.tokens.base.value,
         trivia: {
           open: this.tokens.open.trivia,
           close: this.tokens.close.trivia,
@@ -536,10 +523,7 @@ function parseByTokens(source) {
       return !!this.tokens.variadic;
     }
     get name() {
-      return unescape(this.escapedName);
-    }
-    get escapedName() {
-      return this.tokens.name.value;
+      return unescape(this.tokens.name.value);
     }
   }
 
@@ -816,10 +800,7 @@ function parseByTokens(source) {
       return !!this.tokens.readonly;
     }
     get name() {
-      return unescape(this.escapedName);
-    }
-    get escapedName() {
-      return this.tokens.name.value;
+      return unescape(this.tokens.name.value);
     }
   }
 
@@ -855,7 +836,6 @@ function parseByTokens(source) {
       }
       return {
         value: unescape(name.value),
-        escaped: name.value,
         trivia: name.trivia
       };
     }
@@ -966,10 +946,7 @@ function parseByTokens(source) {
     }
 
     get name() {
-      return unescape(this.escapedName);
-    }
-    get escapedName() {
-      return this.tokens.name.value;
+      return unescape(this.tokens.name.value);
     }
   }
 
@@ -1009,10 +986,7 @@ function parseByTokens(source) {
       return !!this.tokens.partial;
     }
     get name() {
-      return unescape(this.escapedName);
-    }
-    get escapedName() {
-      return this.tokens.name.value;
+      return unescape(this.tokens.name.value);
     }
   }
 
@@ -1142,10 +1116,7 @@ function parseByTokens(source) {
       return "field";
     }
     get name() {
-      return unescape(this.escapedName);
-    }
-    get escapedName() {
-      return this.tokens.name.value;
+      return unescape(this.tokens.name.value);
     }
     get required() {
       return !!this.tokens.required;
@@ -1182,10 +1153,7 @@ function parseByTokens(source) {
       return "enum";
     }
     get name() {
-      return unescape(this.escapedName);
-    }
-    get escapedName() {
-      return this.tokens.name.value;
+      return unescape(this.tokens.name.value);
     }
   }
 
@@ -1224,10 +1192,7 @@ function parseByTokens(source) {
       return "typedef";
     }
     get name() {
-      return unescape(this.escapedName);
-    }
-    get escapedName() {
-      return this.tokens.name.value;
+      return unescape(this.tokens.name.value);
     }
   }
 
@@ -1252,16 +1217,10 @@ function parseByTokens(source) {
       return "includes";
     }
     get target() {
-      return unescape(this.escapedTarget);
-    }
-    get escapedTarget() {
-      return this.tokens.target.value;
+      return unescape(this.tokens.target.value);
     }
     get includes() {
-      return unescape(this.escapedIncludes);
-    }
-    get escapedIncludes() {
-      return this.tokens.mixin.value;
+      return unescape(this.tokens.mixin.value);
     }
   }
 

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -157,7 +157,7 @@ export function write(ast, { templates: ts = templates } = {}) {
     return ts.wrap([
       token(inh.tokens.colon),
       ts.trivia(inh.tokens.name.trivia),
-      ts.inheritance(reference(inh.escapedName, inh.name))
+      ts.inheritance(reference(inh.tokens.name.value, inh.name))
     ]);
   }
 

--- a/test/syntax/baseline/allowany.json
+++ b/test/syntax/baseline/allowany.json
@@ -2,7 +2,6 @@
     {
         "type": "interface",
         "name": "B",
-        "escapedName": "B",
         "inheritance": null,
         "members": [
             {
@@ -11,7 +10,6 @@
                 "body": {
                     "name": {
                         "value": "g",
-                        "escaped": "g",
                         "trivia": " "
                     },
                     "idlType": {
@@ -21,8 +19,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": "\n  "
                         }
@@ -45,7 +41,6 @@
                 "body": {
                     "name": {
                         "value": "g",
-                        "escaped": "g",
                         "trivia": " "
                     },
                     "idlType": {
@@ -55,8 +50,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": "\n  "
                         }
@@ -64,7 +57,6 @@
                     "arguments": [
                         {
                             "name": "b",
-                            "escapedName": "b",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -72,8 +64,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "B",
-                                "baseName": "B",
-                                "escapedBaseName": "B",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -103,7 +93,6 @@
                 "body": {
                     "name": {
                         "value": "g",
-                        "escaped": "g",
                         "trivia": " "
                     },
                     "idlType": {
@@ -113,8 +102,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": "\n  "
                         }
@@ -122,7 +109,6 @@
                     "arguments": [
                         {
                             "name": "s",
-                            "escapedName": "s",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": {
@@ -146,8 +132,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "DOMString",
-                                "baseName": "DOMString",
-                                "escapedBaseName": "DOMString",
                                 "trivia": {
                                     "base": " "
                                 }

--- a/test/syntax/baseline/attributes.json
+++ b/test/syntax/baseline/attributes.json
@@ -2,13 +2,11 @@
     {
         "type": "interface",
         "name": "Person",
-        "escapedName": "Person",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "age",
-                "escapedName": "age",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -16,8 +14,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "unsigned short",
-                    "baseName": "short",
-                    "escapedBaseName": "short",
                     "trivia": {
                         "base": " "
                     }
@@ -34,7 +30,6 @@
             {
                 "type": "attribute",
                 "name": "required",
-                "escapedName": "required",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -42,8 +37,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "any",
-                    "baseName": "any",
-                    "escapedBaseName": "any",
                     "trivia": {
                         "base": " "
                     }

--- a/test/syntax/baseline/callback.json
+++ b/test/syntax/baseline/callback.json
@@ -9,8 +9,6 @@
             "nullable": false,
             "union": false,
             "idlType": "void",
-            "baseName": "void",
-            "escapedBaseName": "void",
             "trivia": {
                 "base": " "
             }
@@ -18,7 +16,6 @@
         "arguments": [
             {
                 "name": "status",
-                "escapedName": "status",
                 "idlType": {
                     "type": "argument-type",
                     "extAttrs": null,
@@ -26,8 +23,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "DOMString",
-                    "baseName": "DOMString",
-                    "escapedBaseName": "DOMString",
                     "trivia": {
                         "base": ""
                     }
@@ -53,7 +48,6 @@
     {
         "type": "callback interface",
         "name": "EventHandler",
-        "escapedName": "EventHandler",
         "inheritance": null,
         "members": [
             {
@@ -62,7 +56,6 @@
                 "body": {
                     "name": {
                         "value": "eventOccurred",
-                        "escaped": "eventOccurred",
                         "trivia": " "
                     },
                     "idlType": {
@@ -72,8 +65,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": "\n  "
                         }
@@ -81,7 +72,6 @@
                     "arguments": [
                         {
                             "name": "details",
-                            "escapedName": "details",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -89,8 +79,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "DOMString",
-                                "baseName": "DOMString",
-                                "escapedBaseName": "DOMString",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -136,8 +124,6 @@
             "nullable": false,
             "union": false,
             "idlType": "boolean",
-            "baseName": "boolean",
-            "escapedBaseName": "boolean",
             "trivia": {
                 "base": " "
             }
@@ -145,7 +131,6 @@
         "arguments": [
             {
                 "name": "a",
-                "escapedName": "a",
                 "idlType": {
                     "type": "argument-type",
                     "extAttrs": null,
@@ -153,8 +138,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "any",
-                    "baseName": "any",
-                    "escapedBaseName": "any",
                     "trivia": {
                         "base": ""
                     }
@@ -168,7 +151,6 @@
             },
             {
                 "name": "b",
-                "escapedName": "b",
                 "idlType": {
                     "type": "argument-type",
                     "extAttrs": null,
@@ -176,8 +158,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "any",
-                    "baseName": "any",
-                    "escapedBaseName": "any",
                     "trivia": {
                         "base": " "
                     }

--- a/test/syntax/baseline/constants.json
+++ b/test/syntax/baseline/constants.json
@@ -2,7 +2,6 @@
     {
         "type": "interface",
         "name": "Util",
-        "escapedName": "Util",
         "inheritance": null,
         "members": [
             {
@@ -15,8 +14,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "boolean",
-                    "baseName": "boolean",
-                    "escapedBaseName": "boolean",
                     "trivia": {
                         "base": " "
                     }
@@ -44,8 +41,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "short",
-                    "baseName": "short",
-                    "escapedBaseName": "short",
                     "trivia": {
                         "base": " "
                     }
@@ -73,8 +68,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "octet",
-                    "baseName": "octet",
-                    "escapedBaseName": "octet",
                     "trivia": {
                         "base": " "
                     }
@@ -102,8 +95,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "unsigned long",
-                    "baseName": "long",
-                    "escapedBaseName": "long",
                     "trivia": {
                         "base": " "
                     }
@@ -131,8 +122,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "float",
-                    "baseName": "float",
-                    "escapedBaseName": "float",
                     "trivia": {
                         "base": " "
                     }
@@ -160,8 +149,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "unrestricted float",
-                    "baseName": "float",
-                    "escapedBaseName": "float",
                     "trivia": {
                         "base": " "
                     }
@@ -189,8 +176,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "unrestricted double",
-                    "baseName": "double",
-                    "escapedBaseName": "double",
                     "trivia": {
                         "base": " "
                     }
@@ -218,8 +203,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "short",
-                    "baseName": "short",
-                    "escapedBaseName": "short",
                     "trivia": {
                         "base": " "
                     }

--- a/test/syntax/baseline/constructor.json
+++ b/test/syntax/baseline/constructor.json
@@ -2,13 +2,11 @@
     {
         "type": "interface",
         "name": "Circle",
-        "escapedName": "Circle",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "r",
-                "escapedName": "r",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -16,8 +14,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "float",
-                    "baseName": "float",
-                    "escapedBaseName": "float",
                     "trivia": {
                         "base": " "
                     }
@@ -34,7 +30,6 @@
             {
                 "type": "attribute",
                 "name": "cx",
-                "escapedName": "cx",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -42,8 +37,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "float",
-                    "baseName": "float",
-                    "escapedBaseName": "float",
                     "trivia": {
                         "base": " "
                     }
@@ -60,7 +53,6 @@
             {
                 "type": "attribute",
                 "name": "cy",
-                "escapedName": "cy",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -68,8 +60,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "float",
-                    "baseName": "float",
-                    "escapedBaseName": "float",
                     "trivia": {
                         "base": " "
                     }
@@ -86,7 +76,6 @@
             {
                 "type": "attribute",
                 "name": "circumference",
-                "escapedName": "circumference",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -94,8 +83,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "float",
-                    "baseName": "float",
-                    "escapedBaseName": "float",
                     "trivia": {
                         "base": " "
                     }
@@ -129,7 +116,6 @@
                         "arguments": [
                             {
                                 "name": "radius",
-                                "escapedName": "radius",
                                 "idlType": {
                                     "type": "argument-type",
                                     "extAttrs": null,
@@ -137,8 +123,6 @@
                                     "nullable": false,
                                     "union": false,
                                     "idlType": "float",
-                                    "baseName": "float",
-                                    "escapedBaseName": "float",
                                     "trivia": {
                                         "base": ""
                                     }

--- a/test/syntax/baseline/dictionary-inherits.json
+++ b/test/syntax/baseline/dictionary-inherits.json
@@ -2,13 +2,11 @@
     {
         "type": "dictionary",
         "name": "PaintOptions",
-        "escapedName": "PaintOptions",
         "inheritance": null,
         "members": [
             {
                 "type": "field",
                 "name": "fillPattern",
-                "escapedName": "fillPattern",
                 "extAttrs": null,
                 "idlType": {
                     "type": "dictionary-type",
@@ -17,8 +15,6 @@
                     "nullable": true,
                     "union": false,
                     "idlType": "DOMString",
-                    "baseName": "DOMString",
-                    "escapedBaseName": "DOMString",
                     "trivia": {
                         "base": "\n  "
                     }
@@ -40,7 +36,6 @@
             {
                 "type": "field",
                 "name": "strokePattern",
-                "escapedName": "strokePattern",
                 "extAttrs": null,
                 "idlType": {
                     "type": "dictionary-type",
@@ -49,8 +44,6 @@
                     "nullable": true,
                     "union": false,
                     "idlType": "DOMString",
-                    "baseName": "DOMString",
-                    "escapedBaseName": "DOMString",
                     "trivia": {
                         "base": "\n  "
                     }
@@ -71,7 +64,6 @@
             {
                 "type": "field",
                 "name": "position",
-                "escapedName": "position",
                 "extAttrs": null,
                 "idlType": {
                     "type": "dictionary-type",
@@ -80,8 +72,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "Point",
-                    "baseName": "Point",
-                    "escapedBaseName": "Point",
                     "trivia": {
                         "base": "\n  "
                     }
@@ -107,10 +97,8 @@
     {
         "type": "dictionary",
         "name": "WetPaintOptions",
-        "escapedName": "WetPaintOptions",
         "inheritance": {
             "name": "PaintOptions",
-            "escapedName": "PaintOptions",
             "trivia": {
                 "colon": " ",
                 "name": " "
@@ -120,7 +108,6 @@
             {
                 "type": "field",
                 "name": "hydrometry",
-                "escapedName": "hydrometry",
                 "extAttrs": null,
                 "idlType": {
                     "type": "dictionary-type",
@@ -129,8 +116,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "float",
-                    "baseName": "float",
-                    "escapedBaseName": "float",
                     "trivia": {
                         "base": "\n  "
                     }

--- a/test/syntax/baseline/dictionary.json
+++ b/test/syntax/baseline/dictionary.json
@@ -2,13 +2,11 @@
     {
         "type": "dictionary",
         "name": "PaintOptions",
-        "escapedName": "PaintOptions",
         "inheritance": null,
         "members": [
             {
                 "type": "field",
                 "name": "fillPattern",
-                "escapedName": "fillPattern",
                 "extAttrs": null,
                 "idlType": {
                     "type": "dictionary-type",
@@ -17,8 +15,6 @@
                     "nullable": true,
                     "union": false,
                     "idlType": "DOMString",
-                    "baseName": "DOMString",
-                    "escapedBaseName": "DOMString",
                     "trivia": {
                         "base": "\n  "
                     }
@@ -40,7 +36,6 @@
             {
                 "type": "field",
                 "name": "strokePattern",
-                "escapedName": "strokePattern",
                 "extAttrs": null,
                 "idlType": {
                     "type": "dictionary-type",
@@ -49,8 +44,6 @@
                     "nullable": true,
                     "union": false,
                     "idlType": "DOMString",
-                    "baseName": "DOMString",
-                    "escapedBaseName": "DOMString",
                     "trivia": {
                         "base": "\n  "
                     }
@@ -71,7 +64,6 @@
             {
                 "type": "field",
                 "name": "position",
-                "escapedName": "position",
                 "extAttrs": null,
                 "idlType": {
                     "type": "dictionary-type",
@@ -80,8 +72,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "Point",
-                    "baseName": "Point",
-                    "escapedBaseName": "Point",
                     "trivia": {
                         "base": "\n  "
                     }
@@ -96,7 +86,6 @@
             {
                 "type": "field",
                 "name": "seq",
-                "escapedName": "seq",
                 "extAttrs": null,
                 "idlType": {
                     "type": "dictionary-type",
@@ -118,15 +107,11 @@
                             "nullable": false,
                             "union": false,
                             "idlType": "long",
-                            "baseName": "long",
-                            "escapedBaseName": "long",
                             "trivia": {
                                 "base": ""
                             }
                         }
                     ],
-                    "baseName": "sequence",
-                    "escapedBaseName": "sequence",
                     "trivia": {
                         "base": "\n  // https://heycam.github.io/webidl/#dfn-optional-argument-default-value allows sequences to default to \"[]\".\n  "
                     }
@@ -149,7 +134,6 @@
             {
                 "type": "field",
                 "name": "reqSeq",
-                "escapedName": "reqSeq",
                 "extAttrs": null,
                 "idlType": {
                     "type": "dictionary-type",
@@ -158,8 +142,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "long",
-                    "baseName": "long",
-                    "escapedBaseName": "long",
                     "trivia": {
                         "base": " "
                     }
@@ -185,12 +167,10 @@
     {
         "type": "dictionary",
         "name": "A",
-        "escapedName": "_A",
         "members": [
             {
                 "type": "field",
                 "name": "h",
-                "escapedName": "h",
                 "extAttrs": null,
                 "idlType": {
                     "type": "dictionary-type",
@@ -199,8 +179,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "long",
-                    "baseName": "long",
-                    "escapedBaseName": "long",
                     "trivia": {
                         "base": "\n  "
                     }
@@ -215,7 +193,6 @@
             {
                 "type": "field",
                 "name": "d",
-                "escapedName": "d",
                 "extAttrs": null,
                 "idlType": {
                     "type": "dictionary-type",
@@ -224,8 +201,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "long",
-                    "baseName": "long",
-                    "escapedBaseName": "long",
                     "trivia": {
                         "base": "\n  "
                     }

--- a/test/syntax/baseline/documentation-dos.json
+++ b/test/syntax/baseline/documentation-dos.json
@@ -2,7 +2,6 @@
     {
         "type": "interface",
         "name": "Documentation",
-        "escapedName": "Documentation",
         "inheritance": null,
         "members": [],
         "extAttrs": null,

--- a/test/syntax/baseline/documentation.json
+++ b/test/syntax/baseline/documentation.json
@@ -2,7 +2,6 @@
     {
         "type": "interface",
         "name": "Documentation",
-        "escapedName": "Documentation",
         "inheritance": null,
         "members": [],
         "extAttrs": null,

--- a/test/syntax/baseline/enum.json
+++ b/test/syntax/baseline/enum.json
@@ -2,7 +2,6 @@
     {
         "type": "enum",
         "name": "MealType",
-        "escapedName": "MealType",
         "values": [
             {
                 "type": "enum-value",
@@ -32,13 +31,11 @@
     {
         "type": "interface",
         "name": "Meal",
-        "escapedName": "Meal",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "type",
-                "escapedName": "type",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -46,8 +43,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "MealType",
-                    "baseName": "MealType",
-                    "escapedBaseName": "MealType",
                     "trivia": {
                         "base": " "
                     }
@@ -64,7 +59,6 @@
             {
                 "type": "attribute",
                 "name": "size",
-                "escapedName": "size",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -72,8 +66,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "float",
-                    "baseName": "float",
-                    "escapedBaseName": "float",
                     "trivia": {
                         "base": " "
                     }
@@ -93,7 +85,6 @@
                 "body": {
                     "name": {
                         "value": "initialize",
-                        "escaped": "initialize",
                         "trivia": " "
                     },
                     "idlType": {
@@ -103,8 +94,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": "     // in grams\n\n  "
                         }
@@ -112,7 +101,6 @@
                     "arguments": [
                         {
                             "name": "type",
-                            "escapedName": "type",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -120,8 +108,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "MealType",
-                                "baseName": "MealType",
-                                "escapedBaseName": "MealType",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -135,7 +121,6 @@
                         },
                         {
                             "name": "size",
-                            "escapedName": "size",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -143,8 +128,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "float",
-                                "baseName": "float",
-                                "escapedBaseName": "float",
                                 "trivia": {
                                     "base": " "
                                 }
@@ -182,7 +165,6 @@
     {
         "type": "enum",
         "name": "AltMealType",
-        "escapedName": "_AltMealType",
         "values": [
             {
                 "type": "enum-value",

--- a/test/syntax/baseline/equivalent-decl.json
+++ b/test/syntax/baseline/equivalent-decl.json
@@ -2,13 +2,11 @@
     {
         "type": "interface",
         "name": "Dictionary",
-        "escapedName": "Dictionary",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "propertyCount",
-                "escapedName": "propertyCount",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -16,8 +14,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "unsigned long",
-                    "baseName": "long",
-                    "escapedBaseName": "long",
                     "trivia": {
                         "base": " "
                     }
@@ -37,7 +33,6 @@
                 "body": {
                     "name": {
                         "value": "getProperty",
-                        "escaped": "getProperty",
                         "trivia": " "
                     },
                     "idlType": {
@@ -47,8 +42,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "float",
-                        "baseName": "float",
-                        "escapedBaseName": "float",
                         "trivia": {
                             "base": " "
                         }
@@ -56,7 +49,6 @@
                     "arguments": [
                         {
                             "name": "propertyName",
-                            "escapedName": "propertyName",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -64,8 +56,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "DOMString",
-                                "baseName": "DOMString",
-                                "escapedBaseName": "DOMString",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -95,7 +85,6 @@
                 "body": {
                     "name": {
                         "value": "setProperty",
-                        "escaped": "setProperty",
                         "trivia": " "
                     },
                     "idlType": {
@@ -105,8 +94,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": " "
                         }
@@ -114,7 +101,6 @@
                     "arguments": [
                         {
                             "name": "propertyName",
-                            "escapedName": "propertyName",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -122,8 +108,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "DOMString",
-                                "baseName": "DOMString",
-                                "escapedBaseName": "DOMString",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -137,7 +121,6 @@
                         },
                         {
                             "name": "propertyValue",
-                            "escapedName": "propertyValue",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -145,8 +128,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "float",
-                                "baseName": "float",
-                                "escapedBaseName": "float",
                                 "trivia": {
                                     "base": " "
                                 }
@@ -184,13 +165,11 @@
     {
         "type": "interface",
         "name": "Dictionary2",
-        "escapedName": "Dictionary2",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "propertyCount",
-                "escapedName": "propertyCount",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -198,8 +177,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "unsigned long",
-                    "baseName": "long",
-                    "escapedBaseName": "long",
                     "trivia": {
                         "base": " "
                     }
@@ -219,7 +196,6 @@
                 "body": {
                     "name": {
                         "value": "getProperty",
-                        "escaped": "getProperty",
                         "trivia": " "
                     },
                     "idlType": {
@@ -229,8 +205,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "float",
-                        "baseName": "float",
-                        "escapedBaseName": "float",
                         "trivia": {
                             "base": "\n\n  "
                         }
@@ -238,7 +212,6 @@
                     "arguments": [
                         {
                             "name": "propertyName",
-                            "escapedName": "propertyName",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -246,8 +219,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "DOMString",
-                                "baseName": "DOMString",
-                                "escapedBaseName": "DOMString",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -277,7 +248,6 @@
                 "body": {
                     "name": {
                         "value": "setProperty",
-                        "escaped": "setProperty",
                         "trivia": " "
                     },
                     "idlType": {
@@ -287,8 +257,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": "\n  "
                         }
@@ -296,7 +264,6 @@
                     "arguments": [
                         {
                             "name": "propertyName",
-                            "escapedName": "propertyName",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -304,8 +271,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "DOMString",
-                                "baseName": "DOMString",
-                                "escapedBaseName": "DOMString",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -319,7 +284,6 @@
                         },
                         {
                             "name": "propertyValue",
-                            "escapedName": "propertyValue",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -327,8 +291,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "float",
-                                "baseName": "float",
-                                "escapedBaseName": "float",
                                 "trivia": {
                                     "base": " "
                                 }
@@ -364,8 +326,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "float",
-                        "baseName": "float",
-                        "escapedBaseName": "float",
                         "trivia": {
                             "base": " "
                         }
@@ -373,7 +333,6 @@
                     "arguments": [
                         {
                             "name": "propertyName",
-                            "escapedName": "propertyName",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -381,8 +340,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "DOMString",
-                                "baseName": "DOMString",
-                                "escapedBaseName": "DOMString",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -418,8 +375,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": " "
                         }
@@ -427,7 +382,6 @@
                     "arguments": [
                         {
                             "name": "propertyName",
-                            "escapedName": "propertyName",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -435,8 +389,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "DOMString",
-                                "baseName": "DOMString",
-                                "escapedBaseName": "DOMString",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -450,7 +402,6 @@
                         },
                         {
                             "name": "propertyValue",
-                            "escapedName": "propertyValue",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -458,8 +409,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "float",
-                                "baseName": "float",
-                                "escapedBaseName": "float",
                                 "trivia": {
                                     "base": " "
                                 }

--- a/test/syntax/baseline/escaped-name.json
+++ b/test/syntax/baseline/escaped-name.json
@@ -2,10 +2,8 @@
     {
         "type": "interface",
         "name": "Iroha",
-        "escapedName": "_Iroha",
         "inheritance": {
             "name": "Magic",
-            "escapedName": "_Magic",
             "trivia": {
                 "colon": " ",
                 "name": " "
@@ -26,9 +24,7 @@
         "type": "includes",
         "extAttrs": null,
         "target": "Iroha",
-        "escapedTarget": "_Iroha",
         "includes": "Color",
-        "escapedIncludes": "_Color",
         "trivia": {
             "target": "\n",
             "includes": " ",

--- a/test/syntax/baseline/escaped-type.json
+++ b/test/syntax/baseline/escaped-type.json
@@ -2,7 +2,6 @@
     {
         "type": "typedef",
         "name": "EscapedType",
-        "escapedName": "EscapedType",
         "idlType": {
             "type": "typedef-type",
             "extAttrs": null,
@@ -10,8 +9,6 @@
             "nullable": false,
             "union": false,
             "idlType": "Type",
-            "baseName": "Type",
-            "escapedBaseName": "_Type",
             "trivia": {
                 "base": " "
             }
@@ -26,7 +23,6 @@
     {
         "type": "typedef",
         "name": "EscapedSequence",
-        "escapedName": "EscapedSequence",
         "idlType": {
             "type": "typedef-type",
             "extAttrs": null,
@@ -47,15 +43,11 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "Type",
-                    "baseName": "Type",
-                    "escapedBaseName": "_Type",
                     "trivia": {
                         "base": ""
                     }
                 }
             ],
-            "baseName": "sequence",
-            "escapedBaseName": "sequence",
             "trivia": {
                 "base": " "
             }

--- a/test/syntax/baseline/extended-attributes.json
+++ b/test/syntax/baseline/extended-attributes.json
@@ -2,10 +2,8 @@
     {
         "type": "interface",
         "name": "ServiceWorkerGlobalScope",
-        "escapedName": "ServiceWorkerGlobalScope",
         "inheritance": {
             "name": "WorkerGlobalScope",
-            "escapedName": "WorkerGlobalScope",
             "trivia": {
                 "colon": " ",
                 "name": " "
@@ -74,7 +72,6 @@
     {
         "type": "interface",
         "name": "IdInterface",
-        "escapedName": "IdInterface",
         "inheritance": null,
         "members": [],
         "extAttrs": {
@@ -145,13 +142,11 @@
     {
         "type": "interface",
         "name": "Circle",
-        "escapedName": "Circle",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "r",
-                "escapedName": "r",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -159,8 +154,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "double",
-                    "baseName": "double",
-                    "escapedBaseName": "double",
                     "trivia": {
                         "base": " "
                     }
@@ -177,7 +170,6 @@
             {
                 "type": "attribute",
                 "name": "cx",
-                "escapedName": "cx",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -185,8 +177,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "double",
-                    "baseName": "double",
-                    "escapedBaseName": "double",
                     "trivia": {
                         "base": " "
                     }
@@ -203,7 +193,6 @@
             {
                 "type": "attribute",
                 "name": "cy",
-                "escapedName": "cy",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -211,8 +200,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "double",
-                    "baseName": "double",
-                    "escapedBaseName": "double",
                     "trivia": {
                         "base": " "
                     }
@@ -229,7 +216,6 @@
             {
                 "type": "attribute",
                 "name": "circumference",
-                "escapedName": "circumference",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -237,8 +223,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "double",
-                    "baseName": "double",
-                    "escapedBaseName": "double",
                     "trivia": {
                         "base": " "
                     }
@@ -272,7 +256,6 @@
                         "arguments": [
                             {
                                 "name": "radius",
-                                "escapedName": "radius",
                                 "idlType": {
                                     "type": "argument-type",
                                     "extAttrs": null,
@@ -280,8 +263,6 @@
                                     "nullable": false,
                                     "union": false,
                                     "idlType": "double",
-                                    "baseName": "double",
-                                    "escapedBaseName": "double",
                                     "trivia": {
                                         "base": ""
                                     }
@@ -321,13 +302,11 @@
     {
         "type": "interface",
         "name": "I",
-        "escapedName": "I",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "attrib",
-                "escapedName": "attrib",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": {
@@ -358,8 +337,6 @@
                             "nullable": false,
                             "union": false,
                             "idlType": "long",
-                            "baseName": "long",
-                            "escapedBaseName": "long",
                             "trivia": {
                                 "base": ""
                             }
@@ -371,15 +348,11 @@
                             "nullable": false,
                             "union": false,
                             "idlType": "Node",
-                            "baseName": "Node",
-                            "escapedBaseName": "Node",
                             "trivia": {
                                 "base": " "
                             }
                         }
                     ],
-                    "baseName": null,
-                    "escapedBaseName": null,
                     "trivia": {
                         "open": " ",
                         "close": ""

--- a/test/syntax/baseline/generic.json
+++ b/test/syntax/baseline/generic.json
@@ -2,7 +2,6 @@
     {
         "type": "interface",
         "name": "Foo",
-        "escapedName": "Foo",
         "inheritance": null,
         "members": [
             {
@@ -11,7 +10,6 @@
                 "body": {
                     "name": {
                         "value": "bar",
-                        "escaped": "bar",
                         "trivia": " "
                     },
                     "idlType": {
@@ -60,29 +58,21 @@
                                                 "nullable": true,
                                                 "union": false,
                                                 "idlType": "DOMString",
-                                                "baseName": "DOMString",
-                                                "escapedBaseName": "DOMString",
                                                 "trivia": {
                                                     "base": ""
                                                 }
                                             }
                                         ],
-                                        "baseName": "sequence",
-                                        "escapedBaseName": "sequence",
                                         "trivia": {
                                             "base": ""
                                         }
                                     }
                                 ],
-                                "baseName": "Promise",
-                                "escapedBaseName": "Promise",
                                 "trivia": {
                                     "base": ""
                                 }
                             }
                         ],
-                        "baseName": "Promise",
-                        "escapedBaseName": "Promise",
                         "trivia": {
                             "base": "\n  "
                         }
@@ -102,7 +92,6 @@
             {
                 "type": "attribute",
                 "name": "baz",
-                "escapedName": "baz",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -123,15 +112,11 @@
                             "nullable": false,
                             "union": false,
                             "idlType": "DOMString",
-                            "baseName": "DOMString",
-                            "escapedBaseName": "DOMString",
                             "trivia": {
                                 "base": ""
                             }
                         }
                     ],
-                    "baseName": "Promise",
-                    "escapedBaseName": "Promise",
                     "trivia": {
                         "base": " "
                     }
@@ -159,7 +144,6 @@
     {
         "type": "interface",
         "name": "ServiceWorkerClients",
-        "escapedName": "ServiceWorkerClients",
         "inheritance": null,
         "members": [
             {
@@ -168,7 +152,6 @@
                 "body": {
                     "name": {
                         "value": "getServiced",
-                        "escaped": "getServiced",
                         "trivia": " "
                     },
                     "idlType": {
@@ -191,15 +174,11 @@
                                 "nullable": true,
                                 "union": false,
                                 "idlType": "Client",
-                                "baseName": "Client",
-                                "escapedBaseName": "Client",
                                 "trivia": {
                                     "base": ""
                                 }
                             }
                         ],
-                        "baseName": "Promise",
-                        "escapedBaseName": "Promise",
                         "trivia": {
                             "base": "\n  "
                         }
@@ -222,7 +201,6 @@
                 "body": {
                     "name": {
                         "value": "reloadAll",
-                        "escaped": "reloadAll",
                         "trivia": " "
                     },
                     "idlType": {
@@ -245,15 +223,11 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "any",
-                                "baseName": "any",
-                                "escapedBaseName": "any",
                                 "trivia": {
                                     "base": ""
                                 }
                             }
                         ],
-                        "baseName": "Promise",
-                        "escapedBaseName": "Promise",
                         "trivia": {
                             "base": "\n  "
                         }
@@ -284,10 +258,8 @@
     {
         "type": "interface",
         "name": "FetchEvent",
-        "escapedName": "FetchEvent",
         "inheritance": {
             "name": "Event",
-            "escapedName": "Event",
             "trivia": {
                 "colon": " ",
                 "name": " "
@@ -300,7 +272,6 @@
                 "body": {
                     "name": {
                         "value": "default",
-                        "escaped": "default",
                         "trivia": " "
                     },
                     "idlType": {
@@ -323,15 +294,11 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "any",
-                                "baseName": "any",
-                                "escapedBaseName": "any",
                                 "trivia": {
                                     "base": ""
                                 }
                             }
                         ],
-                        "baseName": "Promise",
-                        "escapedBaseName": "Promise",
                         "trivia": {
                             "base": "\n  "
                         }

--- a/test/syntax/baseline/getter-setter.json
+++ b/test/syntax/baseline/getter-setter.json
@@ -2,13 +2,11 @@
     {
         "type": "interface",
         "name": "Dictionary",
-        "escapedName": "Dictionary",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "propertyCount",
-                "escapedName": "propertyCount",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -16,8 +14,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "unsigned long",
-                    "baseName": "long",
-                    "escapedBaseName": "long",
                     "trivia": {
                         "base": " "
                     }
@@ -43,8 +39,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "float",
-                        "baseName": "float",
-                        "escapedBaseName": "float",
                         "trivia": {
                             "base": " "
                         }
@@ -52,7 +46,6 @@
                     "arguments": [
                         {
                             "name": "propertyName",
-                            "escapedName": "propertyName",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -60,8 +53,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "DOMString",
-                                "baseName": "DOMString",
-                                "escapedBaseName": "DOMString",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -97,8 +88,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": " "
                         }
@@ -106,7 +95,6 @@
                     "arguments": [
                         {
                             "name": "propertyName",
-                            "escapedName": "propertyName",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -114,8 +102,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "DOMString",
-                                "baseName": "DOMString",
-                                "escapedBaseName": "DOMString",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -129,7 +115,6 @@
                         },
                         {
                             "name": "propertyValue",
-                            "escapedName": "propertyValue",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -137,8 +122,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "float",
-                                "baseName": "float",
-                                "escapedBaseName": "float",
                                 "trivia": {
                                     "base": " "
                                 }

--- a/test/syntax/baseline/identifier-hyphen.json
+++ b/test/syntax/baseline/identifier-hyphen.json
@@ -2,12 +2,10 @@
     {
         "type": "interface",
         "name": "CSSStyleDeclaration",
-        "escapedName": "CSSStyleDeclaration",
         "members": [
             {
                 "type": "attribute",
                 "name": "-will-change",
-                "escapedName": "-will-change",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": {
@@ -38,8 +36,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "CSSOMString",
-                    "baseName": "CSSOMString",
-                    "escapedBaseName": "CSSOMString",
                     "trivia": {
                         "base": " "
                     }

--- a/test/syntax/baseline/identifier-qualified-names.json
+++ b/test/syntax/baseline/identifier-qualified-names.json
@@ -2,7 +2,6 @@
     {
         "type": "typedef",
         "name": "number",
-        "escapedName": "number",
         "idlType": {
             "type": "typedef-type",
             "extAttrs": null,
@@ -10,8 +9,6 @@
             "nullable": false,
             "union": false,
             "idlType": "float",
-            "baseName": "float",
-            "escapedBaseName": "float",
             "trivia": {
                 "base": " "
             }
@@ -26,7 +23,6 @@
     {
         "type": "interface",
         "name": "System",
-        "escapedName": "System",
         "inheritance": null,
         "members": [
             {
@@ -35,7 +31,6 @@
                 "body": {
                     "name": {
                         "value": "createObject",
-                        "escaped": "createObject",
                         "trivia": " "
                     },
                     "idlType": {
@@ -45,8 +40,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "object",
-                        "baseName": "object",
-                        "escapedBaseName": "object",
                         "trivia": {
                             "base": "\n\n    // Operation identifier:          \"createObject\"\n    // Operation argument identifier: \"interface\"\n    "
                         }
@@ -54,7 +47,6 @@
                     "arguments": [
                         {
                             "name": "interface",
-                            "escapedName": "_interface",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -62,8 +54,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "DOMString",
-                                "baseName": "DOMString",
-                                "escapedBaseName": "DOMString",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -99,8 +89,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "DOMString",
-                        "baseName": "DOMString",
-                        "escapedBaseName": "DOMString",
                         "trivia": {
                             "base": " "
                         }
@@ -108,7 +96,6 @@
                     "arguments": [
                         {
                             "name": "keyName",
-                            "escapedName": "keyName",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -116,8 +103,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "DOMString",
-                                "baseName": "DOMString",
-                                "escapedBaseName": "DOMString",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -155,13 +140,11 @@
     {
         "type": "interface",
         "name": "TextField",
-        "escapedName": "TextField",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "const",
-                "escapedName": "_const",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -169,8 +152,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "boolean",
-                    "baseName": "boolean",
-                    "escapedBaseName": "boolean",
                     "trivia": {
                         "base": " "
                     }
@@ -187,7 +168,6 @@
             {
                 "type": "attribute",
                 "name": "value",
-                "escapedName": "_value",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -195,8 +175,6 @@
                     "nullable": true,
                     "union": false,
                     "idlType": "DOMString",
-                    "baseName": "DOMString",
-                    "escapedBaseName": "DOMString",
                     "trivia": {
                         "base": " "
                     }
@@ -224,7 +202,6 @@
     {
         "type": "interface",
         "name": "FooEventTarget",
-        "escapedName": "FooEventTarget",
         "inheritance": null,
         "members": [
             {
@@ -233,7 +210,6 @@
                 "body": {
                     "name": {
                         "value": "addEventListener",
-                        "escaped": "addEventListener",
                         "trivia": " "
                     },
                     "idlType": {
@@ -243,8 +219,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": "\n  // Argument names allow some selected keywords\n  "
                         }
@@ -252,7 +226,6 @@
                     "arguments": [
                         {
                             "name": "callback",
-                            "escapedName": "callback",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -260,8 +233,6 @@
                                 "nullable": true,
                                 "union": false,
                                 "idlType": "EventListener",
-                                "baseName": "EventListener",
-                                "escapedBaseName": "EventListener",
                                 "trivia": {
                                     "base": ""
                                 }

--- a/test/syntax/baseline/indexed-properties.json
+++ b/test/syntax/baseline/indexed-properties.json
@@ -2,13 +2,11 @@
     {
         "type": "interface",
         "name": "OrderedMap",
-        "escapedName": "OrderedMap",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "size",
-                "escapedName": "size",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -16,8 +14,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "unsigned long",
-                    "baseName": "long",
-                    "escapedBaseName": "long",
                     "trivia": {
                         "base": " "
                     }
@@ -37,7 +33,6 @@
                 "body": {
                     "name": {
                         "value": "getByIndex",
-                        "escaped": "getByIndex",
                         "trivia": " "
                     },
                     "idlType": {
@@ -47,8 +42,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "any",
-                        "baseName": "any",
-                        "escapedBaseName": "any",
                         "trivia": {
                             "base": " "
                         }
@@ -56,7 +49,6 @@
                     "arguments": [
                         {
                             "name": "index",
-                            "escapedName": "index",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -64,8 +56,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "unsigned long",
-                                "baseName": "long",
-                                "escapedBaseName": "long",
                                 "trivia": {
                                     "base": " "
                                 }
@@ -95,7 +85,6 @@
                 "body": {
                     "name": {
                         "value": "setByIndex",
-                        "escaped": "setByIndex",
                         "trivia": " "
                     },
                     "idlType": {
@@ -105,8 +94,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": " "
                         }
@@ -114,7 +101,6 @@
                     "arguments": [
                         {
                             "name": "index",
-                            "escapedName": "index",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -122,8 +108,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "unsigned long",
-                                "baseName": "long",
-                                "escapedBaseName": "long",
                                 "trivia": {
                                     "base": " "
                                 }
@@ -137,7 +121,6 @@
                         },
                         {
                             "name": "value",
-                            "escapedName": "value",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -145,8 +128,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "any",
-                                "baseName": "any",
-                                "escapedBaseName": "any",
                                 "trivia": {
                                     "base": " "
                                 }
@@ -176,7 +157,6 @@
                 "body": {
                     "name": {
                         "value": "removeByIndex",
-                        "escaped": "removeByIndex",
                         "trivia": " "
                     },
                     "idlType": {
@@ -186,8 +166,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": " "
                         }
@@ -195,7 +173,6 @@
                     "arguments": [
                         {
                             "name": "index",
-                            "escapedName": "index",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -203,8 +180,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "unsigned long",
-                                "baseName": "long",
-                                "escapedBaseName": "long",
                                 "trivia": {
                                     "base": " "
                                 }
@@ -234,7 +209,6 @@
                 "body": {
                     "name": {
                         "value": "get",
-                        "escaped": "get",
                         "trivia": " "
                     },
                     "idlType": {
@@ -244,8 +218,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "any",
-                        "baseName": "any",
-                        "escapedBaseName": "any",
                         "trivia": {
                             "base": " "
                         }
@@ -253,7 +225,6 @@
                     "arguments": [
                         {
                             "name": "name",
-                            "escapedName": "name",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -261,8 +232,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "DOMString",
-                                "baseName": "DOMString",
-                                "escapedBaseName": "DOMString",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -292,7 +261,6 @@
                 "body": {
                     "name": {
                         "value": "set",
-                        "escaped": "set",
                         "trivia": " "
                     },
                     "idlType": {
@@ -302,8 +270,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": " "
                         }
@@ -311,7 +277,6 @@
                     "arguments": [
                         {
                             "name": "name",
-                            "escapedName": "name",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -319,8 +284,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "DOMString",
-                                "baseName": "DOMString",
-                                "escapedBaseName": "DOMString",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -334,7 +297,6 @@
                         },
                         {
                             "name": "value",
-                            "escapedName": "value",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -342,8 +304,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "any",
-                                "baseName": "any",
-                                "escapedBaseName": "any",
                                 "trivia": {
                                     "base": " "
                                 }
@@ -373,7 +333,6 @@
                 "body": {
                     "name": {
                         "value": "remove",
-                        "escaped": "remove",
                         "trivia": " "
                     },
                     "idlType": {
@@ -383,8 +342,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": " "
                         }
@@ -392,7 +349,6 @@
                     "arguments": [
                         {
                             "name": "name",
-                            "escapedName": "name",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -400,8 +356,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "DOMString",
-                                "baseName": "DOMString",
-                                "escapedBaseName": "DOMString",
                                 "trivia": {
                                     "base": ""
                                 }

--- a/test/syntax/baseline/inherits-getter.json
+++ b/test/syntax/baseline/inherits-getter.json
@@ -2,13 +2,11 @@
     {
         "type": "interface",
         "name": "Animal",
-        "escapedName": "Animal",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "name",
-                "escapedName": "name",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -16,8 +14,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "DOMString",
-                    "baseName": "DOMString",
-                    "escapedBaseName": "DOMString",
                     "trivia": {
                         "base": " "
                     }
@@ -45,10 +41,8 @@
     {
         "type": "interface",
         "name": "Person",
-        "escapedName": "Person",
         "inheritance": {
             "name": "Animal",
-            "escapedName": "Animal",
             "trivia": {
                 "colon": " ",
                 "name": " "
@@ -58,7 +52,6 @@
             {
                 "type": "attribute",
                 "name": "age",
-                "escapedName": "age",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -66,8 +59,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "unsigned short",
-                    "baseName": "short",
-                    "escapedBaseName": "short",
                     "trivia": {
                         "base": " "
                     }
@@ -84,7 +75,6 @@
             {
                 "type": "attribute",
                 "name": "name",
-                "escapedName": "name",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -92,8 +82,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "DOMString",
-                    "baseName": "DOMString",
-                    "escapedBaseName": "DOMString",
                     "trivia": {
                         "base": " "
                     }
@@ -121,10 +109,8 @@
     {
         "type": "interface",
         "name": "Ghost",
-        "escapedName": "Ghost",
         "inheritance": {
             "name": "Person",
-            "escapedName": "Person",
             "trivia": {
                 "colon": " ",
                 "name": " "
@@ -134,7 +120,6 @@
             {
                 "type": "attribute",
                 "name": "name",
-                "escapedName": "name",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -142,8 +127,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "DOMString",
-                    "baseName": "DOMString",
-                    "escapedBaseName": "DOMString",
                     "trivia": {
                         "base": " "
                     }

--- a/test/syntax/baseline/interface-inherits.json
+++ b/test/syntax/baseline/interface-inherits.json
@@ -2,13 +2,11 @@
     {
         "type": "interface",
         "name": "Animal",
-        "escapedName": "Animal",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "name",
-                "escapedName": "name",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -16,8 +14,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "DOMString",
-                    "baseName": "DOMString",
-                    "escapedBaseName": "DOMString",
                     "trivia": {
                         "base": " "
                     }
@@ -45,10 +41,8 @@
     {
         "type": "interface",
         "name": "Human",
-        "escapedName": "Human",
         "inheritance": {
             "name": "Animal",
-            "escapedName": "Animal",
             "trivia": {
                 "colon": " ",
                 "name": " "
@@ -58,7 +52,6 @@
             {
                 "type": "attribute",
                 "name": "pet",
-                "escapedName": "pet",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -66,8 +59,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "Dog",
-                    "baseName": "Dog",
-                    "escapedBaseName": "Dog",
                     "trivia": {
                         "base": " "
                     }
@@ -95,10 +86,8 @@
     {
         "type": "interface",
         "name": "Dog",
-        "escapedName": "Dog",
         "inheritance": {
             "name": "Animal",
-            "escapedName": "Animal",
             "trivia": {
                 "colon": " ",
                 "name": " "
@@ -108,7 +97,6 @@
             {
                 "type": "attribute",
                 "name": "owner",
-                "escapedName": "owner",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -116,8 +104,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "Human",
-                    "baseName": "Human",
-                    "escapedBaseName": "Human",
                     "trivia": {
                         "base": " "
                     }

--- a/test/syntax/baseline/iterable.json
+++ b/test/syntax/baseline/iterable.json
@@ -2,7 +2,6 @@
     {
         "type": "interface",
         "name": "IterableOne",
-        "escapedName": "IterableOne",
         "inheritance": null,
         "members": [
             {
@@ -15,8 +14,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "long",
-                        "baseName": "long",
-                        "escapedBaseName": "long",
                         "trivia": {
                             "base": ""
                         }
@@ -45,7 +42,6 @@
     {
         "type": "interface",
         "name": "IterableTwo",
-        "escapedName": "IterableTwo",
         "inheritance": null,
         "members": [
             {
@@ -58,8 +54,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "short",
-                        "baseName": "short",
-                        "escapedBaseName": "short",
                         "trivia": {
                             "base": ""
                         }
@@ -71,8 +65,6 @@
                         "nullable": true,
                         "union": false,
                         "idlType": "double",
-                        "baseName": "double",
-                        "escapedBaseName": "double",
                         "trivia": {
                             "base": " "
                         }
@@ -101,7 +93,6 @@
     {
         "type": "interface",
         "name": "IterableThree",
-        "escapedName": "IterableThree",
         "inheritance": null,
         "members": [
             {
@@ -130,8 +121,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "long",
-                        "baseName": "long",
-                        "escapedBaseName": "long",
                         "trivia": {
                             "base": " "
                         }

--- a/test/syntax/baseline/maplike.json
+++ b/test/syntax/baseline/maplike.json
@@ -2,7 +2,6 @@
     {
         "type": "interface",
         "name": "MapLike",
-        "escapedName": "MapLike",
         "inheritance": null,
         "members": [
             {
@@ -15,8 +14,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "long",
-                        "baseName": "long",
-                        "escapedBaseName": "long",
                         "trivia": {
                             "base": ""
                         }
@@ -28,8 +25,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "float",
-                        "baseName": "float",
-                        "escapedBaseName": "float",
                         "trivia": {
                             "base": " "
                         }
@@ -58,7 +53,6 @@
     {
         "type": "interface",
         "name": "ReadOnlyMapLike",
-        "escapedName": "ReadOnlyMapLike",
         "inheritance": null,
         "members": [
             {
@@ -71,8 +65,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "long",
-                        "baseName": "long",
-                        "escapedBaseName": "long",
                         "trivia": {
                             "base": ""
                         }
@@ -84,8 +76,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "float",
-                        "baseName": "float",
-                        "escapedBaseName": "float",
                         "trivia": {
                             "base": " "
                         }
@@ -114,7 +104,6 @@
     {
         "type": "interface",
         "name": "I",
-        "escapedName": "I",
         "inheritance": null,
         "members": [
             {
@@ -143,8 +132,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "DOMString",
-                        "baseName": "DOMString",
-                        "escapedBaseName": "DOMString",
                         "trivia": {
                             "base": " "
                         }
@@ -172,8 +159,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "long",
-                        "baseName": "long",
-                        "escapedBaseName": "long",
                         "trivia": {
                             "base": " "
                         }

--- a/test/syntax/baseline/mixin.json
+++ b/test/syntax/baseline/mixin.json
@@ -2,12 +2,10 @@
     {
         "type": "interface mixin",
         "name": "GlobalCrypto",
-        "escapedName": "GlobalCrypto",
         "members": [
             {
                 "type": "attribute",
                 "name": "crypto",
-                "escapedName": "crypto",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -15,8 +13,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "Crypto",
-                    "baseName": "Crypto",
-                    "escapedBaseName": "Crypto",
                     "trivia": {
                         "base": " "
                     }
@@ -46,9 +42,7 @@
         "type": "includes",
         "extAttrs": null,
         "target": "Window",
-        "escapedTarget": "Window",
         "includes": "GlobalCrypto",
-        "escapedIncludes": "GlobalCrypto",
         "trivia": {
             "target": "\n\n",
             "includes": " ",
@@ -60,9 +54,7 @@
         "type": "includes",
         "extAttrs": null,
         "target": "WorkerGlobalScope",
-        "escapedTarget": "WorkerGlobalScope",
         "includes": "GlobalCrypto",
-        "escapedIncludes": "GlobalCrypto",
         "trivia": {
             "target": "\n",
             "includes": " ",
@@ -73,12 +65,10 @@
     {
         "type": "interface mixin",
         "name": "WindowOrWorkerGlobalScope",
-        "escapedName": "WindowOrWorkerGlobalScope",
         "members": [
             {
                 "type": "attribute",
                 "name": "crypto",
-                "escapedName": "crypto",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -86,8 +76,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "Crypto",
-                    "baseName": "Crypto",
-                    "escapedBaseName": "Crypto",
                     "trivia": {
                         "base": " "
                     }
@@ -116,7 +104,6 @@
     {
         "type": "interface mixin",
         "name": "LocalCrypto",
-        "escapedName": "_LocalCrypto",
         "members": [],
         "extAttrs": null,
         "partial": false,

--- a/test/syntax/baseline/namedconstructor.json
+++ b/test/syntax/baseline/namedconstructor.json
@@ -2,10 +2,8 @@
     {
         "type": "interface",
         "name": "HTMLAudioElement",
-        "escapedName": "HTMLAudioElement",
         "inheritance": {
             "name": "HTMLMediaElement",
-            "escapedName": "HTMLMediaElement",
             "trivia": {
                 "colon": " ",
                 "name": " "
@@ -45,7 +43,6 @@
                         "arguments": [
                             {
                                 "name": "src",
-                                "escapedName": "src",
                                 "idlType": {
                                     "type": "argument-type",
                                     "extAttrs": null,
@@ -53,8 +50,6 @@
                                     "nullable": false,
                                     "union": false,
                                     "idlType": "DOMString",
-                                    "baseName": "DOMString",
-                                    "escapedBaseName": "DOMString",
                                     "trivia": {
                                         "base": ""
                                     }

--- a/test/syntax/baseline/namespace.json
+++ b/test/syntax/baseline/namespace.json
@@ -2,12 +2,10 @@
     {
         "type": "namespace",
         "name": "VectorUtils",
-        "escapedName": "VectorUtils",
         "members": [
             {
                 "type": "attribute",
                 "name": "unit",
-                "escapedName": "unit",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -15,8 +13,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "Vector",
-                    "baseName": "Vector",
-                    "escapedBaseName": "Vector",
                     "trivia": {
                         "base": " "
                     }
@@ -36,7 +32,6 @@
                 "body": {
                     "name": {
                         "value": "dotProduct",
-                        "escaped": "dotProduct",
                         "trivia": " "
                     },
                     "idlType": {
@@ -46,8 +41,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "double",
-                        "baseName": "double",
-                        "escapedBaseName": "double",
                         "trivia": {
                             "base": "\n  "
                         }
@@ -55,7 +48,6 @@
                     "arguments": [
                         {
                             "name": "x",
-                            "escapedName": "x",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -63,8 +55,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "Vector",
-                                "baseName": "Vector",
-                                "escapedBaseName": "Vector",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -78,7 +68,6 @@
                         },
                         {
                             "name": "y",
-                            "escapedName": "y",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -86,8 +75,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "Vector",
-                                "baseName": "Vector",
-                                "escapedBaseName": "Vector",
                                 "trivia": {
                                     "base": " "
                                 }
@@ -117,7 +104,6 @@
                 "body": {
                     "name": {
                         "value": "crossProduct",
-                        "escaped": "crossProduct",
                         "trivia": " "
                     },
                     "idlType": {
@@ -127,8 +113,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "Vector",
-                        "baseName": "Vector",
-                        "escapedBaseName": "Vector",
                         "trivia": {
                             "base": "\n  "
                         }
@@ -136,7 +120,6 @@
                     "arguments": [
                         {
                             "name": "x",
-                            "escapedName": "x",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -144,8 +127,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "Vector",
-                                "baseName": "Vector",
-                                "escapedBaseName": "Vector",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -159,7 +140,6 @@
                         },
                         {
                             "name": "y",
-                            "escapedName": "y",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -167,8 +147,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "Vector",
-                                "baseName": "Vector",
-                                "escapedBaseName": "Vector",
                                 "trivia": {
                                     "base": " "
                                 }
@@ -206,7 +184,6 @@
     {
         "type": "namespace",
         "name": "SomeNamespace",
-        "escapedName": "SomeNamespace",
         "members": [],
         "extAttrs": null,
         "partial": true,
@@ -221,7 +198,6 @@
     {
         "type": "namespace",
         "name": "ScalarUtils",
-        "escapedName": "_ScalarUtils",
         "members": [],
         "extAttrs": null,
         "partial": false,

--- a/test/syntax/baseline/nointerfaceobject.json
+++ b/test/syntax/baseline/nointerfaceobject.json
@@ -2,7 +2,6 @@
     {
         "type": "interface",
         "name": "Query",
-        "escapedName": "Query",
         "inheritance": null,
         "members": [
             {
@@ -11,7 +10,6 @@
                 "body": {
                     "name": {
                         "value": "lookupEntry",
-                        "escaped": "lookupEntry",
                         "trivia": " "
                     },
                     "idlType": {
@@ -21,8 +19,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "any",
-                        "baseName": "any",
-                        "escapedBaseName": "any",
                         "trivia": {
                             "base": "\n  "
                         }
@@ -30,7 +26,6 @@
                     "arguments": [
                         {
                             "name": "key",
-                            "escapedName": "key",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -38,8 +33,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "unsigned long",
-                                "baseName": "long",
-                                "escapedBaseName": "long",
                                 "trivia": {
                                     "base": " "
                                 }

--- a/test/syntax/baseline/nullable.json
+++ b/test/syntax/baseline/nullable.json
@@ -2,13 +2,11 @@
     {
         "type": "interface",
         "name": "Node",
-        "escapedName": "Node",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "namespaceURI",
-                "escapedName": "namespaceURI",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -16,8 +14,6 @@
                     "nullable": true,
                     "union": false,
                     "idlType": "DOMString",
-                    "baseName": "DOMString",
-                    "escapedBaseName": "DOMString",
                     "trivia": {
                         "base": " "
                     }

--- a/test/syntax/baseline/nullableobjects.json
+++ b/test/syntax/baseline/nullableobjects.json
@@ -2,7 +2,6 @@
     {
         "type": "interface",
         "name": "A",
-        "escapedName": "A",
         "inheritance": null,
         "members": [],
         "extAttrs": null,
@@ -18,7 +17,6 @@
     {
         "type": "interface",
         "name": "B",
-        "escapedName": "B",
         "inheritance": null,
         "members": [],
         "extAttrs": null,
@@ -34,7 +32,6 @@
     {
         "type": "interface",
         "name": "C",
-        "escapedName": "C",
         "inheritance": null,
         "members": [
             {
@@ -43,7 +40,6 @@
                 "body": {
                     "name": {
                         "value": "f",
-                        "escaped": "f",
                         "trivia": " "
                     },
                     "idlType": {
@@ -53,8 +49,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": "\n  "
                         }
@@ -62,7 +56,6 @@
                     "arguments": [
                         {
                             "name": "x",
-                            "escapedName": "x",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -70,8 +63,6 @@
                                 "nullable": true,
                                 "union": false,
                                 "idlType": "A",
-                                "baseName": "A",
-                                "escapedBaseName": "A",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -101,7 +92,6 @@
                 "body": {
                     "name": {
                         "value": "f",
-                        "escaped": "f",
                         "trivia": " "
                     },
                     "idlType": {
@@ -111,8 +101,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": "\n  "
                         }
@@ -120,7 +108,6 @@
                     "arguments": [
                         {
                             "name": "x",
-                            "escapedName": "x",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -128,8 +115,6 @@
                                 "nullable": true,
                                 "union": false,
                                 "idlType": "B",
-                                "baseName": "B",
-                                "escapedBaseName": "B",
                                 "trivia": {
                                     "base": ""
                                 }

--- a/test/syntax/baseline/operation-optional-arg.json
+++ b/test/syntax/baseline/operation-optional-arg.json
@@ -2,7 +2,6 @@
     {
         "type": "interface",
         "name": "ColorCreator",
-        "escapedName": "ColorCreator",
         "inheritance": null,
         "members": [
             {
@@ -11,7 +10,6 @@
                 "body": {
                     "name": {
                         "value": "createColor",
-                        "escaped": "createColor",
                         "trivia": " "
                     },
                     "idlType": {
@@ -21,8 +19,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "object",
-                        "baseName": "object",
-                        "escapedBaseName": "object",
                         "trivia": {
                             "base": "\n  "
                         }
@@ -30,7 +26,6 @@
                     "arguments": [
                         {
                             "name": "v1",
-                            "escapedName": "v1",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -38,8 +33,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "float",
-                                "baseName": "float",
-                                "escapedBaseName": "float",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -53,7 +46,6 @@
                         },
                         {
                             "name": "v2",
-                            "escapedName": "v2",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -61,8 +53,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "float",
-                                "baseName": "float",
-                                "escapedBaseName": "float",
                                 "trivia": {
                                     "base": " "
                                 }
@@ -76,7 +66,6 @@
                         },
                         {
                             "name": "v3",
-                            "escapedName": "v3",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -84,8 +73,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "float",
-                                "baseName": "float",
-                                "escapedBaseName": "float",
                                 "trivia": {
                                     "base": " "
                                 }
@@ -99,7 +86,6 @@
                         },
                         {
                             "name": "alpha",
-                            "escapedName": "alpha",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -107,8 +93,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "float",
-                                "baseName": "float",
-                                "escapedBaseName": "float",
                                 "trivia": {
                                     "base": " "
                                 }

--- a/test/syntax/baseline/overloading.json
+++ b/test/syntax/baseline/overloading.json
@@ -2,7 +2,6 @@
     {
         "type": "interface",
         "name": "A",
-        "escapedName": "A",
         "inheritance": null,
         "members": [],
         "extAttrs": null,
@@ -18,7 +17,6 @@
     {
         "type": "interface",
         "name": "B",
-        "escapedName": "B",
         "inheritance": null,
         "members": [],
         "extAttrs": null,
@@ -34,7 +32,6 @@
     {
         "type": "interface",
         "name": "C",
-        "escapedName": "C",
         "inheritance": null,
         "members": [
             {
@@ -43,7 +40,6 @@
                 "body": {
                     "name": {
                         "value": "f",
-                        "escaped": "f",
                         "trivia": " "
                     },
                     "idlType": {
@@ -53,8 +49,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": "\n  "
                         }
@@ -62,7 +56,6 @@
                     "arguments": [
                         {
                             "name": "x",
-                            "escapedName": "x",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -70,8 +63,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "A",
-                                "baseName": "A",
-                                "escapedBaseName": "A",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -101,7 +92,6 @@
                 "body": {
                     "name": {
                         "value": "f",
-                        "escaped": "f",
                         "trivia": " "
                     },
                     "idlType": {
@@ -111,8 +101,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": "\n  "
                         }
@@ -120,7 +108,6 @@
                     "arguments": [
                         {
                             "name": "x",
-                            "escapedName": "x",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -128,8 +115,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "B",
-                                "baseName": "B",
-                                "escapedBaseName": "B",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -167,7 +152,6 @@
     {
         "type": "interface",
         "name": "D",
-        "escapedName": "D",
         "inheritance": null,
         "members": [
             {
@@ -176,7 +160,6 @@
                 "body": {
                     "name": {
                         "value": "f",
-                        "escaped": "f",
                         "trivia": " "
                     },
                     "idlType": {
@@ -186,8 +169,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": "\n  /* f1 */ "
                         }
@@ -195,7 +176,6 @@
                     "arguments": [
                         {
                             "name": "a",
-                            "escapedName": "a",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -203,8 +183,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "DOMString",
-                                "baseName": "DOMString",
-                                "escapedBaseName": "DOMString",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -234,7 +212,6 @@
                 "body": {
                     "name": {
                         "value": "f",
-                        "escaped": "f",
                         "trivia": " "
                     },
                     "idlType": {
@@ -244,8 +221,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": "\n  /* f2 */ "
                         }
@@ -253,7 +228,6 @@
                     "arguments": [
                         {
                             "name": "a",
-                            "escapedName": "a",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": {
@@ -277,8 +251,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "DOMString",
-                                "baseName": "DOMString",
-                                "escapedBaseName": "DOMString",
                                 "trivia": {
                                     "base": " "
                                 }
@@ -292,7 +264,6 @@
                         },
                         {
                             "name": "b",
-                            "escapedName": "b",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -300,8 +271,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "DOMString",
-                                "baseName": "DOMString",
-                                "escapedBaseName": "DOMString",
                                 "trivia": {
                                     "base": " "
                                 }
@@ -315,7 +284,6 @@
                         },
                         {
                             "name": "c",
-                            "escapedName": "c",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -323,8 +291,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "float",
-                                "baseName": "float",
-                                "escapedBaseName": "float",
                                 "trivia": {
                                     "base": " "
                                 }
@@ -354,7 +320,6 @@
                 "body": {
                     "name": {
                         "value": "f",
-                        "escaped": "f",
                         "trivia": " "
                     },
                     "idlType": {
@@ -364,8 +329,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": "\n  /* f3 */ "
                         }
@@ -388,7 +351,6 @@
                 "body": {
                     "name": {
                         "value": "f",
-                        "escaped": "f",
                         "trivia": " "
                     },
                     "idlType": {
@@ -398,8 +360,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": "\n  /* f4 */ "
                         }
@@ -407,7 +367,6 @@
                     "arguments": [
                         {
                             "name": "a",
-                            "escapedName": "a",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -415,8 +374,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "long",
-                                "baseName": "long",
-                                "escapedBaseName": "long",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -430,7 +387,6 @@
                         },
                         {
                             "name": "b",
-                            "escapedName": "b",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -438,8 +394,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "DOMString",
-                                "baseName": "DOMString",
-                                "escapedBaseName": "DOMString",
                                 "trivia": {
                                     "base": " "
                                 }
@@ -453,7 +407,6 @@
                         },
                         {
                             "name": "c",
-                            "escapedName": "c",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -461,8 +414,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "DOMString",
-                                "baseName": "DOMString",
-                                "escapedBaseName": "DOMString",
                                 "trivia": {
                                     "base": " "
                                 }
@@ -476,7 +427,6 @@
                         },
                         {
                             "name": "d",
-                            "escapedName": "d",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -484,8 +434,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "float",
-                                "baseName": "float",
-                                "escapedBaseName": "float",
                                 "trivia": {
                                     "base": " "
                                 }

--- a/test/syntax/baseline/overridebuiltins.json
+++ b/test/syntax/baseline/overridebuiltins.json
@@ -2,13 +2,11 @@
     {
         "type": "interface",
         "name": "StringMap2",
-        "escapedName": "StringMap2",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "length",
-                "escapedName": "length",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -16,8 +14,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "unsigned long",
-                    "baseName": "long",
-                    "escapedBaseName": "long",
                     "trivia": {
                         "base": " "
                     }
@@ -37,7 +33,6 @@
                 "body": {
                     "name": {
                         "value": "lookup",
-                        "escaped": "lookup",
                         "trivia": " "
                     },
                     "idlType": {
@@ -47,8 +42,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "DOMString",
-                        "baseName": "DOMString",
-                        "escapedBaseName": "DOMString",
                         "trivia": {
                             "base": " "
                         }
@@ -56,7 +49,6 @@
                     "arguments": [
                         {
                             "name": "key",
-                            "escapedName": "key",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -64,8 +56,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "DOMString",
-                                "baseName": "DOMString",
-                                "escapedBaseName": "DOMString",
                                 "trivia": {
                                     "base": ""
                                 }

--- a/test/syntax/baseline/partial-interface.json
+++ b/test/syntax/baseline/partial-interface.json
@@ -2,13 +2,11 @@
     {
         "type": "interface",
         "name": "Foo",
-        "escapedName": "Foo",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "bar",
-                "escapedName": "bar",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -16,8 +14,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "DOMString",
-                    "baseName": "DOMString",
-                    "escapedBaseName": "DOMString",
                     "trivia": {
                         "base": " "
                     }
@@ -45,12 +41,10 @@
     {
         "type": "interface",
         "name": "Foo",
-        "escapedName": "Foo",
         "members": [
             {
                 "type": "attribute",
                 "name": "quux",
-                "escapedName": "quux",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -58,8 +52,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "DOMString",
-                    "baseName": "DOMString",
-                    "escapedBaseName": "DOMString",
                     "trivia": {
                         "base": " "
                     }

--- a/test/syntax/baseline/primitives.json
+++ b/test/syntax/baseline/primitives.json
@@ -2,13 +2,11 @@
     {
         "type": "interface",
         "name": "Primitives",
-        "escapedName": "Primitives",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "truth",
-                "escapedName": "truth",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -16,8 +14,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "boolean",
-                    "baseName": "boolean",
-                    "escapedBaseName": "boolean",
                     "trivia": {
                         "base": " "
                     }
@@ -34,7 +30,6 @@
             {
                 "type": "attribute",
                 "name": "character",
-                "escapedName": "character",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -42,8 +37,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "byte",
-                    "baseName": "byte",
-                    "escapedBaseName": "byte",
                     "trivia": {
                         "base": " "
                     }
@@ -60,7 +53,6 @@
             {
                 "type": "attribute",
                 "name": "value",
-                "escapedName": "value",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -68,8 +60,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "octet",
-                    "baseName": "octet",
-                    "escapedBaseName": "octet",
                     "trivia": {
                         "base": " "
                     }
@@ -86,7 +76,6 @@
             {
                 "type": "attribute",
                 "name": "number",
-                "escapedName": "number",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -94,8 +83,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "short",
-                    "baseName": "short",
-                    "escapedBaseName": "short",
                     "trivia": {
                         "base": " "
                     }
@@ -112,7 +99,6 @@
             {
                 "type": "attribute",
                 "name": "positive",
-                "escapedName": "positive",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -120,8 +106,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "unsigned short",
-                    "baseName": "short",
-                    "escapedBaseName": "short",
                     "trivia": {
                         "base": " "
                     }
@@ -138,7 +122,6 @@
             {
                 "type": "attribute",
                 "name": "big",
-                "escapedName": "big",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -146,8 +129,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "long",
-                    "baseName": "long",
-                    "escapedBaseName": "long",
                     "trivia": {
                         "base": " "
                     }
@@ -164,7 +145,6 @@
             {
                 "type": "attribute",
                 "name": "bigpositive",
-                "escapedName": "bigpositive",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -172,8 +152,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "unsigned long",
-                    "baseName": "long",
-                    "escapedBaseName": "long",
                     "trivia": {
                         "base": " "
                     }
@@ -190,7 +168,6 @@
             {
                 "type": "attribute",
                 "name": "bigbig",
-                "escapedName": "bigbig",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -198,8 +175,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "long long",
-                    "baseName": "long",
-                    "escapedBaseName": "long",
                     "trivia": {
                         "base": " "
                     }
@@ -216,7 +191,6 @@
             {
                 "type": "attribute",
                 "name": "bigbigpositive",
-                "escapedName": "bigbigpositive",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -224,8 +198,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "unsigned long long",
-                    "baseName": "long",
-                    "escapedBaseName": "long",
                     "trivia": {
                         "base": " "
                     }
@@ -242,7 +214,6 @@
             {
                 "type": "attribute",
                 "name": "real",
-                "escapedName": "real",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -250,8 +221,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "float",
-                    "baseName": "float",
-                    "escapedBaseName": "float",
                     "trivia": {
                         "base": " "
                     }
@@ -268,7 +237,6 @@
             {
                 "type": "attribute",
                 "name": "bigreal",
-                "escapedName": "bigreal",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -276,8 +244,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "double",
-                    "baseName": "double",
-                    "escapedBaseName": "double",
                     "trivia": {
                         "base": " "
                     }
@@ -294,7 +260,6 @@
             {
                 "type": "attribute",
                 "name": "realwithinfinity",
-                "escapedName": "realwithinfinity",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -302,8 +267,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "unrestricted float",
-                    "baseName": "float",
-                    "escapedBaseName": "float",
                     "trivia": {
                         "base": " "
                     }
@@ -320,7 +283,6 @@
             {
                 "type": "attribute",
                 "name": "bigrealwithinfinity",
-                "escapedName": "bigrealwithinfinity",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -328,8 +290,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "unrestricted double",
-                    "baseName": "double",
-                    "escapedBaseName": "double",
                     "trivia": {
                         "base": " "
                     }
@@ -346,7 +306,6 @@
             {
                 "type": "attribute",
                 "name": "string",
-                "escapedName": "string",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -354,8 +313,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "DOMString",
-                    "baseName": "DOMString",
-                    "escapedBaseName": "DOMString",
                     "trivia": {
                         "base": " "
                     }
@@ -372,7 +329,6 @@
             {
                 "type": "attribute",
                 "name": "bytes",
-                "escapedName": "bytes",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -380,8 +336,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "ByteString",
-                    "baseName": "ByteString",
-                    "escapedBaseName": "ByteString",
                     "trivia": {
                         "base": " "
                     }
@@ -398,7 +352,6 @@
             {
                 "type": "attribute",
                 "name": "date",
-                "escapedName": "date",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -406,8 +359,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "Date",
-                    "baseName": "Date",
-                    "escapedBaseName": "Date",
                     "trivia": {
                         "base": " "
                     }
@@ -424,7 +375,6 @@
             {
                 "type": "attribute",
                 "name": "regexp",
-                "escapedName": "regexp",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -432,8 +382,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "RegExp",
-                    "baseName": "RegExp",
-                    "escapedBaseName": "RegExp",
                     "trivia": {
                         "base": " "
                     }

--- a/test/syntax/baseline/promise-void.json
+++ b/test/syntax/baseline/promise-void.json
@@ -2,13 +2,11 @@
     {
         "type": "interface",
         "name": "Cat",
-        "escapedName": "Cat",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "meow",
-                "escapedName": "meow",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -29,15 +27,11 @@
                             "nullable": false,
                             "union": false,
                             "idlType": "void",
-                            "baseName": "void",
-                            "escapedBaseName": "void",
                             "trivia": {
                                 "base": ""
                             }
                         }
                     ],
-                    "baseName": "Promise",
-                    "escapedBaseName": "Promise",
                     "trivia": {
                         "base": " "
                     }

--- a/test/syntax/baseline/prototyperoot.json
+++ b/test/syntax/baseline/prototyperoot.json
@@ -2,13 +2,11 @@
     {
         "type": "interface",
         "name": "Node",
-        "escapedName": "Node",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "nodeType",
-                "escapedName": "nodeType",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -16,8 +14,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "unsigned short",
-                    "baseName": "short",
-                    "escapedBaseName": "short",
                     "trivia": {
                         "base": " "
                     }

--- a/test/syntax/baseline/putforwards.json
+++ b/test/syntax/baseline/putforwards.json
@@ -2,13 +2,11 @@
     {
         "type": "interface",
         "name": "Person",
-        "escapedName": "Person",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "name",
-                "escapedName": "name",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -16,8 +14,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "Name",
-                    "baseName": "Name",
-                    "escapedBaseName": "Name",
                     "trivia": {
                         "base": " "
                     }
@@ -57,7 +53,6 @@
             {
                 "type": "attribute",
                 "name": "age",
-                "escapedName": "age",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -65,8 +60,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "unsigned short",
-                    "baseName": "short",
-                    "escapedBaseName": "short",
                     "trivia": {
                         "base": " "
                     }

--- a/test/syntax/baseline/record.json
+++ b/test/syntax/baseline/record.json
@@ -2,7 +2,6 @@
     {
         "type": "interface",
         "name": "Foo",
-        "escapedName": "Foo",
         "inheritance": null,
         "members": [
             {
@@ -11,7 +10,6 @@
                 "body": {
                     "name": {
                         "value": "foo",
-                        "escaped": "foo",
                         "trivia": " "
                     },
                     "idlType": {
@@ -21,8 +19,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": "\n  "
                         }
@@ -30,7 +26,6 @@
                     "arguments": [
                         {
                             "name": "param",
-                            "escapedName": "param",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -64,8 +59,6 @@
                                                 "nullable": false,
                                                 "union": false,
                                                 "idlType": "ByteString",
-                                                "baseName": "ByteString",
-                                                "escapedBaseName": "ByteString",
                                                 "trivia": {
                                                     "base": ""
                                                 }
@@ -77,22 +70,16 @@
                                                 "nullable": false,
                                                 "union": false,
                                                 "idlType": "any",
-                                                "baseName": "any",
-                                                "escapedBaseName": "any",
                                                 "trivia": {
                                                     "base": " "
                                                 }
                                             }
                                         ],
-                                        "baseName": "record",
-                                        "escapedBaseName": "record",
                                         "trivia": {
                                             "base": ""
                                         }
                                     }
                                 ],
-                                "baseName": "sequence",
-                                "escapedBaseName": "sequence",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -122,7 +109,6 @@
                 "body": {
                     "name": {
                         "value": "bar",
-                        "escaped": "bar",
                         "trivia": " "
                     },
                     "idlType": {
@@ -145,8 +131,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "DOMString",
-                                "baseName": "DOMString",
-                                "escapedBaseName": "DOMString",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -165,8 +149,6 @@
                                         "nullable": false,
                                         "union": false,
                                         "idlType": "float",
-                                        "baseName": "float",
-                                        "escapedBaseName": "float",
                                         "trivia": {
                                             "base": ""
                                         }
@@ -178,23 +160,17 @@
                                         "nullable": false,
                                         "union": false,
                                         "idlType": "DOMString",
-                                        "baseName": "DOMString",
-                                        "escapedBaseName": "DOMString",
                                         "trivia": {
                                             "base": " "
                                         }
                                     }
                                 ],
-                                "baseName": null,
-                                "escapedBaseName": null,
                                 "trivia": {
                                     "open": " ",
                                     "close": ""
                                 }
                             }
                         ],
-                        "baseName": "record",
-                        "escapedBaseName": "record",
                         "trivia": {
                             "base": "\n  "
                         }
@@ -222,7 +198,6 @@
                         "arguments": [
                             {
                                 "name": "init",
-                                "escapedName": "init",
                                 "idlType": {
                                     "type": "argument-type",
                                     "extAttrs": null,
@@ -243,8 +218,6 @@
                                             "nullable": false,
                                             "union": false,
                                             "idlType": "USVString",
-                                            "baseName": "USVString",
-                                            "escapedBaseName": "USVString",
                                             "trivia": {
                                                 "base": ""
                                             }
@@ -256,15 +229,11 @@
                                             "nullable": false,
                                             "union": false,
                                             "idlType": "USVString",
-                                            "baseName": "USVString",
-                                            "escapedBaseName": "USVString",
                                             "trivia": {
                                                 "base": " "
                                             }
                                         }
                                     ],
-                                    "baseName": "record",
-                                    "escapedBaseName": "record",
                                     "trivia": {
                                         "base": ""
                                     }
@@ -304,7 +273,6 @@
     {
         "type": "interface",
         "name": "Bar",
-        "escapedName": "Bar",
         "inheritance": null,
         "members": [
             {
@@ -313,7 +281,6 @@
                 "body": {
                     "name": {
                         "value": "bar",
-                        "escaped": "bar",
                         "trivia": " "
                     },
                     "idlType": {
@@ -336,8 +303,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "DOMString",
-                                "baseName": "DOMString",
-                                "escapedBaseName": "DOMString",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -365,15 +330,11 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "float",
-                                "baseName": "float",
-                                "escapedBaseName": "float",
                                 "trivia": {
                                     "base": " "
                                 }
                             }
                         ],
-                        "baseName": "record",
-                        "escapedBaseName": "record",
                         "trivia": {
                             "base": "\n  "
                         }

--- a/test/syntax/baseline/reg-operations.json
+++ b/test/syntax/baseline/reg-operations.json
@@ -2,13 +2,11 @@
     {
         "type": "interface",
         "name": "Dimensions",
-        "escapedName": "Dimensions",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "width",
-                "escapedName": "width",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -16,8 +14,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "unsigned long",
-                    "baseName": "long",
-                    "escapedBaseName": "long",
                     "trivia": {
                         "base": " "
                     }
@@ -34,7 +30,6 @@
             {
                 "type": "attribute",
                 "name": "height",
-                "escapedName": "height",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -42,8 +37,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "unsigned long",
-                    "baseName": "long",
-                    "escapedBaseName": "long",
                     "trivia": {
                         "base": " "
                     }
@@ -71,7 +64,6 @@
     {
         "type": "interface",
         "name": "Button",
-        "escapedName": "Button",
         "inheritance": null,
         "members": [
             {
@@ -80,7 +72,6 @@
                 "body": {
                     "name": {
                         "value": "isMouseOver",
-                        "escaped": "isMouseOver",
                         "trivia": " "
                     },
                     "idlType": {
@@ -90,8 +81,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "boolean",
-                        "baseName": "boolean",
-                        "escapedBaseName": "boolean",
                         "trivia": {
                             "base": "\n\n  // An operation that takes no arguments, returns a boolean\n  "
                         }
@@ -114,7 +103,6 @@
                 "body": {
                     "name": {
                         "value": "setDimensions",
-                        "escaped": "setDimensions",
                         "trivia": " "
                     },
                     "idlType": {
@@ -124,8 +112,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": "\n\n  // Overloaded operations.\n  "
                         }
@@ -133,7 +119,6 @@
                     "arguments": [
                         {
                             "name": "size",
-                            "escapedName": "size",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -141,8 +126,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "Dimensions",
-                                "baseName": "Dimensions",
-                                "escapedBaseName": "Dimensions",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -172,7 +155,6 @@
                 "body": {
                     "name": {
                         "value": "setDimensions",
-                        "escaped": "setDimensions",
                         "trivia": " "
                     },
                     "idlType": {
@@ -182,8 +164,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": "\n  "
                         }
@@ -191,7 +171,6 @@
                     "arguments": [
                         {
                             "name": "width",
-                            "escapedName": "width",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -199,8 +178,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "unsigned long",
-                                "baseName": "long",
-                                "escapedBaseName": "long",
                                 "trivia": {
                                     "base": " "
                                 }
@@ -214,7 +191,6 @@
                         },
                         {
                             "name": "height",
-                            "escapedName": "height",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -222,8 +198,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "unsigned long",
-                                "baseName": "long",
-                                "escapedBaseName": "long",
                                 "trivia": {
                                     "base": " "
                                 }

--- a/test/syntax/baseline/replaceable.json
+++ b/test/syntax/baseline/replaceable.json
@@ -2,13 +2,11 @@
     {
         "type": "interface",
         "name": "Counter",
-        "escapedName": "Counter",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "value",
-                "escapedName": "value",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -16,8 +14,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "unsigned long",
-                    "baseName": "long",
-                    "escapedBaseName": "long",
                     "trivia": {
                         "base": " "
                     }
@@ -53,7 +49,6 @@
                 "body": {
                     "name": {
                         "value": "increment",
-                        "escaped": "increment",
                         "trivia": " "
                     },
                     "idlType": {
@@ -63,8 +58,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": "\n  "
                         }

--- a/test/syntax/baseline/sequence.json
+++ b/test/syntax/baseline/sequence.json
@@ -2,7 +2,6 @@
     {
         "type": "interface",
         "name": "Canvas",
-        "escapedName": "Canvas",
         "inheritance": null,
         "members": [
             {
@@ -11,7 +10,6 @@
                 "body": {
                     "name": {
                         "value": "drawPolygon",
-                        "escaped": "drawPolygon",
                         "trivia": " "
                     },
                     "idlType": {
@@ -21,8 +19,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": "\n  "
                         }
@@ -30,7 +26,6 @@
                     "arguments": [
                         {
                             "name": "coordinates",
-                            "escapedName": "coordinates",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -51,15 +46,11 @@
                                         "nullable": false,
                                         "union": false,
                                         "idlType": "float",
-                                        "baseName": "float",
-                                        "escapedBaseName": "float",
                                         "trivia": {
                                             "base": ""
                                         }
                                     }
                                 ],
-                                "baseName": "sequence",
-                                "escapedBaseName": "sequence",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -89,7 +80,6 @@
                 "body": {
                     "name": {
                         "value": "getInflectionPoints",
-                        "escaped": "getInflectionPoints",
                         "trivia": " "
                     },
                     "idlType": {
@@ -112,15 +102,11 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "float",
-                                "baseName": "float",
-                                "escapedBaseName": "float",
                                 "trivia": {
                                     "base": ""
                                 }
                             }
                         ],
-                        "baseName": "sequence",
-                        "escapedBaseName": "sequence",
                         "trivia": {
                             "base": "\n  "
                         }
@@ -151,7 +137,6 @@
     {
         "type": "interface",
         "name": "I",
-        "escapedName": "I",
         "inheritance": null,
         "members": [
             {
@@ -160,7 +145,6 @@
                 "body": {
                     "name": {
                         "value": "f1",
-                        "escaped": "f1",
                         "trivia": " "
                     },
                     "idlType": {
@@ -170,8 +154,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": "\n    "
                         }
@@ -179,7 +161,6 @@
                     "arguments": [
                         {
                             "name": "arg",
-                            "escapedName": "arg",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -216,15 +197,11 @@
                                         "nullable": false,
                                         "union": false,
                                         "idlType": "long",
-                                        "baseName": "long",
-                                        "escapedBaseName": "long",
                                         "trivia": {
                                             "base": " "
                                         }
                                     }
                                 ],
-                                "baseName": "sequence",
-                                "escapedBaseName": "sequence",
                                 "trivia": {
                                     "base": ""
                                 }

--- a/test/syntax/baseline/setlike.json
+++ b/test/syntax/baseline/setlike.json
@@ -2,7 +2,6 @@
     {
         "type": "interface",
         "name": "SetLike",
-        "escapedName": "SetLike",
         "inheritance": null,
         "members": [
             {
@@ -15,8 +14,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "long",
-                        "baseName": "long",
-                        "escapedBaseName": "long",
                         "trivia": {
                             "base": ""
                         }
@@ -45,7 +42,6 @@
     {
         "type": "interface",
         "name": "ReadOnlySetLike",
-        "escapedName": "ReadOnlySetLike",
         "inheritance": null,
         "members": [
             {
@@ -58,8 +54,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "long",
-                        "baseName": "long",
-                        "escapedBaseName": "long",
                         "trivia": {
                             "base": ""
                         }
@@ -88,7 +82,6 @@
     {
         "type": "interface",
         "name": "SetLikeExt",
-        "escapedName": "SetLikeExt",
         "inheritance": null,
         "members": [
             {
@@ -117,8 +110,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "long",
-                        "baseName": "long",
-                        "escapedBaseName": "long",
                         "trivia": {
                             "base": " "
                         }

--- a/test/syntax/baseline/static.json
+++ b/test/syntax/baseline/static.json
@@ -2,7 +2,6 @@
     {
         "type": "interface",
         "name": "Point",
-        "escapedName": "Point",
         "inheritance": null,
         "members": [],
         "extAttrs": null,
@@ -18,13 +17,11 @@
     {
         "type": "interface",
         "name": "Circle",
-        "escapedName": "Circle",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "cx",
-                "escapedName": "cx",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -32,8 +29,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "float",
-                    "baseName": "float",
-                    "escapedBaseName": "float",
                     "trivia": {
                         "base": " "
                     }
@@ -50,7 +45,6 @@
             {
                 "type": "attribute",
                 "name": "cy",
-                "escapedName": "cy",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -58,8 +52,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "float",
-                    "baseName": "float",
-                    "escapedBaseName": "float",
                     "trivia": {
                         "base": " "
                     }
@@ -76,7 +68,6 @@
             {
                 "type": "attribute",
                 "name": "radius",
-                "escapedName": "radius",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -84,8 +75,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "float",
-                    "baseName": "float",
-                    "escapedBaseName": "float",
                     "trivia": {
                         "base": " "
                     }
@@ -102,7 +91,6 @@
             {
                 "type": "attribute",
                 "name": "triangulationCount",
-                "escapedName": "triangulationCount",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -110,8 +98,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "long",
-                    "baseName": "long",
-                    "escapedBaseName": "long",
                     "trivia": {
                         "base": " "
                     }
@@ -131,7 +117,6 @@
                 "body": {
                     "name": {
                         "value": "triangulate",
-                        "escaped": "triangulate",
                         "trivia": " "
                     },
                     "idlType": {
@@ -141,8 +126,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "Point",
-                        "baseName": "Point",
-                        "escapedBaseName": "Point",
                         "trivia": {
                             "base": " "
                         }
@@ -150,7 +133,6 @@
                     "arguments": [
                         {
                             "name": "c1",
-                            "escapedName": "c1",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -158,8 +140,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "Circle",
-                                "baseName": "Circle",
-                                "escapedBaseName": "Circle",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -173,7 +153,6 @@
                         },
                         {
                             "name": "c2",
-                            "escapedName": "c2",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -181,8 +160,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "Circle",
-                                "baseName": "Circle",
-                                "escapedBaseName": "Circle",
                                 "trivia": {
                                     "base": " "
                                 }
@@ -196,7 +173,6 @@
                         },
                         {
                             "name": "c3",
-                            "escapedName": "c3",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -204,8 +180,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "Circle",
-                                "baseName": "Circle",
-                                "escapedBaseName": "Circle",
                                 "trivia": {
                                     "base": " "
                                 }

--- a/test/syntax/baseline/stringifier-attribute.json
+++ b/test/syntax/baseline/stringifier-attribute.json
@@ -2,13 +2,11 @@
     {
         "type": "interface",
         "name": "Student",
-        "escapedName": "Student",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "id",
-                "escapedName": "id",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -16,8 +14,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "unsigned long",
-                    "baseName": "long",
-                    "escapedBaseName": "long",
                     "trivia": {
                         "base": " "
                     }
@@ -34,7 +30,6 @@
             {
                 "type": "attribute",
                 "name": "name",
-                "escapedName": "name",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -42,8 +37,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "DOMString",
-                    "baseName": "DOMString",
-                    "escapedBaseName": "DOMString",
                     "trivia": {
                         "base": " "
                     }

--- a/test/syntax/baseline/stringifier-custom.json
+++ b/test/syntax/baseline/stringifier-custom.json
@@ -2,13 +2,11 @@
     {
         "type": "interface",
         "name": "Student",
-        "escapedName": "Student",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "id",
-                "escapedName": "id",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -16,8 +14,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "unsigned long",
-                    "baseName": "long",
-                    "escapedBaseName": "long",
                     "trivia": {
                         "base": " "
                     }
@@ -34,7 +30,6 @@
             {
                 "type": "attribute",
                 "name": "familyName",
-                "escapedName": "familyName",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -42,8 +37,6 @@
                     "nullable": true,
                     "union": false,
                     "idlType": "DOMString",
-                    "baseName": "DOMString",
-                    "escapedBaseName": "DOMString",
                     "trivia": {
                         "base": " "
                     }
@@ -60,7 +53,6 @@
             {
                 "type": "attribute",
                 "name": "givenName",
-                "escapedName": "givenName",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -68,8 +60,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "DOMString",
-                    "baseName": "DOMString",
-                    "escapedBaseName": "DOMString",
                     "trivia": {
                         "base": " "
                     }
@@ -95,8 +85,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "DOMString",
-                        "baseName": "DOMString",
-                        "escapedBaseName": "DOMString",
                         "trivia": {
                             "base": " "
                         }

--- a/test/syntax/baseline/stringifier.json
+++ b/test/syntax/baseline/stringifier.json
@@ -2,7 +2,6 @@
     {
         "type": "interface",
         "name": "A",
-        "escapedName": "A",
         "inheritance": null,
         "members": [
             {
@@ -17,8 +16,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "DOMString",
-                        "baseName": "DOMString",
-                        "escapedBaseName": "DOMString",
                         "trivia": {
                             "base": " "
                         }
@@ -49,7 +46,6 @@
     {
         "type": "interface",
         "name": "B",
-        "escapedName": "B",
         "inheritance": null,
         "members": [
             {

--- a/test/syntax/baseline/treatasnull.json
+++ b/test/syntax/baseline/treatasnull.json
@@ -2,13 +2,11 @@
     {
         "type": "interface",
         "name": "Dog",
-        "escapedName": "Dog",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "name",
-                "escapedName": "name",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -16,8 +14,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "DOMString",
-                    "baseName": "DOMString",
-                    "escapedBaseName": "DOMString",
                     "trivia": {
                         "base": " "
                     }
@@ -34,7 +30,6 @@
             {
                 "type": "attribute",
                 "name": "owner",
-                "escapedName": "owner",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -42,8 +37,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "DOMString",
-                    "baseName": "DOMString",
-                    "escapedBaseName": "DOMString",
                     "trivia": {
                         "base": " "
                     }
@@ -63,7 +56,6 @@
                 "body": {
                     "name": {
                         "value": "isMemberOfBreed",
-                        "escaped": "isMemberOfBreed",
                         "trivia": " "
                     },
                     "idlType": {
@@ -73,8 +65,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "boolean",
-                        "baseName": "boolean",
-                        "escapedBaseName": "boolean",
                         "trivia": {
                             "base": "\n\n  "
                         }
@@ -82,7 +72,6 @@
                     "arguments": [
                         {
                             "name": "breedName",
-                            "escapedName": "breedName",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": {
@@ -113,8 +102,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "DOMString",
-                                "baseName": "DOMString",
-                                "escapedBaseName": "DOMString",
                                 "trivia": {
                                     "base": " "
                                 }

--- a/test/syntax/baseline/treatasundefined.json
+++ b/test/syntax/baseline/treatasundefined.json
@@ -2,13 +2,11 @@
     {
         "type": "interface",
         "name": "Cat",
-        "escapedName": "Cat",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "name",
-                "escapedName": "name",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -16,8 +14,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "DOMString",
-                    "baseName": "DOMString",
-                    "escapedBaseName": "DOMString",
                     "trivia": {
                         "base": " "
                     }
@@ -34,7 +30,6 @@
             {
                 "type": "attribute",
                 "name": "owner",
-                "escapedName": "owner",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -42,8 +37,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "DOMString",
-                    "baseName": "DOMString",
-                    "escapedBaseName": "DOMString",
                     "trivia": {
                         "base": " "
                     }
@@ -63,7 +56,6 @@
                 "body": {
                     "name": {
                         "value": "isMemberOfBreed",
-                        "escaped": "isMemberOfBreed",
                         "trivia": " "
                     },
                     "idlType": {
@@ -73,8 +65,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "boolean",
-                        "baseName": "boolean",
-                        "escapedBaseName": "boolean",
                         "trivia": {
                             "base": "\n\n  "
                         }
@@ -82,7 +72,6 @@
                     "arguments": [
                         {
                             "name": "breedName",
-                            "escapedName": "breedName",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": {
@@ -113,8 +102,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "DOMString",
-                                "baseName": "DOMString",
-                                "escapedBaseName": "DOMString",
                                 "trivia": {
                                     "base": " "
                                 }

--- a/test/syntax/baseline/typedef-union.json
+++ b/test/syntax/baseline/typedef-union.json
@@ -2,7 +2,6 @@
     {
         "type": "typedef",
         "name": "TexImageSource",
-        "escapedName": "TexImageSource",
         "idlType": {
             "type": "typedef-type",
             "extAttrs": null,
@@ -17,8 +16,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "ImageData",
-                    "baseName": "ImageData",
-                    "escapedBaseName": "ImageData",
                     "trivia": {
                         "base": ""
                     }
@@ -30,8 +27,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "HTMLImageElement",
-                    "baseName": "HTMLImageElement",
-                    "escapedBaseName": "HTMLImageElement",
                     "trivia": {
                         "base": "\n           "
                     }
@@ -43,8 +38,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "HTMLCanvasElement",
-                    "baseName": "HTMLCanvasElement",
-                    "escapedBaseName": "HTMLCanvasElement",
                     "trivia": {
                         "base": "\n           "
                     }
@@ -56,15 +49,11 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "HTMLVideoElement",
-                    "baseName": "HTMLVideoElement",
-                    "escapedBaseName": "HTMLVideoElement",
                     "trivia": {
                         "base": "\n           "
                     }
                 }
             ],
-            "baseName": null,
-            "escapedBaseName": null,
             "trivia": {
                 "open": " ",
                 "close": ""

--- a/test/syntax/baseline/typedef.json
+++ b/test/syntax/baseline/typedef.json
@@ -2,13 +2,11 @@
     {
         "type": "interface",
         "name": "Point",
-        "escapedName": "Point",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "x",
-                "escapedName": "x",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -16,8 +14,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "float",
-                    "baseName": "float",
-                    "escapedBaseName": "float",
                     "trivia": {
                         "base": " "
                     }
@@ -34,7 +30,6 @@
             {
                 "type": "attribute",
                 "name": "y",
-                "escapedName": "y",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -42,8 +37,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "float",
-                    "baseName": "float",
-                    "escapedBaseName": "float",
                     "trivia": {
                         "base": " "
                     }
@@ -71,7 +64,6 @@
     {
         "type": "typedef",
         "name": "PointSequence",
-        "escapedName": "PointSequence",
         "idlType": {
             "type": "typedef-type",
             "extAttrs": null,
@@ -92,15 +84,11 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "Point",
-                    "baseName": "Point",
-                    "escapedBaseName": "Point",
                     "trivia": {
                         "base": ""
                     }
                 }
             ],
-            "baseName": "sequence",
-            "escapedBaseName": "sequence",
             "trivia": {
                 "base": " "
             }
@@ -115,13 +103,11 @@
     {
         "type": "interface",
         "name": "Rect",
-        "escapedName": "Rect",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "topleft",
-                "escapedName": "topleft",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -129,8 +115,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "Point",
-                    "baseName": "Point",
-                    "escapedBaseName": "Point",
                     "trivia": {
                         "base": " "
                     }
@@ -147,7 +131,6 @@
             {
                 "type": "attribute",
                 "name": "bottomright",
-                "escapedName": "bottomright",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -155,8 +138,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "Point",
-                    "baseName": "Point",
-                    "escapedBaseName": "Point",
                     "trivia": {
                         "base": " "
                     }
@@ -184,13 +165,11 @@
     {
         "type": "interface",
         "name": "Widget",
-        "escapedName": "Widget",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "bounds",
-                "escapedName": "bounds",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -198,8 +177,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "Rect",
-                    "baseName": "Rect",
-                    "escapedBaseName": "Rect",
                     "trivia": {
                         "base": " "
                     }
@@ -219,7 +196,6 @@
                 "body": {
                     "name": {
                         "value": "pointWithinBounds",
-                        "escaped": "pointWithinBounds",
                         "trivia": " "
                     },
                     "idlType": {
@@ -229,8 +205,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "boolean",
-                        "baseName": "boolean",
-                        "escapedBaseName": "boolean",
                         "trivia": {
                             "base": "\n\n    "
                         }
@@ -238,7 +212,6 @@
                     "arguments": [
                         {
                             "name": "p",
-                            "escapedName": "p",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -246,8 +219,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "Point",
-                                "baseName": "Point",
-                                "escapedBaseName": "Point",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -277,7 +248,6 @@
                 "body": {
                     "name": {
                         "value": "allPointsWithinBounds",
-                        "escaped": "allPointsWithinBounds",
                         "trivia": " "
                     },
                     "idlType": {
@@ -287,8 +257,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "boolean",
-                        "baseName": "boolean",
-                        "escapedBaseName": "boolean",
                         "trivia": {
                             "base": "\n    "
                         }
@@ -296,7 +264,6 @@
                     "arguments": [
                         {
                             "name": "ps",
-                            "escapedName": "ps",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -304,8 +271,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "PointSequence",
-                                "baseName": "PointSequence",
-                                "escapedBaseName": "PointSequence",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -343,7 +308,6 @@
     {
         "type": "typedef",
         "name": "value",
-        "escapedName": "_value",
         "idlType": {
             "type": "typedef-type",
             "extAttrs": {
@@ -367,8 +331,6 @@
             "nullable": false,
             "union": false,
             "idlType": "octet",
-            "baseName": "octet",
-            "escapedBaseName": "octet",
             "trivia": {
                 "base": " "
             }

--- a/test/syntax/baseline/typesuffixes.json
+++ b/test/syntax/baseline/typesuffixes.json
@@ -2,7 +2,6 @@
     {
         "type": "interface",
         "name": "Suffixes",
-        "escapedName": "Suffixes",
         "inheritance": null,
         "members": [
             {
@@ -11,7 +10,6 @@
                 "body": {
                     "name": {
                         "value": "test",
-                        "escaped": "test",
                         "trivia": " "
                     },
                     "idlType": {
@@ -21,8 +19,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": "\n  "
                         }
@@ -30,7 +26,6 @@
                     "arguments": [
                         {
                             "name": "foo",
-                            "escapedName": "foo",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -51,15 +46,11 @@
                                         "nullable": true,
                                         "union": false,
                                         "idlType": "DOMString",
-                                        "baseName": "DOMString",
-                                        "escapedBaseName": "DOMString",
                                         "trivia": {
                                             "base": ""
                                         }
                                     }
                                 ],
-                                "baseName": "sequence",
-                                "escapedBaseName": "sequence",
                                 "trivia": {
                                     "base": ""
                                 }

--- a/test/syntax/baseline/uniontype.json
+++ b/test/syntax/baseline/uniontype.json
@@ -2,13 +2,11 @@
     {
         "type": "interface",
         "name": "Union",
-        "escapedName": "Union",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "test",
-                "escapedName": "test",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -23,8 +21,6 @@
                             "nullable": false,
                             "union": false,
                             "idlType": "float",
-                            "baseName": "float",
-                            "escapedBaseName": "float",
                             "trivia": {
                                 "base": ""
                             }
@@ -43,8 +39,6 @@
                                     "nullable": false,
                                     "union": false,
                                     "idlType": "Date",
-                                    "baseName": "Date",
-                                    "escapedBaseName": "Date",
                                     "trivia": {
                                         "base": ""
                                     }
@@ -56,15 +50,11 @@
                                     "nullable": false,
                                     "union": false,
                                     "idlType": "Event",
-                                    "baseName": "Event",
-                                    "escapedBaseName": "Event",
                                     "trivia": {
                                         "base": " "
                                     }
                                 }
                             ],
-                            "baseName": null,
-                            "escapedBaseName": null,
                             "trivia": {
                                 "open": " ",
                                 "close": ""
@@ -84,8 +74,6 @@
                                     "nullable": false,
                                     "union": false,
                                     "idlType": "Node",
-                                    "baseName": "Node",
-                                    "escapedBaseName": "Node",
                                     "trivia": {
                                         "base": ""
                                     }
@@ -97,23 +85,17 @@
                                     "nullable": false,
                                     "union": false,
                                     "idlType": "DOMString",
-                                    "baseName": "DOMString",
-                                    "escapedBaseName": "DOMString",
                                     "trivia": {
                                         "base": " "
                                     }
                                 }
                             ],
-                            "baseName": null,
-                            "escapedBaseName": null,
                             "trivia": {
                                 "open": " ",
                                 "close": ""
                             }
                         }
                     ],
-                    "baseName": null,
-                    "escapedBaseName": null,
                     "trivia": {
                         "open": " ",
                         "close": ""
@@ -131,7 +113,6 @@
             {
                 "type": "attribute",
                 "name": "test2",
-                "escapedName": "test2",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -162,8 +143,6 @@
                             "nullable": false,
                             "union": false,
                             "idlType": "long",
-                            "baseName": "long",
-                            "escapedBaseName": "long",
                             "trivia": {
                                 "base": " "
                             }
@@ -175,15 +154,11 @@
                             "nullable": false,
                             "union": false,
                             "idlType": "Date",
-                            "baseName": "Date",
-                            "escapedBaseName": "Date",
                             "trivia": {
                                 "base": " "
                             }
                         }
                     ],
-                    "baseName": null,
-                    "escapedBaseName": null,
                     "trivia": {
                         "open": " ",
                         "close": ""

--- a/test/syntax/baseline/variadic-operations.json
+++ b/test/syntax/baseline/variadic-operations.json
@@ -2,13 +2,11 @@
     {
         "type": "interface",
         "name": "IntegerSet",
-        "escapedName": "IntegerSet",
         "inheritance": null,
         "members": [
             {
                 "type": "attribute",
                 "name": "cardinality",
-                "escapedName": "cardinality",
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
@@ -16,8 +14,6 @@
                     "nullable": false,
                     "union": false,
                     "idlType": "unsigned long",
-                    "baseName": "long",
-                    "escapedBaseName": "long",
                     "trivia": {
                         "base": " "
                     }
@@ -37,7 +33,6 @@
                 "body": {
                     "name": {
                         "value": "union",
-                        "escaped": "union",
                         "trivia": " "
                     },
                     "idlType": {
@@ -47,8 +42,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": "\n\n  "
                         }
@@ -56,7 +49,6 @@
                     "arguments": [
                         {
                             "name": "ints",
-                            "escapedName": "ints",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -64,8 +56,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "long",
-                                "baseName": "long",
-                                "escapedBaseName": "long",
                                 "trivia": {
                                     "base": ""
                                 }
@@ -95,7 +85,6 @@
                 "body": {
                     "name": {
                         "value": "intersection",
-                        "escaped": "intersection",
                         "trivia": " "
                     },
                     "idlType": {
@@ -105,8 +94,6 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "void",
-                        "baseName": "void",
-                        "escapedBaseName": "void",
                         "trivia": {
                             "base": "\n  "
                         }
@@ -114,7 +101,6 @@
                     "arguments": [
                         {
                             "name": "ints",
-                            "escapedName": "ints",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -122,8 +108,6 @@
                                 "nullable": false,
                                 "union": false,
                                 "idlType": "long",
-                                "baseName": "long",
-                                "escapedBaseName": "long",
                                 "trivia": {
                                     "base": ""
                                 }


### PR DESCRIPTION
They were required by the writer but now are redundant.