### PR TITLE
BREAKING CHANGE: remove all trivia fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,18 +164,11 @@ attached to a field called `idlType`:
 ```JS
 {
   "type": "attribute-type",
-  "generic": null,
+  "generic": "",
   "idlType": "unsigned short",
   "nullable": false,
   "union": false,
-  "trivia": {
-    "base": " "
-  },
   "extAttrs": {
-    "trivia": {
-      "open": "\n",
-      "close": ""
-    },
     "items": [...]
   }
 }
@@ -184,22 +177,9 @@ attached to a field called `idlType`:
 Where the fields are as follows:
 
 * `type`: String indicating where this type is used. Can be `null` if not applicable.
-* `generic`: An object with the following fields if the type is generic:
-  * `value`: String indicating the generic type (e.g. "Promise", "sequence").
-  * `trivia`: Whitespaces or comments preceding genenic type name token.
+* `generic`: String indicating the generic type (e.g. "Promise", "sequence").
 * `idlType`: String indicating the type name, or array of subtypes if the type is
   generic or a union.
-* `baseName`: String indicating the base type name, e.g. "float" for "unrestricted
-  float".
-* `prefix`: An object with the following fields if a prefix exists:
-  * `value`: String indicating the prefix name ("unsigned" or "unrestricted").
-  * `trivia`: Whitespaces or comments preceding prefix token.
-* `postfix`: An object with the following fields if a postfix exists:
-  * `value`: String indicating the prefix name, currently only for "unsigned long long".
-  * `trivia`: Whitespaces or comments preceding postfix token.
-* `separator`: An object with the following fields if a separator follows:
-  * `value`: String indicating the separator token value, e.g. "," or "or".
-  * `trivia`: Whitespaces or comments preceding separator token.
 * `nullable`: `true` if the type is nullable.
 * `union`: Boolean indicating whether this is a union type or not.
 * `extAttrs`: An [extended attributes](#extended-attributes) container.
@@ -230,13 +210,6 @@ Interfaces look like this:
   "name": "Animal",
   "partial": false,
   "members": [...],
-  "trivia": {
-    "base": "",
-    "name": " ",
-    "open": " ",
-    "close": "\n",
-    "termination": ""
-  },
   "inheritance": null,
   "extAttrs": [...]
 }, {
@@ -244,25 +217,10 @@ Interfaces look like this:
   "name": "Human",
   "partial": false,
   "members": [...],
-  "trivia": {
-    "base": "\n\n",
-    "name": " ",
-    "open": " ",
-    "close": "\n",
-    "termination": ""
-  },
   "inheritance": {
-    "name": "Animal",
-    "trivia": {
-      "colon": " ",
-      "name": " "
-    }
+    "name": "Animal"
   },
   "extAttrs": {
-    "trivia": {
-      "open": "\n\n",
-      "close": ""
-    },
     "items": [...]
   }
 }
@@ -274,7 +232,6 @@ The fields are as follows:
 * `name`: The name of the interface.
 * `partial`: `true` if the type is a partial interface.
 * `members`: An array of interface members (attributes, operations, etc.). Empty if there are none.
-* `trivia`: A trivia object.
 * `inheritance`: An object giving the name of an interface this one inherits from, `null` otherwise.
 * `extAttrs`: An [extended attributes](#extended-attributes) container.
 
@@ -288,33 +245,13 @@ Interfaces mixins look like this:
   "name": "Animal",
   "partial": false,
   "members": [...],
-  "trivia": {
-    "base": "",
-    "mixin": " ",
-    "name": " ",
-    "open": " ",
-    "close": "\n",
-    "termination": ""
-  },
   "extAttrs": [...]
 }, {
   "type": "interface mixin",
   "name": "Human",
   "partial": false,
   "members": [...],
-  "trivia": {
-    "base": "",
-    "mixin": " ",
-    "name": " ",
-    "open": " ",
-    "close": "\n",
-    "termination": ""
-  },
   "extAttrs": {
-    "trivia": {
-      "open": "\n\n",
-      "close": ""
-    },
     "items": [...]
   }
 }
@@ -326,7 +263,6 @@ The fields are as follows:
 * `name`: The name of the interface mixin.
 * `partial`: `true if the type is a partial interface mixin.
 * `members`: An array of interface members (attributes, operations, etc.). Empty if there are none.
-* `trivia`: A trivia object.
 * `extAttrs`: An [extended attributes](#extended-attributes) container.
 
 ### Namespace
@@ -339,18 +275,7 @@ Namespaces look like this:
   "name": "console",
   "partial": false,
   "members": [...],
-  "trivia": {
-    "base": "",
-    "name": " ",
-    "open": " ",
-    "close": "\n",
-    "termination": ""
-  },
   "extAttrs": {
-    "trivia": {
-      "open": "\n\n",
-      "close": ""
-    },
     "items": [...]
   }
 }
@@ -362,7 +287,6 @@ The fields are as follows:
 * `name`: The name of the namespace.
 * `partial`: `true if the type is a partial namespace.
 * `members`: An array of namespace members (attributes and operations). Empty if there are none.
-* `trivia`: A trivia object.
 * `extAttrs`: An [extended attributes](#extended-attributes) container.
 
 ### Callback Interfaces
@@ -381,24 +305,13 @@ A callback looks like this:
   "name": "AsyncOperationCallback",
   "idlType": {
     "type": "return-type",
-    "generic": null,
+    "generic": "",
     "nullable": false,
     "union": false,
     "idlType": "void",
-    "extAttrs": null,
-    "trivia": {
-      "base": " "
-    }
+    "extAttrs": null
   },
   "arguments": [...],
-  "trivia": {
-    "base": "",
-    "name": " ",
-    "assign": " ",
-    "open": " ",
-    "close": "",
-    "termination": ""
-  },
   "extAttrs": null
 }
 ```
@@ -409,7 +322,6 @@ The fields are as follows:
 * `name`: The name of the callback.
 * `idlType`: An [IDL Type](#idl-type) describing what the callback returns.
 * `arguments`: A list of [arguments](#arguments), as in function paramters.
-* `trivia`: A trivia object. The field `assign` is for the equal sign token.
 * `extAttrs`: An [extended attributes](#extended-attributes) container.
 
 ### Dictionary
@@ -427,32 +339,18 @@ A dictionary looks like this:
     "required": false,
     "idlType": {
       "type": "dictionary-type",
-      "generic": null,
+      "generic": "",
       "nullable": true
       "union": false,
       "idlType": "DOMString",
-      "extAttrs": [...],
-      "trivia": {
-        "base": "\n  "
-      }
+      "extAttrs": [...]
     },
     "extAttrs": null,
     "default": {
       "type": "string",
-      "value": "black",
-      "trivia": {
-        "assign": " ",
-        "value": " "
-      }
+      "value": "black"
     }
   }],
-  "trivia": {
-    "base": "// Extracted from Web IDL editors draft May 31 2011\n",
-    "name": " ",
-    "open": " ",
-    "close": "\n",
-    "termination": ""
-  },
   "inheritance": null,
   "extAttrs": null
 }
@@ -464,7 +362,6 @@ The fields are as follows:
 * `name`: The dictionary name.
 * `partial`: `true` if the type is a partial dictionary.
 * `members`: An array of members (see below).
-* `trivia`: A trivia object.
 * `inheritance`: An object indicating which dictionary is being inherited from, `null` otherwise.
 * `extAttrs`: An [extended attributes](#extended-attributes) container.
 
@@ -488,27 +385,17 @@ An enum looks like this:
   "values": [
     {
       "type": "enum-value",
-      "value": "rice",
-      "trivia": " "
+      "value": "rice"
     },
     {
       "type": "enum-value",
-      "value": "noodles",
-      "trivia": " "
+      "value": "noodles"
     },
     {
       "type": "enum-value",
-      "value": "other",
-      "trivia": " "
+      "value": "other"
     }
-  ],
-  "trivia": {
-    "base": "",
-    "name": " ",
-    "open": " ",
-    "close": " ",
-    "termination": ""
-  },
+  ]
   "extAttrs": null
 }
 ```
@@ -517,8 +404,7 @@ The fields are as follows:
 
 * `type`: Always "enum".
 * `name`: The enum's name.
-* `values`: An array of values, which may include a field `separator` for proceding commas. The type of value is "enum-value".
-* `trivia`: A trivia object.
+* `values`: An array of values. The type of value is "enum-value".
 * `extAttrs`: An [extended attributes](#extended-attributes) container.
 
 ### Typedef
@@ -536,24 +422,16 @@ A typedef looks like this:
     "idlType": [
       {
         "type": "typedef-type",
-        "generic": null,
+        "generic": "",
         "nullable": false,
         "union": false,
         "idlType": "Point",
         "extAttrs": [...]
-        "trivia": {
-            "base": ""
-        }
       }
     ],
     "extAttrs": [...]
   },
   "name": "PointSequence",
-  "trivia": {
-    "base": "\n\n      ",
-    "name": " ",
-    "termination": ""
-  },
   "extAttrs": null
 }
 ```
