### PR TITLE
refactor: modularize Token and list()

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,3 +1,0 @@
-export function unescape(identifier) {
-  return identifier.startsWith('_') ? identifier.slice(1) : identifier;
-}

--- a/lib/productions/helpers.js
+++ b/lib/productions/helpers.js
@@ -1,0 +1,33 @@
+export function unescape(identifier) {
+  return identifier.startsWith('_') ? identifier.slice(1) : identifier;
+}
+
+/**
+ * Parses comma-separated list
+ * @param {import("../tokeniser").Tokeniser} tokeniser
+ * @param {object} args
+ * @param {Function} args.parser parser function for each item
+ * @param {boolean} [args.allowDangler] whether to allow dangling comma
+ * @param {string} [args.listName] the name to be shown on error messages
+ */
+export function list(tokeniser, { parser, allowDangler, listName = "list" }) {
+  const first = parser();
+  if (!first) {
+    return [];
+  }
+  first.tokens.separator = tokeniser.consume(",");
+  const items = [first];
+  while (first.tokens.separator) {
+    const item = parser(tokeniser);
+    if (!item) {
+      if (!allowDangler) {
+        error(`Trailing comma in ${listName}`);
+      }
+      break;
+    }
+    item.tokens.separator = tokeniser.consume(",");
+    items.push(item);
+    if (!item.tokens.separator) break;
+  }
+  return items;
+}

--- a/lib/productions/includes.js
+++ b/lib/productions/includes.js
@@ -1,5 +1,5 @@
 import { Base } from "./base";
-import { unescape } from "../helpers";
+import { unescape } from "./helpers";
 
 export class Includes extends Base {
   /**

--- a/lib/productions/token.js
+++ b/lib/productions/token.js
@@ -1,0 +1,20 @@
+import { Base } from "./base";
+
+export class Token extends Base {
+  /**
+   * @param {import("../tokeniser").Tokeniser} tokeniser
+   * @param {string} type
+   */
+  static parser(tokeniser, type) {
+    return () => {
+      const value = tokeniser.consume(type);
+      if (value) {
+        return new Token({ source: tokeniser.source, tokens: { value } });
+      }
+    };
+  }
+
+  get value() {
+    return this.tokens.value.value;
+  }
+}

--- a/lib/tokeniser.js
+++ b/lib/tokeniser.js
@@ -92,7 +92,7 @@ const punctuations = [
 /**
  * @param {string} str
  */
-export function tokenise(str) {
+function tokenise(str) {
   const tokens = [];
   let lastCharIndex = 0;
   let trivia = "";

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -2,8 +2,9 @@
 
 import { argumentNameKeywords, stringTypes, Tokeniser } from "./tokeniser.js";
 import { Base } from "./productions/base.js";
+import { Token } from "./productions/token.js";
 import { Includes } from "./productions/includes.js";
-import { unescape } from "./helpers.js";
+import { list, unescape } from "./productions/helpers.js";
 
 /**
  * @param {Tokeniser} tokeniser
@@ -31,35 +32,6 @@ function parseByTokens(tokeniser) {
 
   function unconsume(position) {
     return tokeniser.unconsume(position);
-  }
-
-  /**
-   * Parses comma-separated list
-   * @param {object} args
-   * @param {Function} args.parser parser function for each item
-   * @param {boolean} [args.allowDangler] whether to allow dangling comma
-   * @param {string} [args.listName] the name to be shown on error messages
-   */
-  function list({ parser, allowDangler, listName = "list" }) {
-    const first = parser();
-    if (!first) {
-      return [];
-    }
-    first.tokens.separator = consume(",");
-    const items = [first];
-    while (first.tokens.separator) {
-      const item = parser();
-      if (!item) {
-        if (!allowDangler) {
-          error(`Trailing comma in ${listName}`);
-        }
-        break;
-      }
-      item.tokens.separator = consume(",");
-      items.push(item);
-      if (!item.tokens.separator) break;
-    }
-    return items;
   }
 
   function integer_type() {
@@ -287,29 +259,11 @@ function parseByTokens(tokeniser) {
   }
 
   function argument_list() {
-    return list({ parser: Argument.parse, listName: "arguments list" });
-  }
-
-  class Token extends Base {
-    /**
-     * @param {string} type
-     */
-    static parser(type) {
-      return () => {
-        const value = consume(type);
-        if (value) {
-          return new Token({ source, tokens: { value } });
-        }
-      };
-    }
-
-    get value() {
-      return this.tokens.value.value;
-    }
+    return list(tokeniser, { parser: Argument.parse, listName: "arguments list" });
   }
 
   function identifiers() {
-    const ids = list({ parser: Token.parser(ID), listName: "identifier list" });
+    const ids = list(tokeniser, { parser: Token.parser(tokeniser, ID), listName: "identifier list" });
     if (!ids.length) {
       error("Expected identifiers but none found");
     }
@@ -391,7 +345,7 @@ function parseByTokens(tokeniser) {
       tokens.open = consume("[");
       if (!tokens.open) return null;
       const ret = new ExtendedAttributes({ source, tokens });
-      ret.items = list({
+      ret.items = list(tokeniser, {
         parser: SimpleExtendedAttribute.parse,
         listName: "extended attribute"
       });
@@ -873,7 +827,7 @@ function parseByTokens(tokeniser) {
       tokens.name = consume(ID) || error("No name for enum");
       current = new Enum({ source, tokens });
       tokens.open = consume("{") || error("Bodyless enum");
-      current.values = list({
+      current.values = list(tokeniser, {
         parser: EnumValue.parse,
         allowDangler: true,
         listName: "enumeration"


### PR DESCRIPTION
Harder to modularize things than I thought because `ExtendedAttributes` depends on `argument_list()` which depends on `Argument` which again depends on `ExtendedAttributes` and `Type`...