@@ -564,7 +442,6 @@ The fields are as follows:
 * `type`: Always "typedef".
 * `name`: The typedef's name.
 * `idlType`: An [IDL Type](#idl-type) describing what typedef's type.
-* `trivia`: A trivia object.
 * `extAttrs`: An [extended attributes](#extended-attributes) container.
 
 ### Includes
@@ -585,7 +462,6 @@ The fields are as follows:
 * `type`: Always "includes".
 * `target`: The interface that includes an interface mixin.
 * `includes`: The interface mixin that is being included by the target.
-* `trivia`: A trivia object. The field `target` is for the base interface identifier, `includes` for the `includes` keyword, and `mixin` for the mixin identifier.
 * `extAttrs`: An [extended attributes](#extended-attributes) container.
 
 ### Operation Member
@@ -594,34 +470,24 @@ An operation looks like this:
 ```JS
 {
   "type": "operation",
-  "special": null,
+  "special": "",
   "body": {
     "idlType": {
       "type": "return-type",
-      "generic": null,
+      "generic": "",
       "nullable": false,
       "union": false,
       "idlType": "void",
-      "extAttrs": null,
-      "trivia": {
-        "base": "\n  "
-      }
+      "extAttrs": null
     },
-    "trivia": {
-      "open": "",
-      "close": ""
-    },
-    "name": {
-      "value": "intersection",
-      "trivia": " "
-    },
+    "name": "intersection",
     "arguments": [{
       "optional": false,
       "variadic": true,
       "extAttrs": null,
       "idlType": {
         "type": "argument-type",
-        "generic": null,
+        "generic": "",
         "nullable": false,
         "union": false,
         "idlType": "long",
@@ -629,9 +495,6 @@ An operation looks like this:
       },
       "name": "ints"
     }],
-  },
-  "trivia": {
-    "termination": ""
   },
   "extAttrs": null
 }
@@ -641,14 +504,12 @@ The fields are as follows:
 
 * `type`: Always "operation".
 * `special`: One of `"getter"`, `"setter"`, `"deleter"`, `"static"`, `"stringifier"`, or `null`.
-* `trivia`: A trivia object.
 * `body`: The operation body. Can be null if bodyless `stringifier`.
 * `extAttrs`: An [extended attributes](#extended-attributes) container.
 
 The operation body fields are as follows:
 
 * `idlType`: An [IDL Type](#idl-type) of what the operation returns.
-* `trivia`: A trivia object.
 * `name`: The name of the operation if exists.
 * `arguments`: An array of [arguments](#arguments) for the operation.
 
@@ -663,21 +524,13 @@ An attribute member looks like this:
   "stringifier": null,
   "inherit": null,
   "readonly": false,
-  "trivia": {
-    "base": "",
-    "name": " ",
-    "termination": ""
-  },
   "idlType": {
     "type": "attribute-type",
-    "generic": null,
+    "generic": "",
     "nullable": false,
     "union": false,
     "idlType": "any",
-    "extAttrs": [...],
-    "trivia": {
-      "base": " "
-    }
+    "extAttrs": [...]
   },
   "name": "regexp",
   "extAttrs": null
@@ -690,7 +543,6 @@ The fields are as follows:
 * `name`: The attribute's name.
 * `special`: One of `"static"`, `"stringifier"`, `"inherit"`, or `null`.
 * `readonly`: `true` if the attribute is read-only.
-* `trivia`: A trivia object.
 * `idlType`: An [IDL Type](#idl-type) for the attribute.
 * `extAttrs`: An [extended attributes](#extended-attributes) container.
 
@@ -703,26 +555,16 @@ A constant member looks like this:
   "type": "const",
   "idlType": {
     "type": "const-type",
-    "generic": null,
+    "generic": "",
     "nullable": false,
     "union": false,
     "idlType": "boolean",
-    "extAttrs": null,
-    "trivia": {
-      "base": " "
-    }
+    "extAttrs": null
   },
   "name": "DEBUG",
   "value": {
     "type": "boolean",
     "value": false
-  },
-  "trivia": {
-    "base": "\n  ",
-    "name": " ",
-    "assign": " ",
-    "value": " ",
-    "termination": ""
   },
   "extAttrs": null
 }
@@ -734,7 +576,6 @@ The fields are as follows:
 * `idlType`: An [IDL Type](#idl-type) of the constant that represents a simple type, the type name.
 * `name`: The name of the constant.
 * `value`: The constant value as described by [Const Values](#default-and-const-values)
-* `trivia`: A trivia object. The field `assign` is for the equal sign token.
 * `extAttrs`: An [extended attributes](#extended-attributes) container.
 
 ### Arguments
@@ -746,20 +587,14 @@ The arguments (e.g. for an operation) look like this:
   "arguments": [{
     "optional": false,
     "variadic": true
-    "extAttrs": null,
-    "trivia": {
-      "name": " "
-    },
+    "extAttrs": null
     "idlType": {
       "type": "argument-type",
-      "generic": null,
+      "generic": "",
       "nullable": false,
       "union": false,
       "idlType": "float",
-      "extAttrs": [...],
-      "trivia": {
-        "base": " "
-      }
+      "extAttrs": [...]
     },
     "name": "ints",
   }]
@@ -772,10 +607,6 @@ The fields are as follows:
 * `variadic`: `true` if the argument is variadic.
 * `idlType`: An [IDL Type](#idl-type) describing the type of the argument.
 * `name`: The argument's name.
-* `separator`: An object with the following fields if a separator follows:
-  * `value`: Always ",".
-  * `trivia`: Whitespaces or comments preceding separator token.
-* `trivia`: A trivia object.
 * `extAttrs`: An [extended attributes](#extended-attributes) container.
 
 ### Extended Attributes
@@ -785,30 +616,13 @@ Extended attribute container look like this:
 ```JS
 {
   "extAttrs": {
-    "trivia": {
-      "open": "\n\n",
-      "close": ""
-    },
     "items": [{
       "name": "TreatNullAs",
-      "signature": {
-        "arguments": [...],
-        "trivia": {
-          "open": "",
-          "close": ""
-        }
-      },
+      "arguments": [...],
       "type": "extended-attribute",
       "rhs": {
         "type": "identifier",
-        "value": "EmptyString",
-        "trivia": {
-          "assign": "",
-          "value": ""
-        }
-      },
-      "trivia": {
-        "name": ""
+        "value": "EmptyString"
       }
     }]
   }
@@ -817,22 +631,17 @@ Extended attribute container look like this:
 
 The fields are as follows:
 
-* `trivia`: A trivia object.
 * `items`: An array of extended attributes.
 
 Extended attributes look like this:
 
 * `name`: The extended attribute's name.
-* `signature`: An object containing trivia and [arguments](#arguments), if the extended
+* `arguments`: An array of [arguments](#arguments), if the extended
   attribute has a signature (e.g. `[Foo()]`) or if its right-hand side does (e.g.
   `[NamedConstructor=Name(DOMString blah)]`).
 * `type`: Always `"extended-attribute"`.
 * `rhs`: If there is a right-hand side, this will capture its `type` (which can be
   "identifier" or "identifier-list"), its `value`, and its preceding trivia.
-* `trivia`: A trivia object.
-* `separator`: An object with the following fields if a separator follows:
-  * `value`: Always ",".
-  * `trivia`: Whitespaces or comments preceding separator token.
 
 ### Default and Const Values
 
@@ -858,12 +667,6 @@ These appear as members of interfaces that look like this:
   "type": "maplike", // or "iterable" / "setlike"
   "idlType": /* One or two types */ ,
   "readonly": false, // only for maplike and setlike
-  "trivia": {
-    "base": " ",
-    "open": "",
-    "close": "",
-    "termination": ""
-  },
   "extAttrs": null
 }
 ```
@@ -873,7 +676,6 @@ The fields are as follows:
 * `type`: Always one of "iterable", "maplike" or "setlike".
 * `idlType`: An array with one or more [IDL Types](#idl-type) representing the declared type arguments.
 * `readonly`: `true` if the maplike or setlike is declared as read only.
-* `trivia`: A trivia object.
 * `extAttrs`: An [extended attributes](#extended-attributes) container.
 
 ## Testing

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -218,14 +218,6 @@ function parseByTokens(source) {
     }
   }
 
-  function optional_consume(...args) {
-    const token = consume(...args);
-    if (token) {
-      token.optional = true;
-    }
-    return token;
-  }
-
   function unescape(identifier) {
     return identifier.startsWith('_') ? identifier.slice(1) : identifier;
   }
@@ -246,7 +238,7 @@ function parseByTokens(source) {
     if (!first) {
       return [];
     }
-    first.tokens.separator = optional_consume(",");
+    first.tokens.separator = consume(",");
     const items = [first];
     while (first.tokens.separator) {
       const item = parser();
@@ -256,7 +248,7 @@ function parseByTokens(source) {
         }
         break;
       }
-      item.tokens.separator = optional_consume(",");
+      item.tokens.separator = consume(",");
       items.push(item);
       if (!item.tokens.separator) break;
     }
@@ -269,16 +261,6 @@ function parseByTokens(source) {
         source: { value: source },
         tokens: { value: tokens }
       });
-    }
-
-    get trivia() {
-      const object = {};
-      for (const [key, value] of Object.entries(this.tokens)) {
-        if (value && !value.optional) {
-          object[key] = value.trivia;
-        }
-      }
-      return object;
     }
 
     toJSON() {
@@ -298,17 +280,17 @@ function parseByTokens(source) {
   }
 
   function integer_type() {
-    const prefix = optional_consume("unsigned");
+    const prefix = consume("unsigned");
     const base = consume("short", "long");
     if (base) {
-      const postfix = optional_consume("long");
+      const postfix = consume("long");
       return new Type({ tokens: { prefix, base, postfix } });
     }
     if (prefix) error("Failed to parse integer type");
   }
 
   function float_type() {
-    const prefix = optional_consume("unrestricted");
+    const prefix = consume("unrestricted");
     const base = consume("float", "double");
     if (base) {
       return new Type({ tokens: { prefix, base } });
@@ -350,7 +332,7 @@ function parseByTokens(source) {
   }
 
   function type_suffix(obj) {
-    const nullable = optional_consume("?");
+    const nullable = consume("?");
     if (nullable) {
       obj.tokens.nullable = nullable;
     }
@@ -365,7 +347,7 @@ function parseByTokens(source) {
     }
 
     get generic() {
-      return null;
+      return "";
     }
     get nullable() {
       return !!this.tokens.nullable;
@@ -394,7 +376,7 @@ function parseByTokens(source) {
         return;
       }
       const ret = new GenericType({ tokens: { base } });
-      ret.tokens.open = optional_consume("<") || error(`No opening bracket after ${base.type}`);
+      ret.tokens.open = consume("<") || error(`No opening bracket after ${base.type}`);
       switch (base.type) {
         case "Promise": {
           if (probe("[")) error("Promise type cannot have extended attribute");
@@ -412,7 +394,7 @@ function parseByTokens(source) {
           if (probe("[")) error("Record key cannot have extended attribute");
           const keyType = consume(...stringTypes) || error(`Record key must be one of: ${stringTypes.join(", ")}`);
           const keyIdlType = new Type({ tokens: { base: keyType }});
-          keyIdlType.tokens.separator = optional_consume(",") || error("Missing comma after record key type");
+          keyIdlType.tokens.separator = consume(",") || error("Missing comma after record key type");
           keyIdlType.type = typeName;
           const valueType = type_with_extended_attributes(typeName) || error("Error parsing generic type record");
           ret.subtype.push(keyIdlType, valueType);
@@ -420,18 +402,12 @@ function parseByTokens(source) {
         }
       }
       if (!ret.idlType) error(`Error parsing generic type ${base.type}`);
-      ret.tokens.close = optional_consume(">") || error(`Missing closing bracket after ${base.type}`);
+      ret.tokens.close = consume(">") || error(`Missing closing bracket after ${base.type}`);
       return ret;
     }
 
     get generic() {
-      return {
-        value: this.tokens.base.value,
-        trivia: {
-          open: this.tokens.open.trivia,
-          close: this.tokens.close.trivia,
-        }
-      };
+      return this.tokens.base.value;
     }
   }
 
@@ -445,7 +421,7 @@ function parseByTokens(source) {
       ret = new Type({ tokens: { base } });
       if (probe("<")) error(`Unsupported generic type ${base.value}`);
     }
-    if (ret.generic && ret.generic.value === "Promise" && probe("?")) {
+    if (ret.generic === "Promise" && probe("?")) {
       error("Promise type cannot be nullable");
     }
     ret.type = typeName || null;
@@ -465,7 +441,7 @@ function parseByTokens(source) {
         const typ = type_with_extended_attributes() || error("No type after open parenthesis or 'or' in union type");
         if (typ.idlType === "any") error("Type `any` cannot be included in a union type");
         ret.subtype.push(typ);
-        const or = optional_consume("or");
+        const or = consume("or");
         if (or) {
           typ.tokens.separator = or;
         }
@@ -500,13 +476,13 @@ function parseByTokens(source) {
       const start_position = consume_position;
       const tokens = {};
       const ret = new Argument({ tokens });
-      tokens.optional = optional_consume("optional");
+      tokens.optional = consume("optional");
       ret.idlType = type_with_extended_attributes("argument-type");
       if (!ret.idlType) {
         return unconsume(start_position);
       }
       if (!tokens.optional) {
-        tokens.variadic = optional_consume("...");
+        tokens.variadic = consume("...");
       }
       tokens.name = consume(ID, ...argumentNameKeywords);
       if (!tokens.name) {
@@ -547,9 +523,6 @@ function parseByTokens(source) {
     get value() {
       return this.tokens.value.value;
     }
-    get trivia() {
-      return this.tokens.value.trivia;
-    }
   }
 
   function identifiers() {
@@ -565,7 +538,7 @@ function parseByTokens(source) {
       const tokens = { assign: consume("=") };
       const ret = new ExtendedAttributeParameters({ tokens });
       if (tokens.assign) {
-        tokens.secondaryName = optional_consume(ID, FLOAT, INT, STR);
+        tokens.secondaryName = consume(ID, FLOAT, INT, STR);
       }
       tokens.open = consume("(");
       if (tokens.open) {
@@ -611,24 +584,19 @@ function parseByTokens(source) {
       return this.tokens.name.value;
     }
     get rhs() {
-      const { rhsType: type, tokens, list, trivia } = this.params;
+      const { rhsType: type, tokens, list } = this.params;
       if (!type) {
         return null;
       }
       const value = type === "identifier-list" ? list : tokens.secondaryName.value;
-      if (!Array.isArray(value)) {
-        trivia.value = tokens.secondaryName.trivia;
-        trivia.open = trivia.close = undefined;
-      }
-      return { type, value, trivia };
+      return { type, value };
     }
-    get signature() {
-      const { rhsType, list, trivia } = this.params;
+    get arguments() {
+      const { rhsType, list } = this.params;
       if (!list || rhsType === "identifier-list") {
-        return null;
+        return [];
       }
-      trivia.assign = undefined;
-      return { arguments: list, trivia };
+      return list;
     }
   }
 
@@ -680,14 +648,6 @@ function parseByTokens(source) {
     }
     get negative() {
       return const_data(this.expression[0]).negative;
-    }
-    get trivia() {
-      const [first, second] = this.expression;
-      const trivia = first.type === "[" ? {
-        open: first.trivia,
-        close: second.trivia
-      } : { value: first.trivia };
-      return Object.assign(super.trivia, trivia);
     }
   }
 
@@ -766,9 +726,9 @@ function parseByTokens(source) {
       const tokens = { special };
       const ret = new Attribute({ tokens });
       if (!special && !noInherit) {
-        tokens.special = optional_consume("inherit");
+        tokens.special = consume("inherit");
       }
-      tokens.readonly = optional_consume("readonly");
+      tokens.readonly = consume("readonly");
       if (readonly && !tokens.readonly && probe("attribute")) {
         error("Attributes must be readonly in this context");
       }
@@ -778,9 +738,9 @@ function parseByTokens(source) {
         return;
       }
       ret.idlType = type_with_extended_attributes("attribute-type") || error("No type in attribute");
-      switch (ret.idlType.generic && ret.idlType.generic.value) {
+      switch (ret.idlType.generic) {
         case "sequence":
-        case "record": error(`Attributes cannot accept ${ret.idlType.generic.value} types`);
+        case "record": error(`Attributes cannot accept ${ret.idlType.generic} types`);
       }
       tokens.name = consume(ID, "required") || error("No name in attribute");
       tokens.termination = consume(";") || error("Unterminated attribute");
@@ -792,7 +752,7 @@ function parseByTokens(source) {
     }
     get special() {
       if (!this.tokens.special) {
-        return null;
+        return "";
       }
       return this.tokens.special.value;
     }
@@ -822,7 +782,7 @@ function parseByTokens(source) {
       const tokens = {};
       const ret = new OperationBody({ tokens });
       ret.idlType = return_type() || error("Missing return type");
-      tokens.name = optional_consume(ID);
+      tokens.name = consume(ID);
       tokens.open = consume("(") || error("Invalid operation");
       ret.arguments = argument_list();
       tokens.close = consume(")") || error("Unterminated operation");
@@ -832,12 +792,9 @@ function parseByTokens(source) {
     get name() {
       const { name } = this.tokens;
       if (!name) {
-        return null;
+        return "";
       }
-      return {
-        value: unescape(name.value),
-        trivia: name.trivia
-      };
+      return unescape(name.value);
     }
   }
 
@@ -853,7 +810,7 @@ function parseByTokens(source) {
         }
       }
       if (!special && !regular) {
-        tokens.special = optional_consume("getter", "setter", "deleter");
+        tokens.special = consume("getter", "setter", "deleter");
       }
       ret.body = OperationBody.parse();
       tokens.termination = consume(";") || error("Unterminated attribute");
@@ -864,18 +821,18 @@ function parseByTokens(source) {
       return "operation";
     }
     get name() {
-      return (this.body && this.body.name && this.body.name.value) || "";
+      return (this.body && this.body.name) || "";
     }
     get special() {
       if (!this.tokens.special) {
-        return null;
+        return "";
       }
       return this.tokens.special.value;
     }
   }
 
   function static_member() {
-    const special = optional_consume("static");
+    const special = consume("static");
     if (!special) return;
     const member = Attribute.parse({ special }) ||
       Operation.parse({ special }) ||
@@ -884,7 +841,7 @@ function parseByTokens(source) {
   }
 
   function stringifier() {
-    const special = optional_consume("stringifier");
+    const special = consume("stringifier");
     if (!special) return;
     const member = Attribute.parse({ special }) ||
       Operation.parse({ special }) ||
@@ -897,7 +854,7 @@ function parseByTokens(source) {
       const start_position = consume_position;
       const tokens = {};
       const ret = new IterableLike({ tokens });
-      tokens.readonly = optional_consume("readonly");
+      tokens.readonly = consume("readonly");
       tokens.base = tokens.readonly ?
         consume("maplike", "setlike") :
         consume("iterable", "maplike", "setlike");
@@ -914,7 +871,7 @@ function parseByTokens(source) {
       const first = type_with_extended_attributes() || error(`Error parsing ${type} declaration`);
       ret.idlType = [first];
       if (secondTypeAllowed) {
-        first.tokens.separator = optional_consume(",");
+        first.tokens.separator = consume(",");
         if (first.tokens.separator) {
           ret.idlType.push(type_with_extended_attributes());
         }
@@ -1069,7 +1026,7 @@ function parseByTokens(source) {
   }
 
   function partial() {
-    const partial = optional_consume("partial");
+    const partial = consume("partial");
     if (!partial) return;
     return Dictionary.parse({ partial }) ||
       interface_({ partial }) ||
@@ -1103,7 +1060,7 @@ function parseByTokens(source) {
       const tokens = {};
       const ret = new Field({ tokens });
       ret.extAttrs = ExtendedAttributes.parse();
-      tokens.required = optional_consume("required");
+      tokens.required = consume("required");
       ret.idlType = type_with_extended_attributes("dictionary-type") || error("No type for dictionary member");
       tokens.name = consume(ID) || error("No name for dictionary member");
       ret.default = Default.parse();

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -164,6 +164,7 @@ export function write(ast, { templates: ts = templates } = {}) {
   function container(it) {
     return ts.definition(ts.wrap([
       extended_attributes(it.extAttrs),
+      token(it.tokens.callback),
       token(it.tokens.partial),
       token(it.tokens.base),
       token(it.tokens.mixin),
@@ -240,9 +241,11 @@ export function write(ast, { templates: ts = templates } = {}) {
     ]), { data: it });
   }
   function enum_value(v, parent) {
-    return wrap`${ts.trivia(v.trivia)}${
-      ts.definition(wrap`"${ts.name(v.value, { data: v, parent })}"`, { data: v, parent })
-    }${token(v.tokens.separator)}`;
+    return ts.wrap([
+      ts.trivia(v.tokens.value.trivia),
+      ts.definition(wrap`"${ts.name(v.value, { data: v, parent })}"`, { data: v, parent }),
+      token(v.tokens.separator)
+    ]);
   }
   function iterable_like(it, parent) {
     return ts.definition(ts.wrap([
@@ -254,12 +257,6 @@ export function write(ast, { templates: ts = templates } = {}) {
       token(it.tokens.close),
       token(it.tokens.termination)
     ]), { data: it, parent });
-  }
-  function callbackInterface(it) {
-    return ts.definition(
-      wrap`${ts.trivia(it.trivia.callback)}callback${container(it)}`,
-      { data: it }
-    );
   }
   function eof(it) {
     return ts.trivia(it.trivia);
@@ -283,7 +280,7 @@ export function write(ast, { templates: ts = templates } = {}) {
     legacyiterable: iterable_like,
     maplike: iterable_like,
     setlike: iterable_like,
-    "callback interface": callbackInterface,
+    "callback interface": container,
     eof
   };
   function dispatch(it, parent) {

--- a/test/syntax/baseline/allowany.json
+++ b/test/syntax/baseline/allowany.json
@@ -8,51 +8,32 @@
                 "type": "operation",
                 "name": "g",
                 "body": {
-                    "name": {
-                        "value": "g",
-                        "trivia": " "
-                    },
+                    "name": "g",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": "\n  "
-                        }
+                        "idlType": "void"
                     },
-                    "arguments": [],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    "arguments": []
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             },
             {
                 "type": "operation",
                 "name": "g",
                 "body": {
-                    "name": {
-                        "value": "g",
-                        "trivia": " "
-                    },
+                    "name": "g",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": "\n  "
-                        }
+                        "idlType": "void"
                     },
                     "arguments": [
                         {
@@ -60,51 +41,32 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "B",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "B"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             },
             {
                 "type": "operation",
                 "name": "g",
                 "body": {
-                    "name": {
-                        "value": "g",
-                        "trivia": " "
-                    },
+                    "name": "g",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": "\n  "
-                        }
+                        "idlType": "void"
                     },
                     "arguments": [
                         {
@@ -117,54 +79,27 @@
                                             "type": "extended-attribute",
                                             "name": "AllowAny",
                                             "rhs": null,
-                                            "signature": null,
-                                            "trivia": {
-                                                "name": ""
-                                            }
+                                            "arguments": []
                                         }
-                                    ],
-                                    "trivia": {
-                                        "open": "",
-                                        "close": ""
-                                    }
+                                    ]
                                 },
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "DOMString",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "DOMString"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/attributes.json
+++ b/test/syntax/baseline/attributes.json
@@ -10,22 +10,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned short",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "unsigned short"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n\n  // A simple attribute that can be set to any value the range an unsigned\n  // short can take.\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -33,33 +25,18 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "any",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "any"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n\n  // required is an allowed attribute name\n  ",
-                    "name": " ",
-                    "termination": " "
-                }
+                "special": "",
+                "readonly": false
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/callback.json
+++ b/test/syntax/baseline/callback.json
@@ -5,13 +5,10 @@
         "idlType": {
             "type": "return-type",
             "extAttrs": null,
-            "generic": null,
+            "generic": "",
             "nullable": false,
             "union": false,
-            "idlType": "void",
-            "trivia": {
-                "base": " "
-            }
+            "idlType": "void"
         },
         "arguments": [
             {
@@ -19,31 +16,17 @@
                 "idlType": {
                     "type": "argument-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString",
-                    "trivia": {
-                        "base": ""
-                    }
+                    "idlType": "DOMString"
                 },
                 "default": null,
                 "optional": false,
-                "variadic": false,
-                "trivia": {
-                    "name": " "
-                }
+                "variadic": false
             }
         ],
-        "extAttrs": null,
-        "trivia": {
-            "base": "",
-            "name": " ",
-            "assign": " ",
-            "open": " ",
-            "close": "",
-            "termination": ""
-        }
+        "extAttrs": null
     },
     {
         "type": "callback interface",
@@ -54,20 +37,14 @@
                 "type": "operation",
                 "name": "eventOccurred",
                 "body": {
-                    "name": {
-                        "value": "eventOccurred",
-                        "trivia": " "
-                    },
+                    "name": "eventOccurred",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": "\n  "
-                        }
+                        "idlType": "void"
                     },
                     "arguments": [
                         {
@@ -75,44 +52,23 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "DOMString",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "DOMString"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "callback": "\n\n",
-            "base": " ",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "callback",
@@ -120,13 +76,10 @@
         "idlType": {
             "type": "return-type",
             "extAttrs": null,
-            "generic": null,
+            "generic": "",
             "nullable": false,
             "union": false,
-            "idlType": "boolean",
-            "trivia": {
-                "base": " "
-            }
+            "idlType": "boolean"
         },
         "arguments": [
             {
@@ -134,51 +87,31 @@
                 "idlType": {
                     "type": "argument-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "any",
-                    "trivia": {
-                        "base": ""
-                    }
+                    "idlType": "any"
                 },
                 "default": null,
                 "optional": false,
-                "variadic": false,
-                "trivia": {
-                    "name": " "
-                }
+                "variadic": false
             },
             {
                 "name": "b",
                 "idlType": {
                     "type": "argument-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "any",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "any"
                 },
                 "default": null,
                 "optional": false,
-                "variadic": false,
-                "trivia": {
-                    "name": " "
-                }
+                "variadic": false
             }
         ],
-        "extAttrs": null,
-        "trivia": {
-            "base": "\n\n",
-            "name": " ",
-            "assign": " ",
-            "open": " ",
-            "close": "",
-            "termination": ""
-        }
+        "extAttrs": null
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/constants.json
+++ b/test/syntax/baseline/constants.json
@@ -10,25 +10,15 @@
                 "idlType": {
                     "type": "const-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "boolean",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "boolean"
                 },
                 "extAttrs": null,
                 "value": {
                     "type": "boolean",
                     "value": false
-                },
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "assign": " ",
-                    "value": " ",
-                    "termination": ""
                 }
             },
             {
@@ -37,25 +27,15 @@
                 "idlType": {
                     "type": "const-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "short",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "short"
                 },
                 "extAttrs": null,
                 "value": {
                     "type": "number",
                     "value": "-1"
-                },
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "assign": " ",
-                    "value": " ",
-                    "termination": ""
                 }
             },
             {
@@ -64,25 +44,15 @@
                 "idlType": {
                     "type": "const-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "octet",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "octet"
                 },
                 "extAttrs": null,
                 "value": {
                     "type": "number",
                     "value": "10"
-                },
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "assign": " ",
-                    "value": " ",
-                    "termination": ""
                 }
             },
             {
@@ -91,25 +61,15 @@
                 "idlType": {
                     "type": "const-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned long",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "unsigned long"
                 },
                 "extAttrs": null,
                 "value": {
                     "type": "number",
                     "value": "0x0000fc00"
-                },
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "assign": " ",
-                    "value": " ",
-                    "termination": ""
                 }
             },
             {
@@ -118,25 +78,15 @@
                 "idlType": {
                     "type": "const-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "float",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "float"
                 },
                 "extAttrs": null,
                 "value": {
                     "type": "number",
                     "value": "6.022e23"
-                },
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "assign": " ",
-                    "value": " ",
-                    "termination": ""
                 }
             },
             {
@@ -145,25 +95,15 @@
                 "idlType": {
                     "type": "const-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "unrestricted float",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "unrestricted float"
                 },
                 "extAttrs": null,
                 "value": {
                     "type": "Infinity",
                     "negative": false
-                },
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "assign": " ",
-                    "value": " ",
-                    "termination": ""
                 }
             },
             {
@@ -172,25 +112,15 @@
                 "idlType": {
                     "type": "const-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "unrestricted double",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "unrestricted double"
                 },
                 "extAttrs": null,
                 "value": {
                     "type": "Infinity",
                     "negative": true
-                },
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "assign": " ",
-                    "value": " ",
-                    "termination": ""
                 }
             },
             {
@@ -199,36 +129,19 @@
                 "idlType": {
                     "type": "const-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "short",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "short"
                 },
                 "extAttrs": null,
                 "value": {
                     "type": "NaN"
-                },
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "assign": " ",
-                    "value": " ",
-                    "termination": ""
                 }
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/constructor.json
+++ b/test/syntax/baseline/constructor.json
@@ -10,22 +10,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "float",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "float"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -33,22 +25,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "float",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "float"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -56,22 +40,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "float",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "float"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -79,22 +55,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "float",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "float"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": true,
-                "trivia": {
-                    "base": " ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": true
             }
         ],
         "extAttrs": {
@@ -103,61 +71,32 @@
                     "type": "extended-attribute",
                     "name": "Constructor",
                     "rhs": null,
-                    "signature": null,
-                    "trivia": {
-                        "name": ""
-                    }
+                    "arguments": []
                 },
                 {
                     "type": "extended-attribute",
                     "name": "Constructor",
                     "rhs": null,
-                    "signature": {
-                        "arguments": [
-                            {
-                                "name": "radius",
-                                "idlType": {
-                                    "type": "argument-type",
-                                    "extAttrs": null,
-                                    "generic": null,
-                                    "nullable": false,
-                                    "union": false,
-                                    "idlType": "float",
-                                    "trivia": {
-                                        "base": ""
-                                    }
-                                },
-                                "default": null,
-                                "optional": false,
-                                "variadic": false,
-                                "trivia": {
-                                    "name": " "
-                                }
-                            }
-                        ],
-                        "trivia": {
-                            "open": "",
-                            "close": ""
+                    "arguments": [
+                        {
+                            "name": "radius",
+                            "idlType": {
+                                "type": "argument-type",
+                                "extAttrs": null,
+                                "generic": "",
+                                "nullable": false,
+                                "union": false,
+                                "idlType": "float"
+                            },
+                            "default": null,
+                            "optional": false,
+                            "variadic": false
                         }
-                    },
-                    "trivia": {
-                        "name": "\n "
-                    }
+                    ]
                 }
-            ],
-            "trivia": {
-                "open": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
-                "close": ""
-            }
+            ]
         },
-        "partial": false,
-        "trivia": {
-            "base": "\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/dictionary-inherits.json
+++ b/test/syntax/baseline/dictionary-inherits.json
@@ -11,27 +11,16 @@
                 "idlType": {
                     "type": "dictionary-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": true,
                     "union": false,
-                    "idlType": "DOMString",
-                    "trivia": {
-                        "base": "\n  "
-                    }
+                    "idlType": "DOMString"
                 },
                 "default": {
                     "type": "string",
-                    "value": "black",
-                    "trivia": {
-                        "assign": " ",
-                        "value": " "
-                    }
+                    "value": "black"
                 },
-                "required": false,
-                "trivia": {
-                    "name": " ",
-                    "termination": ""
-                }
+                "required": false
             },
             {
                 "type": "field",
@@ -40,26 +29,15 @@
                 "idlType": {
                     "type": "dictionary-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": true,
                     "union": false,
-                    "idlType": "DOMString",
-                    "trivia": {
-                        "base": "\n  "
-                    }
+                    "idlType": "DOMString"
                 },
                 "default": {
-                    "type": "null",
-                    "trivia": {
-                        "assign": " ",
-                        "value": " "
-                    }
+                    "type": "null"
                 },
-                "required": false,
-                "trivia": {
-                    "name": " ",
-                    "termination": ""
-                }
+                "required": false
             },
             {
                 "type": "field",
@@ -68,41 +46,23 @@
                 "idlType": {
                     "type": "dictionary-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "Point",
-                    "trivia": {
-                        "base": "\n  "
-                    }
+                    "idlType": "Point"
                 },
                 "default": null,
-                "required": false,
-                "trivia": {
-                    "name": " ",
-                    "termination": ""
-                }
+                "required": false
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "dictionary",
         "name": "WetPaintOptions",
         "inheritance": {
-            "name": "PaintOptions",
-            "trivia": {
-                "colon": " ",
-                "name": " "
-            }
+            "name": "PaintOptions"
         },
         "members": [
             {
@@ -112,31 +72,17 @@
                 "idlType": {
                     "type": "dictionary-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "float",
-                    "trivia": {
-                        "base": "\n  "
-                    }
+                    "idlType": "float"
                 },
                 "default": null,
-                "required": false,
-                "trivia": {
-                    "name": " ",
-                    "termination": ""
-                }
+                "required": false
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/dictionary.json
+++ b/test/syntax/baseline/dictionary.json
@@ -11,27 +11,16 @@
                 "idlType": {
                     "type": "dictionary-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": true,
                     "union": false,
-                    "idlType": "DOMString",
-                    "trivia": {
-                        "base": "\n  "
-                    }
+                    "idlType": "DOMString"
                 },
                 "default": {
                     "type": "string",
-                    "value": "black",
-                    "trivia": {
-                        "assign": " ",
-                        "value": " "
-                    }
+                    "value": "black"
                 },
-                "required": false,
-                "trivia": {
-                    "name": " ",
-                    "termination": ""
-                }
+                "required": false
             },
             {
                 "type": "field",
@@ -40,26 +29,15 @@
                 "idlType": {
                     "type": "dictionary-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": true,
                     "union": false,
-                    "idlType": "DOMString",
-                    "trivia": {
-                        "base": "\n  "
-                    }
+                    "idlType": "DOMString"
                 },
                 "default": {
-                    "type": "null",
-                    "trivia": {
-                        "assign": " ",
-                        "value": " "
-                    }
+                    "type": "null"
                 },
-                "required": false,
-                "trivia": {
-                    "name": " ",
-                    "termination": ""
-                }
+                "required": false
             },
             {
                 "type": "field",
@@ -68,20 +46,13 @@
                 "idlType": {
                     "type": "dictionary-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "Point",
-                    "trivia": {
-                        "base": "\n  "
-                    }
+                    "idlType": "Point"
                 },
                 "default": null,
-                "required": false,
-                "trivia": {
-                    "name": " ",
-                    "termination": ""
-                }
+                "required": false
             },
             {
                 "type": "field",
@@ -90,46 +61,25 @@
                 "idlType": {
                     "type": "dictionary-type",
                     "extAttrs": null,
-                    "generic": {
-                        "value": "sequence",
-                        "trivia": {
-                            "open": "",
-                            "close": ""
-                        }
-                    },
+                    "generic": "sequence",
                     "nullable": false,
                     "union": false,
                     "idlType": [
                         {
                             "type": "dictionary-type",
                             "extAttrs": null,
-                            "generic": null,
+                            "generic": "",
                             "nullable": false,
                             "union": false,
-                            "idlType": "long",
-                            "trivia": {
-                                "base": ""
-                            }
+                            "idlType": "long"
                         }
-                    ],
-                    "trivia": {
-                        "base": "\n  // https://heycam.github.io/webidl/#dfn-optional-argument-default-value allows sequences to default to \"[]\".\n  "
-                    }
+                    ]
                 },
                 "default": {
                     "type": "sequence",
-                    "value": [],
-                    "trivia": {
-                        "assign": " ",
-                        "open": " ",
-                        "close": ""
-                    }
+                    "value": []
                 },
-                "required": false,
-                "trivia": {
-                    "name": " ",
-                    "termination": ""
-                }
+                "required": false
             },
             {
                 "type": "field",
@@ -138,31 +88,17 @@
                 "idlType": {
                     "type": "dictionary-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "long",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "long"
                 },
                 "default": null,
-                "required": true,
-                "trivia": {
-                    "name": " ",
-                    "termination": ""
-                }
+                "required": true
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "// Extracted from Web IDL editors draft May 31 2011\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "dictionary",
@@ -175,20 +111,13 @@
                 "idlType": {
                     "type": "dictionary-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "long",
-                    "trivia": {
-                        "base": "\n  "
-                    }
+                    "idlType": "long"
                 },
                 "default": null,
-                "required": false,
-                "trivia": {
-                    "name": " ",
-                    "termination": ""
-                }
+                "required": false
             },
             {
                 "type": "field",
@@ -197,31 +126,17 @@
                 "idlType": {
                     "type": "dictionary-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "long",
-                    "trivia": {
-                        "base": "\n  "
-                    }
+                    "idlType": "long"
                 },
                 "default": null,
-                "required": false,
-                "trivia": {
-                    "name": " ",
-                    "termination": ""
-                }
+                "required": false
             }
         ],
         "extAttrs": null,
-        "partial": true,
-        "trivia": {
-            "base": " ",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": true
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/documentation-dos.json
+++ b/test/syntax/baseline/documentation-dos.json
@@ -5,14 +5,7 @@
         "inheritance": null,
         "members": [],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "/**\n* \\brief Testing documentation features\n*\n* This is a\n* single paragraph\n*\n* <p>This is valid.</p>\n* <p>This is <em>valid</em>.</p>\n* <p>This is <b>valid</b>.</p>\n* <p>This is <a href=''>valid</a>.</p>\n* <ul>\n* <li>This</li>\n* <li>is</li>\n* <li>valid</li>\n* </ul>\n* <dl>\n* <dt>This</dt>\n* <dd>valid</dd>\n* </dl>\n* <table>\n* <tr>\n* <td>this</td>\n* <td>is</td>\n* </tr>\n* <tr>\n* <td>valid</td>\n* </tr>\n* </table>\n* <p>This is <br> valid.</p>\n* <p>This is <br /> valid.</p>\n* <p>This is <br/> valid.</p>\n*/\n",
-            "name": " ",
-            "open": " ",
-            "close": "",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/documentation.json
+++ b/test/syntax/baseline/documentation.json
@@ -5,14 +5,7 @@
         "inheritance": null,
         "members": [],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "/**\n* \\brief Testing documentation features\n*\n* This is a\n* single paragraph\n*\n* <p>This is valid.</p>\n* <p>This is <em>valid</em>.</p>\n* <p>This is <b>valid</b>.</p>\n* <p>This is <a href=''>valid</a>.</p>\n* <ul>\n* <li>This</li>\n* <li>is</li>\n* <li>valid</li>\n* </ul>\n* <dl>\n* <dt>This</dt>\n* <dd>valid</dd>\n* </dl>\n* <table>\n* <tr>\n* <td>this</td>\n* <td>is</td>\n* </tr>\n* <tr>\n* <td>valid</td>\n* </tr>\n* </table>\n* <p>This is <br> valid.</p>\n* <p>This is <br /> valid.</p>\n* <p>This is <br/> valid.</p>\n* <p><img src=\"foo.png\" alt=\"Valid\"/></p>\n*/\n",
-            "name": " ",
-            "open": " ",
-            "close": "",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/enum.json
+++ b/test/syntax/baseline/enum.json
@@ -5,28 +5,18 @@
         "values": [
             {
                 "type": "enum-value",
-                "value": "rice",
-                "trivia": " "
+                "value": "rice"
             },
             {
                 "type": "enum-value",
-                "value": "noodles",
-                "trivia": " "
+                "value": "noodles"
             },
             {
                 "type": "enum-value",
-                "value": "other",
-                "trivia": " "
+                "value": "other"
             }
         ],
-        "extAttrs": null,
-        "trivia": {
-            "base": "",
-            "name": " ",
-            "open": " ",
-            "close": " ",
-            "termination": ""
-        }
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -39,22 +29,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "MealType",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "MealType"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -62,41 +44,27 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "float",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "float"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "operation",
                 "name": "initialize",
                 "body": {
-                    "name": {
-                        "value": "initialize",
-                        "trivia": " "
-                    },
+                    "name": "initialize",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": "     // in grams\n\n  "
-                        }
+                        "idlType": "void"
                     },
                     "arguments": [
                         {
@@ -104,63 +72,37 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "MealType",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "MealType"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         },
                         {
                             "name": "size",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "float",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "float"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "enum",
@@ -168,28 +110,18 @@
         "values": [
             {
                 "type": "enum-value",
-                "value": "rice",
-                "trivia": " "
+                "value": "rice"
             },
             {
                 "type": "enum-value",
-                "value": "noodles",
-                "trivia": " "
+                "value": "noodles"
             },
             {
                 "type": "enum-value",
-                "value": "other",
-                "trivia": " "
+                "value": "other"
             }
         ],
-        "extAttrs": null,
-        "trivia": {
-            "base": "\n\n",
-            "name": " ",
-            "open": " ",
-            "close": " ",
-            "termination": ""
-        }
+        "extAttrs": null
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/equivalent-decl.json
+++ b/test/syntax/baseline/equivalent-decl.json
@@ -10,41 +10,27 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned long",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "unsigned long"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": true,
-                "trivia": {
-                    "base": " ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": true
             },
             {
                 "type": "operation",
                 "name": "getProperty",
                 "body": {
-                    "name": {
-                        "value": "getProperty",
-                        "trivia": " "
-                    },
+                    "name": "getProperty",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "float",
-                        "trivia": {
-                            "base": " "
-                        }
+                        "idlType": "float"
                     },
                     "arguments": [
                         {
@@ -52,51 +38,32 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "DOMString",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "DOMString"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": "getter",
-                "trivia": {
-                    "termination": ""
-                }
+                "special": "getter"
             },
             {
                 "type": "operation",
                 "name": "setProperty",
                 "body": {
-                    "name": {
-                        "value": "setProperty",
-                        "trivia": " "
-                    },
+                    "name": "setProperty",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": " "
-                        }
+                        "idlType": "void"
                     },
                     "arguments": [
                         {
@@ -104,63 +71,37 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "DOMString",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "DOMString"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         },
                         {
                             "name": "propertyValue",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "float",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "float"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": "setter",
-                "trivia": {
-                    "termination": ""
-                }
+                "special": "setter"
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
@@ -173,41 +114,27 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned long",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "unsigned long"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": true,
-                "trivia": {
-                    "base": " ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": true
             },
             {
                 "type": "operation",
                 "name": "getProperty",
                 "body": {
-                    "name": {
-                        "value": "getProperty",
-                        "trivia": " "
-                    },
+                    "name": "getProperty",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "float",
-                        "trivia": {
-                            "base": "\n\n  "
-                        }
+                        "idlType": "float"
                     },
                     "arguments": [
                         {
@@ -215,51 +142,32 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "DOMString",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "DOMString"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             },
             {
                 "type": "operation",
                 "name": "setProperty",
                 "body": {
-                    "name": {
-                        "value": "setProperty",
-                        "trivia": " "
-                    },
+                    "name": "setProperty",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": "\n  "
-                        }
+                        "idlType": "void"
                     },
                     "arguments": [
                         {
@@ -267,68 +175,46 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "DOMString",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "DOMString"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         },
                         {
                             "name": "propertyValue",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "float",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "float"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             },
             {
                 "type": "operation",
                 "name": "",
                 "body": {
-                    "name": null,
+                    "name": "",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "float",
-                        "trivia": {
-                            "base": " "
-                        }
+                        "idlType": "float"
                     },
                     "arguments": [
                         {
@@ -336,48 +222,32 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "DOMString",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "DOMString"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": " ",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": "getter",
-                "trivia": {
-                    "termination": ""
-                }
+                "special": "getter"
             },
             {
                 "type": "operation",
                 "name": "",
                 "body": {
-                    "name": null,
+                    "name": "",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": " "
-                        }
+                        "idlType": "void"
                     },
                     "arguments": [
                         {
@@ -385,63 +255,37 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "DOMString",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "DOMString"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         },
                         {
                             "name": "propertyValue",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "float",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "float"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": " ",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": "setter",
-                "trivia": {
-                    "termination": ""
-                }
+                "special": "setter"
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/escaped-name.json
+++ b/test/syntax/baseline/escaped-name.json
@@ -3,34 +3,17 @@
         "type": "interface",
         "name": "Iroha",
         "inheritance": {
-            "name": "Magic",
-            "trivia": {
-                "colon": " ",
-                "name": " "
-            }
+            "name": "Magic"
         },
         "members": [],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "",
-            "name": " ",
-            "open": " ",
-            "close": "",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "includes",
         "extAttrs": null,
         "target": "Iroha",
-        "includes": "Color",
-        "trivia": {
-            "target": "\n",
-            "includes": " ",
-            "mixin": " ",
-            "termination": ""
-        }
+        "includes": "Color"
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/escaped-type.json
+++ b/test/syntax/baseline/escaped-type.json
@@ -5,20 +5,12 @@
         "idlType": {
             "type": "typedef-type",
             "extAttrs": null,
-            "generic": null,
+            "generic": "",
             "nullable": false,
             "union": false,
-            "idlType": "Type",
-            "trivia": {
-                "base": " "
-            }
+            "idlType": "Type"
         },
-        "extAttrs": null,
-        "trivia": {
-            "base": "",
-            "name": " ",
-            "termination": ""
-        }
+        "extAttrs": null
     },
     {
         "type": "typedef",
@@ -26,38 +18,21 @@
         "idlType": {
             "type": "typedef-type",
             "extAttrs": null,
-            "generic": {
-                "value": "sequence",
-                "trivia": {
-                    "open": "",
-                    "close": ""
-                }
-            },
+            "generic": "sequence",
             "nullable": false,
             "union": false,
             "idlType": [
                 {
                     "type": "typedef-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "Type",
-                    "trivia": {
-                        "base": ""
-                    }
+                    "idlType": "Type"
                 }
-            ],
-            "trivia": {
-                "base": " "
-            }
+            ]
         },
-        "extAttrs": null,
-        "trivia": {
-            "base": "\n",
-            "name": " ",
-            "termination": ""
-        }
+        "extAttrs": null
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/extended-attributes.json
+++ b/test/syntax/baseline/extended-attributes.json
@@ -3,11 +3,7 @@
         "type": "interface",
         "name": "ServiceWorkerGlobalScope",
         "inheritance": {
-            "name": "WorkerGlobalScope",
-            "trivia": {
-                "colon": " ",
-                "name": " "
-            }
+            "name": "WorkerGlobalScope"
         },
         "members": [],
         "extAttrs": {
@@ -19,55 +15,27 @@
                         "type": "identifier-list",
                         "value": [
                             {
-                                "value": "Worker",
-                                "trivia": ""
+                                "value": "Worker"
                             },
                             {
-                                "value": "ServiceWorker",
-                                "trivia": ""
+                                "value": "ServiceWorker"
                             }
-                        ],
-                        "trivia": {
-                            "assign": "",
-                            "open": "",
-                            "close": ""
-                        }
+                        ]
                     },
-                    "signature": null,
-                    "trivia": {
-                        "name": ""
-                    }
+                    "arguments": []
                 },
                 {
                     "type": "extended-attribute",
                     "name": "Exposed",
                     "rhs": {
                         "type": "identifier",
-                        "value": "ServiceWorker",
-                        "trivia": {
-                            "assign": "",
-                            "value": ""
-                        }
+                        "value": "ServiceWorker"
                     },
-                    "signature": null,
-                    "trivia": {
-                        "name": " "
-                    }
+                    "arguments": []
                 }
-            ],
-            "trivia": {
-                "open": "// Extracted from http://www.w3.org/TR/2015/WD-service-workers-20150205/\n\n",
-                "close": ""
-            }
+            ]
         },
-        "partial": false,
-        "trivia": {
-            "base": "\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
@@ -81,63 +49,31 @@
                     "name": "IntAttr",
                     "rhs": {
                         "type": "integer",
-                        "value": "0",
-                        "trivia": {
-                            "assign": "",
-                            "value": ""
-                        }
+                        "value": "0"
                     },
-                    "signature": null,
-                    "trivia": {
-                        "name": ""
-                    }
+                    "arguments": []
                 },
                 {
                     "type": "extended-attribute",
                     "name": "FloatAttr",
                     "rhs": {
                         "type": "float",
-                        "value": "3.14",
-                        "trivia": {
-                            "assign": "",
-                            "value": ""
-                        }
+                        "value": "3.14"
                     },
-                    "signature": null,
-                    "trivia": {
-                        "name": " "
-                    }
+                    "arguments": []
                 },
                 {
                     "type": "extended-attribute",
                     "name": "StringAttr",
                     "rhs": {
                         "type": "string",
-                        "value": "\"abc\"",
-                        "trivia": {
-                            "assign": "",
-                            "value": ""
-                        }
+                        "value": "\"abc\""
                     },
-                    "signature": null,
-                    "trivia": {
-                        "name": " "
-                    }
+                    "arguments": []
                 }
-            ],
-            "trivia": {
-                "open": "\n\n// Conformance with ExtendedAttributeList grammar in http://www.w3.org/TR/WebIDL/#idl-extended-attributes\n// Section 3.11\n",
-                "close": ""
-            }
+            ]
         },
-        "partial": false,
-        "trivia": {
-            "base": "\n",
-            "name": " ",
-            "open": " ",
-            "close": "",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
@@ -150,22 +86,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "double",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "double"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -173,22 +101,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "double",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "double"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -196,22 +116,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "double",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "double"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -219,22 +131,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "double",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "double"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": true,
-                "trivia": {
-                    "base": " ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": true
             }
         ],
         "extAttrs": {
@@ -243,61 +147,32 @@
                     "type": "extended-attribute",
                     "name": "Constructor",
                     "rhs": null,
-                    "signature": null,
-                    "trivia": {
-                        "name": "\n  "
-                    }
+                    "arguments": []
                 },
                 {
                     "type": "extended-attribute",
                     "name": "Constructor",
                     "rhs": null,
-                    "signature": {
-                        "arguments": [
-                            {
-                                "name": "radius",
-                                "idlType": {
-                                    "type": "argument-type",
-                                    "extAttrs": null,
-                                    "generic": null,
-                                    "nullable": false,
-                                    "union": false,
-                                    "idlType": "double",
-                                    "trivia": {
-                                        "base": ""
-                                    }
-                                },
-                                "default": null,
-                                "optional": false,
-                                "variadic": false,
-                                "trivia": {
-                                    "name": " "
-                                }
-                            }
-                        ],
-                        "trivia": {
-                            "open": "",
-                            "close": ""
+                    "arguments": [
+                        {
+                            "name": "radius",
+                            "idlType": {
+                                "type": "argument-type",
+                                "extAttrs": null,
+                                "generic": "",
+                                "nullable": false,
+                                "union": false,
+                                "idlType": "double"
+                            },
+                            "default": null,
+                            "optional": false,
+                            "variadic": false
                         }
-                    },
-                    "trivia": {
-                        "name": "\n  "
-                    }
+                    ]
                 }
-            ],
-            "trivia": {
-                "open": "\n\n// Extracted from http://www.w3.org/TR/2016/REC-WebIDL-1-20161215/#Constructor on 2017-5-18 with whitespace differences\n",
-                "close": "\n"
-            }
+            ]
         },
-        "partial": false,
-        "trivia": {
-            "base": "\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
@@ -315,57 +190,35 @@
                                 "type": "extended-attribute",
                                 "name": "XAttr",
                                 "rhs": null,
-                                "signature": null,
-                                "trivia": {
-                                    "name": ""
-                                }
+                                "arguments": []
                             }
-                        ],
-                        "trivia": {
-                            "open": " ",
-                            "close": ""
-                        }
+                        ]
                     },
                     "union": true,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "idlType": [
                         {
                             "type": null,
                             "extAttrs": null,
-                            "generic": null,
+                            "generic": "",
                             "nullable": false,
                             "union": false,
-                            "idlType": "long",
-                            "trivia": {
-                                "base": ""
-                            }
+                            "idlType": "long"
                         },
                         {
                             "type": null,
                             "extAttrs": null,
-                            "generic": null,
+                            "generic": "",
                             "nullable": false,
                             "union": false,
-                            "idlType": "Node",
-                            "trivia": {
-                                "base": " "
-                            }
+                            "idlType": "Node"
                         }
-                    ],
-                    "trivia": {
-                        "open": " ",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n    ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             }
         ],
         "extAttrs": {
@@ -375,31 +228,13 @@
                     "name": "Exposed",
                     "rhs": {
                         "type": "identifier",
-                        "value": "Window",
-                        "trivia": {
-                            "assign": "",
-                            "value": ""
-                        }
+                        "value": "Window"
                     },
-                    "signature": null,
-                    "trivia": {
-                        "name": ""
-                    }
+                    "arguments": []
                 }
-            ],
-            "trivia": {
-                "open": "\n\n// Extracted from https://heycam.github.io/webidl/#idl-annotated-types on 2017-12-15\n",
-                "close": ""
-            }
+            ]
         },
-        "partial": false,
-        "trivia": {
-            "base": "\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/generic.json
+++ b/test/syntax/baseline/generic.json
@@ -8,86 +8,46 @@
                 "type": "operation",
                 "name": "bar",
                 "body": {
-                    "name": {
-                        "value": "bar",
-                        "trivia": " "
-                    },
+                    "name": "bar",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": {
-                            "value": "Promise",
-                            "trivia": {
-                                "open": "",
-                                "close": ""
-                            }
-                        },
+                        "generic": "Promise",
                         "nullable": false,
                         "union": false,
                         "idlType": [
                             {
                                 "type": "return-type",
                                 "extAttrs": null,
-                                "generic": {
-                                    "value": "Promise",
-                                    "trivia": {
-                                        "open": "",
-                                        "close": ""
-                                    }
-                                },
+                                "generic": "Promise",
                                 "nullable": false,
                                 "union": false,
                                 "idlType": [
                                     {
                                         "type": "return-type",
                                         "extAttrs": null,
-                                        "generic": {
-                                            "value": "sequence",
-                                            "trivia": {
-                                                "open": "",
-                                                "close": ""
-                                            }
-                                        },
+                                        "generic": "sequence",
                                         "nullable": false,
                                         "union": false,
                                         "idlType": [
                                             {
                                                 "type": "return-type",
                                                 "extAttrs": null,
-                                                "generic": null,
+                                                "generic": "",
                                                 "nullable": true,
                                                 "union": false,
-                                                "idlType": "DOMString",
-                                                "trivia": {
-                                                    "base": ""
-                                                }
+                                                "idlType": "DOMString"
                                             }
-                                        ],
-                                        "trivia": {
-                                            "base": ""
-                                        }
+                                        ]
                                     }
-                                ],
-                                "trivia": {
-                                    "base": ""
-                                }
+                                ]
                             }
-                        ],
-                        "trivia": {
-                            "base": "\n  "
-                        }
+                        ]
                     },
-                    "arguments": [],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    "arguments": []
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             },
             {
                 "type": "attribute",
@@ -95,51 +55,27 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": {
-                        "value": "Promise",
-                        "trivia": {
-                            "open": "",
-                            "close": ""
-                        }
-                    },
+                    "generic": "Promise",
                     "nullable": false,
                     "union": false,
                     "idlType": [
                         {
                             "type": "attribute-type",
                             "extAttrs": null,
-                            "generic": null,
+                            "generic": "",
                             "nullable": false,
                             "union": false,
-                            "idlType": "DOMString",
-                            "trivia": {
-                                "base": ""
-                            }
+                            "idlType": "DOMString"
                         }
-                    ],
-                    "trivia": {
-                        "base": " "
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": true,
-                "trivia": {
-                    "base": " ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": true
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
@@ -150,181 +86,97 @@
                 "type": "operation",
                 "name": "getServiced",
                 "body": {
-                    "name": {
-                        "value": "getServiced",
-                        "trivia": " "
-                    },
+                    "name": "getServiced",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": {
-                            "value": "Promise",
-                            "trivia": {
-                                "open": "",
-                                "close": ""
-                            }
-                        },
+                        "generic": "Promise",
                         "nullable": false,
                         "union": false,
                         "idlType": [
                             {
                                 "type": "return-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": true,
                                 "union": false,
-                                "idlType": "Client",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "Client"
                             }
-                        ],
-                        "trivia": {
-                            "base": "\n  "
-                        }
+                        ]
                     },
-                    "arguments": [],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    "arguments": []
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             },
             {
                 "type": "operation",
                 "name": "reloadAll",
                 "body": {
-                    "name": {
-                        "value": "reloadAll",
-                        "trivia": " "
-                    },
+                    "name": "reloadAll",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": {
-                            "value": "Promise",
-                            "trivia": {
-                                "open": "",
-                                "close": ""
-                            }
-                        },
+                        "generic": "Promise",
                         "nullable": false,
                         "union": false,
                         "idlType": [
                             {
                                 "type": "return-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "any",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "any"
                             }
-                        ],
-                        "trivia": {
-                            "base": "\n  "
-                        }
+                        ]
                     },
-                    "arguments": [],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    "arguments": []
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n// Extracted from https://slightlyoff.github.io/ServiceWorker/spec/service_worker/ on 2014-05-08\n\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
         "name": "FetchEvent",
         "inheritance": {
-            "name": "Event",
-            "trivia": {
-                "colon": " ",
-                "name": " "
-            }
+            "name": "Event"
         },
         "members": [
             {
                 "type": "operation",
                 "name": "default",
                 "body": {
-                    "name": {
-                        "value": "default",
-                        "trivia": " "
-                    },
+                    "name": "default",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": {
-                            "value": "Promise",
-                            "trivia": {
-                                "open": "",
-                                "close": ""
-                            }
-                        },
+                        "generic": "Promise",
                         "nullable": false,
                         "union": false,
                         "idlType": [
                             {
                                 "type": "return-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "any",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "any"
                             }
-                        ],
-                        "trivia": {
-                            "base": "\n  "
-                        }
+                        ]
                     },
-                    "arguments": [],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    "arguments": []
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n// Extracted from https://slightlyoff.github.io/ServiceWorker/spec/service_worker/ on 2014-05-13\n\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/getter-setter.json
+++ b/test/syntax/baseline/getter-setter.json
@@ -10,38 +10,27 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned long",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "unsigned long"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": true,
-                "trivia": {
-                    "base": " ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": true
             },
             {
                 "type": "operation",
                 "name": "",
                 "body": {
-                    "name": null,
+                    "name": "",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "float",
-                        "trivia": {
-                            "base": " "
-                        }
+                        "idlType": "float"
                     },
                     "arguments": [
                         {
@@ -49,48 +38,32 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "DOMString",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "DOMString"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": " ",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": "getter",
-                "trivia": {
-                    "termination": ""
-                }
+                "special": "getter"
             },
             {
                 "type": "operation",
                 "name": "",
                 "body": {
-                    "name": null,
+                    "name": "",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": " "
-                        }
+                        "idlType": "void"
                     },
                     "arguments": [
                         {
@@ -98,63 +71,37 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "DOMString",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "DOMString"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         },
                         {
                             "name": "propertyValue",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "float",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "float"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": " ",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": "setter",
-                "trivia": {
-                    "termination": ""
-                }
+                "special": "setter"
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/identifier-hyphen.json
+++ b/test/syntax/baseline/identifier-hyphen.json
@@ -15,30 +15,16 @@
                                 "name": "TreatNullAs",
                                 "rhs": {
                                     "type": "identifier",
-                                    "value": "EmptyString",
-                                    "trivia": {
-                                        "assign": "",
-                                        "value": ""
-                                    }
+                                    "value": "EmptyString"
                                 },
-                                "signature": null,
-                                "trivia": {
-                                    "name": ""
-                                }
+                                "arguments": []
                             }
-                        ],
-                        "trivia": {
-                            "open": " ",
-                            "close": ""
-                        }
+                        ]
                     },
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "CSSOMString",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "CSSOMString"
                 },
                 "extAttrs": {
                     "items": [
@@ -46,35 +32,16 @@
                             "type": "extended-attribute",
                             "name": "CEReactions",
                             "rhs": null,
-                            "signature": null,
-                            "trivia": {
-                                "name": ""
-                            }
+                            "arguments": []
                         }
-                    ],
-                    "trivia": {
-                        "open": "\n  ",
-                        "close": ""
-                    }
+                    ]
                 },
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": " ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             }
         ],
         "extAttrs": null,
-        "partial": true,
-        "trivia": {
-            "base": " ",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": true
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/identifier-qualified-names.json
+++ b/test/syntax/baseline/identifier-qualified-names.json
@@ -5,20 +5,12 @@
         "idlType": {
             "type": "typedef-type",
             "extAttrs": null,
-            "generic": null,
+            "generic": "",
             "nullable": false,
             "union": false,
-            "idlType": "float",
-            "trivia": {
-                "base": " "
-            }
+            "idlType": "float"
         },
-        "extAttrs": null,
-        "trivia": {
-            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n  // Typedef identifier: \"number\"\n  // Qualified name:    \"::framework::number\"\n  ",
-            "name": " ",
-            "termination": ""
-        }
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -29,20 +21,14 @@
                 "type": "operation",
                 "name": "createObject",
                 "body": {
-                    "name": {
-                        "value": "createObject",
-                        "trivia": " "
-                    },
+                    "name": "createObject",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "object",
-                        "trivia": {
-                            "base": "\n\n    // Operation identifier:          \"createObject\"\n    // Operation argument identifier: \"interface\"\n    "
-                        }
+                        "idlType": "object"
                     },
                     "arguments": [
                         {
@@ -50,48 +36,32 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "DOMString",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "DOMString"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             },
             {
                 "type": "operation",
                 "name": "",
                 "body": {
-                    "name": null,
+                    "name": "",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "DOMString",
-                        "trivia": {
-                            "base": " "
-                        }
+                        "idlType": "DOMString"
                     },
                     "arguments": [
                         {
@@ -99,43 +69,23 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "DOMString",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "DOMString"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": " ",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": "getter",
-                "trivia": {
-                    "termination": ""
-                }
+                "special": "getter"
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n  // Interface identifier: \"System\"\n  // Qualified name:       \"::framework::System\"\n  ",
-            "name": " ",
-            "open": " ",
-            "close": "\n  ",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
@@ -148,22 +98,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "boolean",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "boolean"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n\n      // Attribute identifier: \"const\"\n      ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -171,33 +113,18 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": true,
                     "union": false,
-                    "idlType": "DOMString",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "DOMString"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n\n      // Attribute identifier: \"value\"\n      ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n\n    // Interface identifier: \"TextField\"\n    // Qualified name:       \"::framework::gui::TextField\"\n    ",
-            "name": " ",
-            "open": " ",
-            "close": "\n    ",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
@@ -208,20 +135,14 @@
                 "type": "operation",
                 "name": "addEventListener",
                 "body": {
-                    "name": {
-                        "value": "addEventListener",
-                        "trivia": " "
-                    },
+                    "name": "addEventListener",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": "\n  // Argument names allow some selected keywords\n  "
-                        }
+                        "idlType": "void"
                     },
                     "arguments": [
                         {
@@ -229,43 +150,23 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": true,
                                 "union": false,
-                                "idlType": "EventListener",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "EventListener"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/indexed-properties.json
+++ b/test/syntax/baseline/indexed-properties.json
@@ -10,41 +10,27 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned long",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "unsigned long"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": true,
-                "trivia": {
-                    "base": " ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": true
             },
             {
                 "type": "operation",
                 "name": "getByIndex",
                 "body": {
-                    "name": {
-                        "value": "getByIndex",
-                        "trivia": " "
-                    },
+                    "name": "getByIndex",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "any",
-                        "trivia": {
-                            "base": " "
-                        }
+                        "idlType": "any"
                     },
                     "arguments": [
                         {
@@ -52,51 +38,32 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "unsigned long",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "unsigned long"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": "getter",
-                "trivia": {
-                    "termination": ""
-                }
+                "special": "getter"
             },
             {
                 "type": "operation",
                 "name": "setByIndex",
                 "body": {
-                    "name": {
-                        "value": "setByIndex",
-                        "trivia": " "
-                    },
+                    "name": "setByIndex",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": " "
-                        }
+                        "idlType": "void"
                     },
                     "arguments": [
                         {
@@ -104,71 +71,46 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "unsigned long",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "unsigned long"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         },
                         {
                             "name": "value",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "any",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "any"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": "setter",
-                "trivia": {
-                    "termination": ""
-                }
+                "special": "setter"
             },
             {
                 "type": "operation",
                 "name": "removeByIndex",
                 "body": {
-                    "name": {
-                        "value": "removeByIndex",
-                        "trivia": " "
-                    },
+                    "name": "removeByIndex",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": " "
-                        }
+                        "idlType": "void"
                     },
                     "arguments": [
                         {
@@ -176,51 +118,32 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "unsigned long",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "unsigned long"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": "deleter",
-                "trivia": {
-                    "termination": ""
-                }
+                "special": "deleter"
             },
             {
                 "type": "operation",
                 "name": "get",
                 "body": {
-                    "name": {
-                        "value": "get",
-                        "trivia": " "
-                    },
+                    "name": "get",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "any",
-                        "trivia": {
-                            "base": " "
-                        }
+                        "idlType": "any"
                     },
                     "arguments": [
                         {
@@ -228,51 +151,32 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "DOMString",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "DOMString"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": "getter",
-                "trivia": {
-                    "termination": ""
-                }
+                "special": "getter"
             },
             {
                 "type": "operation",
                 "name": "set",
                 "body": {
-                    "name": {
-                        "value": "set",
-                        "trivia": " "
-                    },
+                    "name": "set",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": " "
-                        }
+                        "idlType": "void"
                     },
                     "arguments": [
                         {
@@ -280,71 +184,46 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "DOMString",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "DOMString"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         },
                         {
                             "name": "value",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "any",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "any"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": "setter",
-                "trivia": {
-                    "termination": ""
-                }
+                "special": "setter"
             },
             {
                 "type": "operation",
                 "name": "remove",
                 "body": {
-                    "name": {
-                        "value": "remove",
-                        "trivia": " "
-                    },
+                    "name": "remove",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": " "
-                        }
+                        "idlType": "void"
                     },
                     "arguments": [
                         {
@@ -352,43 +231,23 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "DOMString",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "DOMString"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": "deleter",
-                "trivia": {
-                    "termination": ""
-                }
+                "special": "deleter"
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/inherits-getter.json
+++ b/test/syntax/baseline/inherits-getter.json
@@ -10,43 +10,24 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "DOMString"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": true,
-                "trivia": {
-                    "base": " ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": true
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
         "name": "Person",
         "inheritance": {
-            "name": "Animal",
-            "trivia": {
-                "colon": " ",
-                "name": " "
-            }
+            "name": "Animal"
         },
         "members": [
             {
@@ -55,22 +36,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned short",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "unsigned short"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": true,
-                "trivia": {
-                    "base": " ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": true
             },
             {
                 "type": "attribute",
@@ -78,43 +51,24 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "DOMString"
                 },
                 "extAttrs": null,
                 "special": "inherit",
-                "readonly": false,
-                "trivia": {
-                    "base": " ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "readonly": false
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
         "name": "Ghost",
         "inheritance": {
-            "name": "Person",
-            "trivia": {
-                "colon": " ",
-                "name": " "
-            }
+            "name": "Person"
         },
         "members": [
             {
@@ -123,33 +77,18 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "DOMString"
                 },
                 "extAttrs": null,
                 "special": "inherit",
-                "readonly": true,
-                "trivia": {
-                    "base": " ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "readonly": true
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/interface-inherits.json
+++ b/test/syntax/baseline/interface-inherits.json
@@ -10,43 +10,24 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "DOMString"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
         "name": "Human",
         "inheritance": {
-            "name": "Animal",
-            "trivia": {
-                "colon": " ",
-                "name": " "
-            }
+            "name": "Animal"
         },
         "members": [
             {
@@ -55,43 +36,24 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "Dog",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "Dog"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
         "name": "Dog",
         "inheritance": {
-            "name": "Animal",
-            "trivia": {
-                "colon": " ",
-                "name": " "
-            }
+            "name": "Animal"
         },
         "members": [
             {
@@ -100,33 +62,18 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "Human",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "Human"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/iterable.json
+++ b/test/syntax/baseline/iterable.json
@@ -10,34 +10,18 @@
                     {
                         "type": null,
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "long",
-                        "trivia": {
-                            "base": ""
-                        }
+                        "idlType": "long"
                     }
                 ],
                 "extAttrs": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "open": "",
-                    "close": "",
-                    "termination": ""
-                }
+                "readonly": false
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
@@ -50,45 +34,26 @@
                     {
                         "type": null,
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "short",
-                        "trivia": {
-                            "base": ""
-                        }
+                        "idlType": "short"
                     },
                     {
                         "type": null,
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": true,
                         "union": false,
-                        "idlType": "double",
-                        "trivia": {
-                            "base": " "
-                        }
+                        "idlType": "double"
                     }
                 ],
                 "extAttrs": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "open": "",
-                    "close": "",
-                    "termination": ""
-                }
+                "readonly": false
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
@@ -106,45 +71,22 @@
                                     "type": "extended-attribute",
                                     "name": "XAttr",
                                     "rhs": null,
-                                    "signature": null,
-                                    "trivia": {
-                                        "name": ""
-                                    }
+                                    "arguments": []
                                 }
-                            ],
-                            "trivia": {
-                                "open": "",
-                                "close": ""
-                            }
+                            ]
                         },
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "long",
-                        "trivia": {
-                            "base": " "
-                        }
+                        "idlType": "long"
                     }
                 ],
                 "extAttrs": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "open": "",
-                    "close": "",
-                    "termination": ""
-                }
+                "readonly": false
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/maplike.json
+++ b/test/syntax/baseline/maplike.json
@@ -10,45 +10,26 @@
                     {
                         "type": null,
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "long",
-                        "trivia": {
-                            "base": ""
-                        }
+                        "idlType": "long"
                     },
                     {
                         "type": null,
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "float",
-                        "trivia": {
-                            "base": " "
-                        }
+                        "idlType": "float"
                     }
                 ],
                 "extAttrs": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "open": "",
-                    "close": "",
-                    "termination": ""
-                }
+                "readonly": false
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
@@ -61,45 +42,26 @@
                     {
                         "type": null,
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "long",
-                        "trivia": {
-                            "base": ""
-                        }
+                        "idlType": "long"
                     },
                     {
                         "type": null,
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "float",
-                        "trivia": {
-                            "base": " "
-                        }
+                        "idlType": "float"
                     }
                 ],
                 "extAttrs": null,
-                "readonly": true,
-                "trivia": {
-                    "base": " ",
-                    "open": "",
-                    "close": "",
-                    "termination": ""
-                }
+                "readonly": true
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
@@ -117,24 +79,14 @@
                                     "type": "extended-attribute",
                                     "name": "XAttr2",
                                     "rhs": null,
-                                    "signature": null,
-                                    "trivia": {
-                                        "name": ""
-                                    }
+                                    "arguments": []
                                 }
-                            ],
-                            "trivia": {
-                                "open": "",
-                                "close": ""
-                            }
+                            ]
                         },
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "DOMString",
-                        "trivia": {
-                            "base": " "
-                        }
+                        "idlType": "DOMString"
                     },
                     {
                         "type": null,
@@ -144,45 +96,22 @@
                                     "type": "extended-attribute",
                                     "name": "XAttr3",
                                     "rhs": null,
-                                    "signature": null,
-                                    "trivia": {
-                                        "name": ""
-                                    }
+                                    "arguments": []
                                 }
-                            ],
-                            "trivia": {
-                                "open": " ",
-                                "close": ""
-                            }
+                            ]
                         },
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "long",
-                        "trivia": {
-                            "base": " "
-                        }
+                        "idlType": "long"
                     }
                 ],
                 "extAttrs": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n    ",
-                    "open": "",
-                    "close": "",
-                    "termination": ""
-                }
+                "readonly": false
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n// Extracted from https://heycam.github.io/webidl/#idl-type-extended-attribute-associated-with on 2017-07-01\n\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/mixin.json
+++ b/test/syntax/baseline/mixin.json
@@ -9,58 +9,30 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "Crypto",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "Crypto"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": true,
-                "trivia": {
-                    "base": " ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": true
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "// Extracted from https://heycam.github.io/webidl/#using-mixins-and-partials on 2017-11-02\n\n",
-            "mixin": " ",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "includes",
         "extAttrs": null,
         "target": "Window",
-        "includes": "GlobalCrypto",
-        "trivia": {
-            "target": "\n\n",
-            "includes": " ",
-            "mixin": " ",
-            "termination": ""
-        }
+        "includes": "GlobalCrypto"
     },
     {
         "type": "includes",
         "extAttrs": null,
         "target": "WorkerGlobalScope",
-        "includes": "GlobalCrypto",
-        "trivia": {
-            "target": "\n",
-            "includes": " ",
-            "mixin": " ",
-            "termination": ""
-        }
+        "includes": "GlobalCrypto"
     },
     {
         "type": "interface mixin",
@@ -72,49 +44,25 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "Crypto",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "Crypto"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": true,
-                "trivia": {
-                    "base": " ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": true
             }
         ],
         "extAttrs": null,
-        "partial": true,
-        "trivia": {
-            "base": " ",
-            "mixin": " ",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": true
     },
     {
         "type": "interface mixin",
         "name": "LocalCrypto",
         "members": [],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n",
-            "mixin": " ",
-            "name": " ",
-            "open": " ",
-            "close": "",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/namedconstructor.json
+++ b/test/syntax/baseline/namedconstructor.json
@@ -3,11 +3,7 @@
         "type": "interface",
         "name": "HTMLAudioElement",
         "inheritance": {
-            "name": "HTMLMediaElement",
-            "trivia": {
-                "colon": " ",
-                "name": " "
-            }
+            "name": "HTMLMediaElement"
         },
         "members": [],
         "extAttrs": {
@@ -17,74 +13,37 @@
                     "name": "NamedConstructor",
                     "rhs": {
                         "type": "identifier",
-                        "value": "Audio",
-                        "trivia": {
-                            "assign": "",
-                            "value": ""
-                        }
+                        "value": "Audio"
                     },
-                    "signature": null,
-                    "trivia": {
-                        "name": ""
-                    }
+                    "arguments": []
                 },
                 {
                     "type": "extended-attribute",
                     "name": "NamedConstructor",
                     "rhs": {
                         "type": "identifier",
-                        "value": "Audio",
-                        "trivia": {
-                            "assign": "",
-                            "value": ""
-                        }
+                        "value": "Audio"
                     },
-                    "signature": {
-                        "arguments": [
-                            {
-                                "name": "src",
-                                "idlType": {
-                                    "type": "argument-type",
-                                    "extAttrs": null,
-                                    "generic": null,
-                                    "nullable": false,
-                                    "union": false,
-                                    "idlType": "DOMString",
-                                    "trivia": {
-                                        "base": ""
-                                    }
-                                },
-                                "default": null,
-                                "optional": false,
-                                "variadic": false,
-                                "trivia": {
-                                    "name": " "
-                                }
-                            }
-                        ],
-                        "trivia": {
-                            "open": "",
-                            "close": ""
+                    "arguments": [
+                        {
+                            "name": "src",
+                            "idlType": {
+                                "type": "argument-type",
+                                "extAttrs": null,
+                                "generic": "",
+                                "nullable": false,
+                                "union": false,
+                                "idlType": "DOMString"
+                            },
+                            "default": null,
+                            "optional": false,
+                            "variadic": false
                         }
-                    },
-                    "trivia": {
-                        "name": "\n "
-                    }
+                    ]
                 }
-            ],
-            "trivia": {
-                "open": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
-                "close": ""
-            }
+            ]
         },
-        "partial": false,
-        "trivia": {
-            "base": "\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n  // ...\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/namespace.json
+++ b/test/syntax/baseline/namespace.json
@@ -9,41 +9,27 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "Vector",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "Vector"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": true,
-                "trivia": {
-                    "base": " ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": true
             },
             {
                 "type": "operation",
                 "name": "dotProduct",
                 "body": {
-                    "name": {
-                        "value": "dotProduct",
-                        "trivia": " "
-                    },
+                    "name": "dotProduct",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "double",
-                        "trivia": {
-                            "base": "\n  "
-                        }
+                        "idlType": "double"
                     },
                     "arguments": [
                         {
@@ -51,71 +37,46 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "Vector",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "Vector"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         },
                         {
                             "name": "y",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "Vector",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "Vector"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             },
             {
                 "type": "operation",
                 "name": "crossProduct",
                 "body": {
-                    "name": {
-                        "value": "crossProduct",
-                        "trivia": " "
-                    },
+                    "name": "crossProduct",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "Vector",
-                        "trivia": {
-                            "base": "\n  "
-                        }
+                        "idlType": "Vector"
                     },
                     "arguments": [
                         {
@@ -123,91 +84,51 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "Vector",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "Vector"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         },
                         {
                             "name": "y",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "Vector",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "Vector"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "// Extracted from Web IDL editors draft March 27 2017\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "namespace",
         "name": "SomeNamespace",
         "members": [],
         "extAttrs": null,
-        "partial": true,
-        "trivia": {
-            "base": " ",
-            "name": " ",
-            "open": " ",
-            "close": "\n  /* namespace_members... */\n",
-            "termination": ""
-        }
+        "partial": true
     },
     {
         "type": "namespace",
         "name": "ScalarUtils",
         "members": [],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n",
-            "name": " ",
-            "open": " ",
-            "close": "",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/nointerfaceobject.json
+++ b/test/syntax/baseline/nointerfaceobject.json
@@ -8,20 +8,14 @@
                 "type": "operation",
                 "name": "lookupEntry",
                 "body": {
-                    "name": {
-                        "value": "lookupEntry",
-                        "trivia": " "
-                    },
+                    "name": "lookupEntry",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "any",
-                        "trivia": {
-                            "base": "\n  "
-                        }
+                        "idlType": "any"
                     },
                     "arguments": [
                         {
@@ -29,32 +23,19 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "unsigned long",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "unsigned long"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             }
         ],
         "extAttrs": {
@@ -63,25 +44,11 @@
                     "type": "extended-attribute",
                     "name": "NoInterfaceObject",
                     "rhs": null,
-                    "signature": null,
-                    "trivia": {
-                        "name": ""
-                    }
+                    "arguments": []
                 }
-            ],
-            "trivia": {
-                "open": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
-                "close": ""
-            }
+            ]
         },
-        "partial": false,
-        "trivia": {
-            "base": "\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/nullable.json
+++ b/test/syntax/baseline/nullable.json
@@ -10,33 +10,18 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": true,
                     "union": false,
-                    "idlType": "DOMString",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "DOMString"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": true,
-                "trivia": {
-                    "base": " ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": true
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "",
-            "name": " ",
-            "open": " ",
-            "close": "\n  // ...\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/nullableobjects.json
+++ b/test/syntax/baseline/nullableobjects.json
@@ -5,14 +5,7 @@
         "inheritance": null,
         "members": [],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "// Extracted from WebIDL spec 2011-05-23\n\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n  // ...\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
@@ -20,14 +13,7 @@
         "inheritance": null,
         "members": [],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n  // ...\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
@@ -38,20 +24,14 @@
                 "type": "operation",
                 "name": "f",
                 "body": {
-                    "name": {
-                        "value": "f",
-                        "trivia": " "
-                    },
+                    "name": "f",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": "\n  "
-                        }
+                        "idlType": "void"
                     },
                     "arguments": [
                         {
@@ -59,51 +39,32 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": true,
                                 "union": false,
-                                "idlType": "A",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "A"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             },
             {
                 "type": "operation",
                 "name": "f",
                 "body": {
-                    "name": {
-                        "value": "f",
-                        "trivia": " "
-                    },
+                    "name": "f",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": "\n  "
-                        }
+                        "idlType": "void"
                     },
                     "arguments": [
                         {
@@ -111,43 +72,23 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": true,
                                 "union": false,
-                                "idlType": "B",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "B"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/operation-optional-arg.json
+++ b/test/syntax/baseline/operation-optional-arg.json
@@ -8,20 +8,14 @@
                 "type": "operation",
                 "name": "createColor",
                 "body": {
-                    "name": {
-                        "value": "createColor",
-                        "trivia": " "
-                    },
+                    "name": "createColor",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "object",
-                        "trivia": {
-                            "base": "\n  "
-                        }
+                        "idlType": "object"
                     },
                     "arguments": [
                         {
@@ -29,110 +23,68 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "float",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "float"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         },
                         {
                             "name": "v2",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "float",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "float"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         },
                         {
                             "name": "v3",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "float",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "float"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         },
                         {
                             "name": "alpha",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "float",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "float"
                             },
                             "default": {
                                 "type": "number",
-                                "value": "3.5",
-                                "trivia": {
-                                    "assign": " ",
-                                    "value": " "
-                                }
+                                "value": "3.5"
                             },
                             "optional": true,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/overloading.json
+++ b/test/syntax/baseline/overloading.json
@@ -5,14 +5,7 @@
         "inheritance": null,
         "members": [],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n  // ...\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
@@ -20,14 +13,7 @@
         "inheritance": null,
         "members": [],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n  // ...\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
@@ -38,20 +24,14 @@
                 "type": "operation",
                 "name": "f",
                 "body": {
-                    "name": {
-                        "value": "f",
-                        "trivia": " "
-                    },
+                    "name": "f",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": "\n  "
-                        }
+                        "idlType": "void"
                     },
                     "arguments": [
                         {
@@ -59,51 +39,32 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "A",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "A"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             },
             {
                 "type": "operation",
                 "name": "f",
                 "body": {
-                    "name": {
-                        "value": "f",
-                        "trivia": " "
-                    },
+                    "name": "f",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": "\n  "
-                        }
+                        "idlType": "void"
                     },
                     "arguments": [
                         {
@@ -111,43 +72,23 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "B",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "B"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
@@ -158,20 +99,14 @@
                 "type": "operation",
                 "name": "f",
                 "body": {
-                    "name": {
-                        "value": "f",
-                        "trivia": " "
-                    },
+                    "name": "f",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": "\n  /* f1 */ "
-                        }
+                        "idlType": "void"
                     },
                     "arguments": [
                         {
@@ -179,51 +114,32 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "DOMString",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "DOMString"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             },
             {
                 "type": "operation",
                 "name": "f",
                 "body": {
-                    "name": {
-                        "value": "f",
-                        "trivia": " "
-                    },
+                    "name": "f",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": "\n  /* f2 */ "
-                        }
+                        "idlType": "void"
                     },
                     "arguments": [
                         {
@@ -236,133 +152,82 @@
                                             "type": "extended-attribute",
                                             "name": "AllowAny",
                                             "rhs": null,
-                                            "signature": null,
-                                            "trivia": {
-                                                "name": ""
-                                            }
+                                            "arguments": []
                                         }
-                                    ],
-                                    "trivia": {
-                                        "open": "",
-                                        "close": ""
-                                    }
+                                    ]
                                 },
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "DOMString",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "DOMString"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         },
                         {
                             "name": "b",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "DOMString",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "DOMString"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         },
                         {
                             "name": "c",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "float",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "float"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": true,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": true
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             },
             {
                 "type": "operation",
                 "name": "f",
                 "body": {
-                    "name": {
-                        "value": "f",
-                        "trivia": " "
-                    },
+                    "name": "f",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": "\n  /* f3 */ "
-                        }
+                        "idlType": "void"
                     },
-                    "arguments": [],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    "arguments": []
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             },
             {
                 "type": "operation",
                 "name": "f",
                 "body": {
-                    "name": {
-                        "value": "f",
-                        "trivia": " "
-                    },
+                    "name": "f",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": "\n  /* f4 */ "
-                        }
+                        "idlType": "void"
                     },
                     "arguments": [
                         {
@@ -370,103 +235,65 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "long",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "long"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         },
                         {
                             "name": "b",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "DOMString",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "DOMString"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         },
                         {
                             "name": "c",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "DOMString",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "DOMString"
                             },
                             "default": null,
                             "optional": true,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         },
                         {
                             "name": "d",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "float",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "float"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": true,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": true
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/overridebuiltins.json
+++ b/test/syntax/baseline/overridebuiltins.json
@@ -10,41 +10,27 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned long",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "unsigned long"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": true,
-                "trivia": {
-                    "base": " ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": true
             },
             {
                 "type": "operation",
                 "name": "lookup",
                 "body": {
-                    "name": {
-                        "value": "lookup",
-                        "trivia": " "
-                    },
+                    "name": "lookup",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "DOMString",
-                        "trivia": {
-                            "base": " "
-                        }
+                        "idlType": "DOMString"
                     },
                     "arguments": [
                         {
@@ -52,32 +38,19 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "DOMString",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "DOMString"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": "getter",
-                "trivia": {
-                    "termination": ""
-                }
+                "special": "getter"
             }
         ],
         "extAttrs": {
@@ -86,25 +59,11 @@
                     "type": "extended-attribute",
                     "name": "OverrideBuiltins",
                     "rhs": null,
-                    "signature": null,
-                    "trivia": {
-                        "name": ""
-                    }
+                    "arguments": []
                 }
-            ],
-            "trivia": {
-                "open": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
-                "close": ""
-            }
+            ]
         },
-        "partial": false,
-        "trivia": {
-            "base": "\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/partial-interface.json
+++ b/test/syntax/baseline/partial-interface.json
@@ -10,33 +10,18 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "DOMString"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
@@ -48,33 +33,18 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "DOMString"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             }
         ],
         "extAttrs": null,
-        "partial": true,
-        "trivia": {
-            "base": " ",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": true
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/primitives.json
+++ b/test/syntax/baseline/primitives.json
@@ -10,22 +10,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "boolean",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "boolean"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -33,22 +25,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "byte",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "byte"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -56,22 +40,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "octet",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "octet"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -79,22 +55,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "short",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "short"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -102,22 +70,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned short",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "unsigned short"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -125,22 +85,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "long",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "long"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -148,22 +100,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned long",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "unsigned long"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -171,22 +115,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "long long",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "long long"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -194,22 +130,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned long long",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "unsigned long long"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -217,22 +145,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "float",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "float"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -240,22 +160,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "double",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "double"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -263,22 +175,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "unrestricted float",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "unrestricted float"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -286,22 +190,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "unrestricted double",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "unrestricted double"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -309,22 +205,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "DOMString"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -332,22 +220,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "ByteString",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "ByteString"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -355,22 +235,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "Date",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "Date"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -378,33 +250,18 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "RegExp",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "RegExp"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/promise-void.json
+++ b/test/syntax/baseline/promise-void.json
@@ -10,51 +10,27 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": {
-                        "value": "Promise",
-                        "trivia": {
-                            "open": "",
-                            "close": ""
-                        }
-                    },
+                    "generic": "Promise",
                     "nullable": false,
                     "union": false,
                     "idlType": [
                         {
                             "type": "return-type",
                             "extAttrs": null,
-                            "generic": null,
+                            "generic": "",
                             "nullable": false,
                             "union": false,
-                            "idlType": "void",
-                            "trivia": {
-                                "base": ""
-                            }
+                            "idlType": "void"
                         }
-                    ],
-                    "trivia": {
-                        "base": " "
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n    ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/prototyperoot.json
+++ b/test/syntax/baseline/prototyperoot.json
@@ -10,22 +10,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned short",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "unsigned short"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": true,
-                "trivia": {
-                    "base": " ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": true
             }
         ],
         "extAttrs": {
@@ -34,25 +26,11 @@
                     "type": "extended-attribute",
                     "name": "PrototypeRoot",
                     "rhs": null,
-                    "signature": null,
-                    "trivia": {
-                        "name": ""
-                    }
+                    "arguments": []
                 }
-            ],
-            "trivia": {
-                "open": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
-                "close": ""
-            }
+            ]
         },
-        "partial": false,
-        "trivia": {
-            "base": "\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/putforwards.json
+++ b/test/syntax/baseline/putforwards.json
@@ -10,13 +10,10 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "Name",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "Name"
                 },
                 "extAttrs": {
                     "items": [
@@ -25,30 +22,14 @@
                             "name": "PutForwards",
                             "rhs": {
                                 "type": "identifier",
-                                "value": "full",
-                                "trivia": {
-                                    "assign": "",
-                                    "value": ""
-                                }
+                                "value": "full"
                             },
-                            "signature": null,
-                            "trivia": {
-                                "name": ""
-                            }
+                            "arguments": []
                         }
-                    ],
-                    "trivia": {
-                        "open": "\n  ",
-                        "close": ""
-                    }
+                    ]
                 },
-                "special": null,
-                "readonly": true,
-                "trivia": {
-                    "base": " ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": true
             },
             {
                 "type": "attribute",
@@ -56,33 +37,18 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned short",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "unsigned short"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/record.json
+++ b/test/syntax/baseline/record.json
@@ -8,20 +8,14 @@
                 "type": "operation",
                 "name": "foo",
                 "body": {
-                    "name": {
-                        "value": "foo",
-                        "trivia": " "
-                    },
+                    "name": "foo",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": "\n  "
-                        }
+                        "idlType": "void"
                     },
                     "arguments": [
                         {
@@ -29,163 +23,97 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": {
-                                    "value": "sequence",
-                                    "trivia": {
-                                        "open": "",
-                                        "close": ""
-                                    }
-                                },
+                                "generic": "sequence",
                                 "nullable": false,
                                 "union": false,
                                 "idlType": [
                                     {
                                         "type": "argument-type",
                                         "extAttrs": null,
-                                        "generic": {
-                                            "value": "record",
-                                            "trivia": {
-                                                "open": "",
-                                                "close": ""
-                                            }
-                                        },
+                                        "generic": "record",
                                         "nullable": false,
                                         "union": false,
                                         "idlType": [
                                             {
                                                 "type": "argument-type",
                                                 "extAttrs": null,
-                                                "generic": null,
+                                                "generic": "",
                                                 "nullable": false,
                                                 "union": false,
-                                                "idlType": "ByteString",
-                                                "trivia": {
-                                                    "base": ""
-                                                }
+                                                "idlType": "ByteString"
                                             },
                                             {
                                                 "type": "argument-type",
                                                 "extAttrs": null,
-                                                "generic": null,
+                                                "generic": "",
                                                 "nullable": false,
                                                 "union": false,
-                                                "idlType": "any",
-                                                "trivia": {
-                                                    "base": " "
-                                                }
+                                                "idlType": "any"
                                             }
-                                        ],
-                                        "trivia": {
-                                            "base": ""
-                                        }
+                                        ]
                                     }
-                                ],
-                                "trivia": {
-                                    "base": ""
-                                }
+                                ]
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             },
             {
                 "type": "operation",
                 "name": "bar",
                 "body": {
-                    "name": {
-                        "value": "bar",
-                        "trivia": " "
-                    },
+                    "name": "bar",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": {
-                            "value": "record",
-                            "trivia": {
-                                "open": "",
-                                "close": ""
-                            }
-                        },
+                        "generic": "record",
                         "nullable": false,
                         "union": false,
                         "idlType": [
                             {
                                 "type": "return-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "DOMString",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "DOMString"
                             },
                             {
                                 "type": "return-type",
                                 "extAttrs": null,
                                 "union": true,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": true,
                                 "idlType": [
                                     {
                                         "type": null,
                                         "extAttrs": null,
-                                        "generic": null,
+                                        "generic": "",
                                         "nullable": false,
                                         "union": false,
-                                        "idlType": "float",
-                                        "trivia": {
-                                            "base": ""
-                                        }
+                                        "idlType": "float"
                                     },
                                     {
                                         "type": null,
                                         "extAttrs": null,
-                                        "generic": null,
+                                        "generic": "",
                                         "nullable": false,
                                         "union": false,
-                                        "idlType": "DOMString",
-                                        "trivia": {
-                                            "base": " "
-                                        }
+                                        "idlType": "DOMString"
                                     }
-                                ],
-                                "trivia": {
-                                    "open": " ",
-                                    "close": ""
-                                }
+                                ]
                             }
-                        ],
-                        "trivia": {
-                            "base": "\n  "
-                        }
+                        ]
                     },
-                    "arguments": [],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    "arguments": []
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             }
         ],
         "extAttrs": {
@@ -194,81 +122,43 @@
                     "type": "extended-attribute",
                     "name": "Constructor",
                     "rhs": null,
-                    "signature": {
-                        "arguments": [
-                            {
-                                "name": "init",
-                                "idlType": {
-                                    "type": "argument-type",
-                                    "extAttrs": null,
-                                    "generic": {
-                                        "value": "record",
-                                        "trivia": {
-                                            "open": "",
-                                            "close": ""
-                                        }
+                    "arguments": [
+                        {
+                            "name": "init",
+                            "idlType": {
+                                "type": "argument-type",
+                                "extAttrs": null,
+                                "generic": "record",
+                                "nullable": false,
+                                "union": false,
+                                "idlType": [
+                                    {
+                                        "type": "argument-type",
+                                        "extAttrs": null,
+                                        "generic": "",
+                                        "nullable": false,
+                                        "union": false,
+                                        "idlType": "USVString"
                                     },
-                                    "nullable": false,
-                                    "union": false,
-                                    "idlType": [
-                                        {
-                                            "type": "argument-type",
-                                            "extAttrs": null,
-                                            "generic": null,
-                                            "nullable": false,
-                                            "union": false,
-                                            "idlType": "USVString",
-                                            "trivia": {
-                                                "base": ""
-                                            }
-                                        },
-                                        {
-                                            "type": "argument-type",
-                                            "extAttrs": null,
-                                            "generic": null,
-                                            "nullable": false,
-                                            "union": false,
-                                            "idlType": "USVString",
-                                            "trivia": {
-                                                "base": " "
-                                            }
-                                        }
-                                    ],
-                                    "trivia": {
-                                        "base": ""
+                                    {
+                                        "type": "argument-type",
+                                        "extAttrs": null,
+                                        "generic": "",
+                                        "nullable": false,
+                                        "union": false,
+                                        "idlType": "USVString"
                                     }
-                                },
-                                "default": null,
-                                "optional": false,
-                                "variadic": false,
-                                "trivia": {
-                                    "name": " "
-                                }
-                            }
-                        ],
-                        "trivia": {
-                            "open": "",
-                            "close": ""
+                                ]
+                            },
+                            "default": null,
+                            "optional": false,
+                            "variadic": false
                         }
-                    },
-                    "trivia": {
-                        "name": ""
-                    }
+                    ]
                 }
-            ],
-            "trivia": {
-                "open": "",
-                "close": ""
-            }
+            ]
         },
-        "partial": false,
-        "trivia": {
-            "base": "\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
@@ -279,33 +169,21 @@
                 "type": "operation",
                 "name": "bar",
                 "body": {
-                    "name": {
-                        "value": "bar",
-                        "trivia": " "
-                    },
+                    "name": "bar",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": {
-                            "value": "record",
-                            "trivia": {
-                                "open": "",
-                                "close": ""
-                            }
-                        },
+                        "generic": "record",
                         "nullable": false,
                         "union": false,
                         "idlType": [
                             {
                                 "type": "return-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "DOMString",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "DOMString"
                             },
                             {
                                 "type": "return-type",
@@ -315,52 +193,25 @@
                                             "type": "extended-attribute",
                                             "name": "XAttr",
                                             "rhs": null,
-                                            "signature": null,
-                                            "trivia": {
-                                                "name": ""
-                                            }
+                                            "arguments": []
                                         }
-                                    ],
-                                    "trivia": {
-                                        "open": " ",
-                                        "close": ""
-                                    }
+                                    ]
                                 },
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "float",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "float"
                             }
-                        ],
-                        "trivia": {
-                            "base": "\n  "
-                        }
+                        ]
                     },
-                    "arguments": [],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    "arguments": []
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/reg-operations.json
+++ b/test/syntax/baseline/reg-operations.json
@@ -10,22 +10,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned long",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "unsigned long"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -33,33 +25,18 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned long",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "unsigned long"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
@@ -70,51 +47,32 @@
                 "type": "operation",
                 "name": "isMouseOver",
                 "body": {
-                    "name": {
-                        "value": "isMouseOver",
-                        "trivia": " "
-                    },
+                    "name": "isMouseOver",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "boolean",
-                        "trivia": {
-                            "base": "\n\n  // An operation that takes no arguments, returns a boolean\n  "
-                        }
+                        "idlType": "boolean"
                     },
-                    "arguments": [],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    "arguments": []
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             },
             {
                 "type": "operation",
                 "name": "setDimensions",
                 "body": {
-                    "name": {
-                        "value": "setDimensions",
-                        "trivia": " "
-                    },
+                    "name": "setDimensions",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": "\n\n  // Overloaded operations.\n  "
-                        }
+                        "idlType": "void"
                     },
                     "arguments": [
                         {
@@ -122,51 +80,32 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "Dimensions",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "Dimensions"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             },
             {
                 "type": "operation",
                 "name": "setDimensions",
                 "body": {
-                    "name": {
-                        "value": "setDimensions",
-                        "trivia": " "
-                    },
+                    "name": "setDimensions",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": "\n  "
-                        }
+                        "idlType": "void"
                     },
                     "arguments": [
                         {
@@ -174,63 +113,37 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "unsigned long",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "unsigned long"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         },
                         {
                             "name": "height",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "unsigned long",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "unsigned long"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/replaceable.json
+++ b/test/syntax/baseline/replaceable.json
@@ -10,13 +10,10 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned long",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "unsigned long"
                 },
                 "extAttrs": {
                     "items": [
@@ -24,66 +21,34 @@
                             "type": "extended-attribute",
                             "name": "Replaceable",
                             "rhs": null,
-                            "signature": null,
-                            "trivia": {
-                                "name": ""
-                            }
+                            "arguments": []
                         }
-                    ],
-                    "trivia": {
-                        "open": "\n  ",
-                        "close": ""
-                    }
+                    ]
                 },
-                "special": null,
-                "readonly": true,
-                "trivia": {
-                    "base": " ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": true
             },
             {
                 "type": "operation",
                 "name": "increment",
                 "body": {
-                    "name": {
-                        "value": "increment",
-                        "trivia": " "
-                    },
+                    "name": "increment",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": "\n  "
-                        }
+                        "idlType": "void"
                     },
-                    "arguments": [],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    "arguments": []
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/sequence.json
+++ b/test/syntax/baseline/sequence.json
@@ -8,20 +8,14 @@
                 "type": "operation",
                 "name": "drawPolygon",
                 "body": {
-                    "name": {
-                        "value": "drawPolygon",
-                        "trivia": " "
-                    },
+                    "name": "drawPolygon",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": "\n  "
-                        }
+                        "idlType": "void"
                     },
                     "arguments": [
                         {
@@ -29,110 +23,59 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": {
-                                    "value": "sequence",
-                                    "trivia": {
-                                        "open": "",
-                                        "close": ""
-                                    }
-                                },
+                                "generic": "sequence",
                                 "nullable": false,
                                 "union": false,
                                 "idlType": [
                                     {
                                         "type": "argument-type",
                                         "extAttrs": null,
-                                        "generic": null,
+                                        "generic": "",
                                         "nullable": false,
                                         "union": false,
-                                        "idlType": "float",
-                                        "trivia": {
-                                            "base": ""
-                                        }
+                                        "idlType": "float"
                                     }
-                                ],
-                                "trivia": {
-                                    "base": ""
-                                }
+                                ]
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             },
             {
                 "type": "operation",
                 "name": "getInflectionPoints",
                 "body": {
-                    "name": {
-                        "value": "getInflectionPoints",
-                        "trivia": " "
-                    },
+                    "name": "getInflectionPoints",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": {
-                            "value": "sequence",
-                            "trivia": {
-                                "open": "",
-                                "close": ""
-                            }
-                        },
+                        "generic": "sequence",
                         "nullable": false,
                         "union": false,
                         "idlType": [
                             {
                                 "type": "return-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "float",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "float"
                             }
-                        ],
-                        "trivia": {
-                            "base": "\n  "
-                        }
+                        ]
                     },
-                    "arguments": [],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    "arguments": []
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n// edited to remove sequence as attributes, now invalid\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n  // ...\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
@@ -143,20 +86,14 @@
                 "type": "operation",
                 "name": "f1",
                 "body": {
-                    "name": {
-                        "value": "f1",
-                        "trivia": " "
-                    },
+                    "name": "f1",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": "\n    "
-                        }
+                        "idlType": "void"
                     },
                     "arguments": [
                         {
@@ -164,13 +101,7 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": {
-                                    "value": "sequence",
-                                    "trivia": {
-                                        "open": "",
-                                        "close": ""
-                                    }
-                                },
+                                "generic": "sequence",
                                 "nullable": false,
                                 "union": false,
                                 "idlType": [
@@ -182,59 +113,29 @@
                                                     "type": "extended-attribute",
                                                     "name": "XAttr",
                                                     "rhs": null,
-                                                    "signature": null,
-                                                    "trivia": {
-                                                        "name": ""
-                                                    }
+                                                    "arguments": []
                                                 }
-                                            ],
-                                            "trivia": {
-                                                "open": "",
-                                                "close": ""
-                                            }
+                                            ]
                                         },
-                                        "generic": null,
+                                        "generic": "",
                                         "nullable": false,
                                         "union": false,
-                                        "idlType": "long",
-                                        "trivia": {
-                                            "base": " "
-                                        }
+                                        "idlType": "long"
                                     }
-                                ],
-                                "trivia": {
-                                    "base": ""
-                                }
+                                ]
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n// Extracted from https://heycam.github.io/webidl/#idl-type-extended-attribute-associated-with on 2017-07-01\n\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/setlike.json
+++ b/test/syntax/baseline/setlike.json
@@ -10,34 +10,18 @@
                     {
                         "type": null,
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "long",
-                        "trivia": {
-                            "base": ""
-                        }
+                        "idlType": "long"
                     }
                 ],
                 "extAttrs": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "open": "",
-                    "close": "",
-                    "termination": ""
-                }
+                "readonly": false
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
@@ -50,34 +34,18 @@
                     {
                         "type": null,
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "long",
-                        "trivia": {
-                            "base": ""
-                        }
+                        "idlType": "long"
                     }
                 ],
                 "extAttrs": null,
-                "readonly": true,
-                "trivia": {
-                    "base": " ",
-                    "open": "",
-                    "close": "",
-                    "termination": ""
-                }
+                "readonly": true
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
@@ -95,45 +63,22 @@
                                     "type": "extended-attribute",
                                     "name": "XAttr",
                                     "rhs": null,
-                                    "signature": null,
-                                    "trivia": {
-                                        "name": ""
-                                    }
+                                    "arguments": []
                                 }
-                            ],
-                            "trivia": {
-                                "open": "",
-                                "close": ""
-                            }
+                            ]
                         },
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "long",
-                        "trivia": {
-                            "base": " "
-                        }
+                        "idlType": "long"
                     }
                 ],
                 "extAttrs": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "open": "",
-                    "close": "",
-                    "termination": ""
-                }
+                "readonly": false
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/static.json
+++ b/test/syntax/baseline/static.json
@@ -5,14 +5,7 @@
         "inheritance": null,
         "members": [],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
-            "name": " ",
-            "open": " ",
-            "close": " /* ... */ ",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
@@ -25,22 +18,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "float",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "float"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -48,22 +33,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "float",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "float"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -71,22 +48,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "float",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "float"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -94,41 +63,27 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "long",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "long"
                 },
                 "extAttrs": null,
                 "special": "static",
-                "readonly": true,
-                "trivia": {
-                    "base": " ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "readonly": true
             },
             {
                 "type": "operation",
                 "name": "triangulate",
                 "body": {
-                    "name": {
-                        "value": "triangulate",
-                        "trivia": " "
-                    },
+                    "name": "triangulate",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "Point",
-                        "trivia": {
-                            "base": " "
-                        }
+                        "idlType": "Point"
                     },
                     "arguments": [
                         {
@@ -136,83 +91,51 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "Circle",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "Circle"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         },
                         {
                             "name": "c2",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "Circle",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "Circle"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         },
                         {
                             "name": "c3",
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "Circle",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "Circle"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": "static",
-                "trivia": {
-                    "termination": ""
-                }
+                "special": "static"
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/stringifier-attribute.json
+++ b/test/syntax/baseline/stringifier-attribute.json
@@ -10,22 +10,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned long",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "unsigned long"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -33,22 +25,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "DOMString"
                 },
                 "extAttrs": null,
                 "special": "stringifier",
-                "readonly": false,
-                "trivia": {
-                    "base": " ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "readonly": false
             }
         ],
         "extAttrs": {
@@ -57,25 +41,11 @@
                     "type": "extended-attribute",
                     "name": "Constructor",
                     "rhs": null,
-                    "signature": null,
-                    "trivia": {
-                        "name": ""
-                    }
+                    "arguments": []
                 }
-            ],
-            "trivia": {
-                "open": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
-                "close": ""
-            }
+            ]
         },
-        "partial": false,
-        "trivia": {
-            "base": "\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/stringifier-custom.json
+++ b/test/syntax/baseline/stringifier-custom.json
@@ -10,22 +10,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned long",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "unsigned long"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -33,22 +25,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": true,
                     "union": false,
-                    "idlType": "DOMString",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "DOMString"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -56,50 +40,32 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "DOMString"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "operation",
                 "name": "",
                 "body": {
-                    "name": null,
+                    "name": "",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "DOMString",
-                        "trivia": {
-                            "base": " "
-                        }
+                        "idlType": "DOMString"
                     },
-                    "arguments": [],
-                    "trivia": {
-                        "open": " ",
-                        "close": ""
-                    }
+                    "arguments": []
                 },
                 "extAttrs": null,
-                "special": "stringifier",
-                "trivia": {
-                    "termination": ""
-                }
+                "special": "stringifier"
             }
         ],
         "extAttrs": {
@@ -108,25 +74,11 @@
                     "type": "extended-attribute",
                     "name": "Constructor",
                     "rhs": null,
-                    "signature": null,
-                    "trivia": {
-                        "name": ""
-                    }
+                    "arguments": []
                 }
-            ],
-            "trivia": {
-                "open": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
-                "close": ""
-            }
+            ]
         },
-        "partial": false,
-        "trivia": {
-            "base": "\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/stringifier.json
+++ b/test/syntax/baseline/stringifier.json
@@ -8,40 +8,23 @@
                 "type": "operation",
                 "name": "",
                 "body": {
-                    "name": null,
+                    "name": "",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "DOMString",
-                        "trivia": {
-                            "base": " "
-                        }
+                        "idlType": "DOMString"
                     },
-                    "arguments": [],
-                    "trivia": {
-                        "open": " ",
-                        "close": ""
-                    }
+                    "arguments": []
                 },
                 "extAttrs": null,
-                "special": "stringifier",
-                "trivia": {
-                    "termination": ""
-                }
+                "special": "stringifier"
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
@@ -53,21 +36,11 @@
                 "name": "",
                 "body": null,
                 "extAttrs": null,
-                "special": "stringifier",
-                "trivia": {
-                    "termination": ""
-                }
+                "special": "stringifier"
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/treatasnull.json
+++ b/test/syntax/baseline/treatasnull.json
@@ -10,22 +10,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "DOMString"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -33,41 +25,27 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "DOMString"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "operation",
                 "name": "isMemberOfBreed",
                 "body": {
-                    "name": {
-                        "value": "isMemberOfBreed",
-                        "trivia": " "
-                    },
+                    "name": "isMemberOfBreed",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "boolean",
-                        "trivia": {
-                            "base": "\n\n  "
-                        }
+                        "idlType": "boolean"
                     },
                     "arguments": [
                         {
@@ -81,60 +59,29 @@
                                             "name": "TreatNullAs",
                                             "rhs": {
                                                 "type": "identifier",
-                                                "value": "EmptyString",
-                                                "trivia": {
-                                                    "assign": "",
-                                                    "value": ""
-                                                }
+                                                "value": "EmptyString"
                                             },
-                                            "signature": null,
-                                            "trivia": {
-                                                "name": ""
-                                            }
+                                            "arguments": []
                                         }
-                                    ],
-                                    "trivia": {
-                                        "open": "",
-                                        "close": ""
-                                    }
+                                    ]
                                 },
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "DOMString",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "DOMString"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/treatasundefined.json
+++ b/test/syntax/baseline/treatasundefined.json
@@ -10,22 +10,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "DOMString"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -33,41 +25,27 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "DOMString",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "DOMString"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n  ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "operation",
                 "name": "isMemberOfBreed",
                 "body": {
-                    "name": {
-                        "value": "isMemberOfBreed",
-                        "trivia": " "
-                    },
+                    "name": "isMemberOfBreed",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "boolean",
-                        "trivia": {
-                            "base": "\n\n  "
-                        }
+                        "idlType": "boolean"
                     },
                     "arguments": [
                         {
@@ -81,60 +59,29 @@
                                             "name": "TreatUndefinedAs",
                                             "rhs": {
                                                 "type": "identifier",
-                                                "value": "EmptyString",
-                                                "trivia": {
-                                                    "assign": "",
-                                                    "value": ""
-                                                }
+                                                "value": "EmptyString"
                                             },
-                                            "signature": null,
-                                            "trivia": {
-                                                "name": ""
-                                            }
+                                            "arguments": []
                                         }
-                                    ],
-                                    "trivia": {
-                                        "open": "",
-                                        "close": ""
-                                    }
+                                    ]
                                 },
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "DOMString",
-                                "trivia": {
-                                    "base": " "
-                                }
+                                "idlType": "DOMString"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/typedef-union.json
+++ b/test/syntax/baseline/typedef-union.json
@@ -6,65 +6,44 @@
             "type": "typedef-type",
             "extAttrs": null,
             "union": true,
-            "generic": null,
+            "generic": "",
             "nullable": false,
             "idlType": [
                 {
                     "type": null,
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "ImageData",
-                    "trivia": {
-                        "base": ""
-                    }
+                    "idlType": "ImageData"
                 },
                 {
                     "type": null,
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "HTMLImageElement",
-                    "trivia": {
-                        "base": "\n           "
-                    }
+                    "idlType": "HTMLImageElement"
                 },
                 {
                     "type": null,
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "HTMLCanvasElement",
-                    "trivia": {
-                        "base": "\n           "
-                    }
+                    "idlType": "HTMLCanvasElement"
                 },
                 {
                     "type": null,
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "HTMLVideoElement",
-                    "trivia": {
-                        "base": "\n           "
-                    }
+                    "idlType": "HTMLVideoElement"
                 }
-            ],
-            "trivia": {
-                "open": " ",
-                "close": ""
-            }
+            ]
         },
-        "extAttrs": null,
-        "trivia": {
-            "base": "  ",
-            "name": " ",
-            "termination": ""
-        }
+        "extAttrs": null
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/typedef.json
+++ b/test/syntax/baseline/typedef.json
@@ -10,22 +10,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "float",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "float"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n        ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -33,33 +25,18 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "float",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "float"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n        ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n      ",
-            "name": " ",
-            "open": " ",
-            "close": "\n      ",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "typedef",
@@ -67,38 +44,21 @@
         "idlType": {
             "type": "typedef-type",
             "extAttrs": null,
-            "generic": {
-                "value": "sequence",
-                "trivia": {
-                    "open": "",
-                    "close": ""
-                }
-            },
+            "generic": "sequence",
             "nullable": false,
             "union": false,
             "idlType": [
                 {
                     "type": "typedef-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "Point",
-                    "trivia": {
-                        "base": ""
-                    }
+                    "idlType": "Point"
                 }
-            ],
-            "trivia": {
-                "base": " "
-            }
+            ]
         },
-        "extAttrs": null,
-        "trivia": {
-            "base": "\n\n      ",
-            "name": " ",
-            "termination": ""
-        }
+        "extAttrs": null
     },
     {
         "type": "interface",
@@ -111,22 +71,14 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "Point",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "Point"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n        ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -134,33 +86,18 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "Point",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "Point"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n        ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n      ",
-            "name": " ",
-            "open": " ",
-            "close": "\n      ",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "interface",
@@ -173,41 +110,27 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "Rect",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "Rect"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": true,
-                "trivia": {
-                    "base": " ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": true
             },
             {
                 "type": "operation",
                 "name": "pointWithinBounds",
                 "body": {
-                    "name": {
-                        "value": "pointWithinBounds",
-                        "trivia": " "
-                    },
+                    "name": "pointWithinBounds",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "boolean",
-                        "trivia": {
-                            "base": "\n\n    "
-                        }
+                        "idlType": "boolean"
                     },
                     "arguments": [
                         {
@@ -215,51 +138,32 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "Point",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "Point"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             },
             {
                 "type": "operation",
                 "name": "allPointsWithinBounds",
                 "body": {
-                    "name": {
-                        "value": "allPointsWithinBounds",
-                        "trivia": " "
-                    },
+                    "name": "allPointsWithinBounds",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "boolean",
-                        "trivia": {
-                            "base": "\n    "
-                        }
+                        "idlType": "boolean"
                     },
                     "arguments": [
                         {
@@ -267,43 +171,23 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "PointSequence",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "PointSequence"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "\n\n  ",
-            "name": " ",
-            "open": " ",
-            "close": "\n  ",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "typedef",
@@ -316,31 +200,16 @@
                         "type": "extended-attribute",
                         "name": "Clamp",
                         "rhs": null,
-                        "signature": null,
-                        "trivia": {
-                            "name": ""
-                        }
+                        "arguments": []
                     }
-                ],
-                "trivia": {
-                    "open": " ",
-                    "close": ""
-                }
+                ]
             },
-            "generic": null,
+            "generic": "",
             "nullable": false,
             "union": false,
-            "idlType": "octet",
-            "trivia": {
-                "base": " "
-            }
+            "idlType": "octet"
         },
-        "extAttrs": null,
-        "trivia": {
-            "base": "\n\n  ",
-            "name": " ",
-            "termination": ""
-        }
+        "extAttrs": null
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/typesuffixes.json
+++ b/test/syntax/baseline/typesuffixes.json
@@ -8,20 +8,14 @@
                 "type": "operation",
                 "name": "test",
                 "body": {
-                    "name": {
-                        "value": "test",
-                        "trivia": " "
-                    },
+                    "name": "test",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": "\n  "
-                        }
+                        "idlType": "void"
                     },
                     "arguments": [
                         {
@@ -29,61 +23,32 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": {
-                                    "value": "sequence",
-                                    "trivia": {
-                                        "open": "",
-                                        "close": ""
-                                    }
-                                },
+                                "generic": "sequence",
                                 "nullable": true,
                                 "union": false,
                                 "idlType": [
                                     {
                                         "type": "argument-type",
                                         "extAttrs": null,
-                                        "generic": null,
+                                        "generic": "",
                                         "nullable": true,
                                         "union": false,
-                                        "idlType": "DOMString",
-                                        "trivia": {
-                                            "base": ""
-                                        }
+                                        "idlType": "DOMString"
                                     }
-                                ],
-                                "trivia": {
-                                    "base": ""
-                                }
+                                ]
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": false,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": false
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/uniontype.json
+++ b/test/syntax/baseline/uniontype.json
@@ -11,104 +11,72 @@
                     "type": "attribute-type",
                     "extAttrs": null,
                     "union": true,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "idlType": [
                         {
                             "type": null,
                             "extAttrs": null,
-                            "generic": null,
+                            "generic": "",
                             "nullable": false,
                             "union": false,
-                            "idlType": "float",
-                            "trivia": {
-                                "base": ""
-                            }
+                            "idlType": "float"
                         },
                         {
                             "type": null,
                             "extAttrs": null,
                             "union": true,
-                            "generic": null,
+                            "generic": "",
                             "nullable": false,
                             "idlType": [
                                 {
                                     "type": null,
                                     "extAttrs": null,
-                                    "generic": null,
+                                    "generic": "",
                                     "nullable": false,
                                     "union": false,
-                                    "idlType": "Date",
-                                    "trivia": {
-                                        "base": ""
-                                    }
+                                    "idlType": "Date"
                                 },
                                 {
                                     "type": null,
                                     "extAttrs": null,
-                                    "generic": null,
+                                    "generic": "",
                                     "nullable": false,
                                     "union": false,
-                                    "idlType": "Event",
-                                    "trivia": {
-                                        "base": " "
-                                    }
+                                    "idlType": "Event"
                                 }
-                            ],
-                            "trivia": {
-                                "open": " ",
-                                "close": ""
-                            }
+                            ]
                         },
                         {
                             "type": null,
                             "extAttrs": null,
                             "union": true,
-                            "generic": null,
+                            "generic": "",
                             "nullable": true,
                             "idlType": [
                                 {
                                     "type": null,
                                     "extAttrs": null,
-                                    "generic": null,
+                                    "generic": "",
                                     "nullable": false,
                                     "union": false,
-                                    "idlType": "Node",
-                                    "trivia": {
-                                        "base": ""
-                                    }
+                                    "idlType": "Node"
                                 },
                                 {
                                     "type": null,
                                     "extAttrs": null,
-                                    "generic": null,
+                                    "generic": "",
                                     "nullable": false,
                                     "union": false,
-                                    "idlType": "DOMString",
-                                    "trivia": {
-                                        "base": " "
-                                    }
+                                    "idlType": "DOMString"
                                 }
-                            ],
-                            "trivia": {
-                                "open": " ",
-                                "close": ""
-                            }
+                            ]
                         }
-                    ],
-                    "trivia": {
-                        "open": " ",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             },
             {
                 "type": "attribute",
@@ -117,7 +85,7 @@
                     "type": "attribute-type",
                     "extAttrs": null,
                     "union": true,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "idlType": [
                         {
@@ -128,61 +96,32 @@
                                         "type": "extended-attribute",
                                         "name": "EnforceRange",
                                         "rhs": null,
-                                        "signature": null,
-                                        "trivia": {
-                                            "name": ""
-                                        }
+                                        "arguments": []
                                     }
-                                ],
-                                "trivia": {
-                                    "open": "",
-                                    "close": ""
-                                }
+                                ]
                             },
-                            "generic": null,
+                            "generic": "",
                             "nullable": false,
                             "union": false,
-                            "idlType": "long",
-                            "trivia": {
-                                "base": " "
-                            }
+                            "idlType": "long"
                         },
                         {
                             "type": null,
                             "extAttrs": null,
-                            "generic": null,
+                            "generic": "",
                             "nullable": false,
                             "union": false,
-                            "idlType": "Date",
-                            "trivia": {
-                                "base": " "
-                            }
+                            "idlType": "Date"
                         }
-                    ],
-                    "trivia": {
-                        "open": " ",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": false,
-                "trivia": {
-                    "base": "\n ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": false
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",

--- a/test/syntax/baseline/variadic-operations.json
+++ b/test/syntax/baseline/variadic-operations.json
@@ -10,41 +10,27 @@
                 "idlType": {
                     "type": "attribute-type",
                     "extAttrs": null,
-                    "generic": null,
+                    "generic": "",
                     "nullable": false,
                     "union": false,
-                    "idlType": "unsigned long",
-                    "trivia": {
-                        "base": " "
-                    }
+                    "idlType": "unsigned long"
                 },
                 "extAttrs": null,
-                "special": null,
-                "readonly": true,
-                "trivia": {
-                    "base": " ",
-                    "name": " ",
-                    "termination": ""
-                }
+                "special": "",
+                "readonly": true
             },
             {
                 "type": "operation",
                 "name": "union",
                 "body": {
-                    "name": {
-                        "value": "union",
-                        "trivia": " "
-                    },
+                    "name": "union",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": "\n\n  "
-                        }
+                        "idlType": "void"
                     },
                     "arguments": [
                         {
@@ -52,51 +38,32 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "long",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "long"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": true,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": true
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             },
             {
                 "type": "operation",
                 "name": "intersection",
                 "body": {
-                    "name": {
-                        "value": "intersection",
-                        "trivia": " "
-                    },
+                    "name": "intersection",
                     "idlType": {
                         "type": "return-type",
                         "extAttrs": null,
-                        "generic": null,
+                        "generic": "",
                         "nullable": false,
                         "union": false,
-                        "idlType": "void",
-                        "trivia": {
-                            "base": "\n  "
-                        }
+                        "idlType": "void"
                     },
                     "arguments": [
                         {
@@ -104,43 +71,23 @@
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
-                                "generic": null,
+                                "generic": "",
                                 "nullable": false,
                                 "union": false,
-                                "idlType": "long",
-                                "trivia": {
-                                    "base": ""
-                                }
+                                "idlType": "long"
                             },
                             "default": null,
                             "optional": false,
-                            "variadic": true,
-                            "trivia": {
-                                "name": " "
-                            }
+                            "variadic": true
                         }
-                    ],
-                    "trivia": {
-                        "open": "",
-                        "close": ""
-                    }
+                    ]
                 },
                 "extAttrs": null,
-                "special": null,
-                "trivia": {
-                    "termination": ""
-                }
+                "special": ""
             }
         ],
         "extAttrs": null,
-        "partial": false,
-        "trivia": {
-            "base": "// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06\n",
-            "name": " ",
-            "open": " ",
-            "close": "\n",
-            "termination": ""
-        }
+        "partial": false
     },
     {
         "type": "eof",


### PR DESCRIPTION
Also `generic` now always returns string rather than `null` or an object.