### PR TITLE
fix(lib/webidl2): emit error message correctly

### DIFF
--- a/lib/productions/default.js
+++ b/lib/productions/default.js
@@ -1,5 +1,5 @@
-import { Base } from "./base";
-import { const_data, const_value } from "./helpers";
+import { Base } from "./base.js";
+import { const_data, const_value } from "./helpers.js";
 
 export class Default extends Base {
   /**

--- a/lib/productions/includes.js
+++ b/lib/productions/includes.js
@@ -1,5 +1,5 @@
-import { Base } from "./base";
-import { unescape } from "./helpers";
+import { Base } from "./base.js";
+import { unescape } from "./helpers.js";
 
 export class Includes extends Base {
   /**

--- a/lib/productions/token.js
+++ b/lib/productions/token.js
@@ -1,4 +1,4 @@
-import { Base } from "./base";
+import { Base } from "./base.js";
 
 export class Token extends Base {
   /**

--- a/lib/tokeniser.js
+++ b/lib/tokeniser.js
@@ -189,11 +189,10 @@ export class Tokeniser {
   }
 
   /**
-   * @param {*} current
    * @param {string} message
    */
-  error(current, message) {
-    throw new WebIDLParseError(syntaxError(this.source, this.position, current, message));
+  error(message) {
+    throw new WebIDLParseError(syntaxError(this.source, this.position, this.current, message));
   }
 
   /**

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -12,7 +12,6 @@ import { Default } from "./productions/default.js";
  */
 function parseByTokens(tokeniser) {
   const source = tokeniser.source;
-  let current = null;
 
   const DECIMAL = "decimal";
   const INT = "integer";
@@ -20,7 +19,7 @@ function parseByTokens(tokeniser) {
   const STR = "string";
 
   function error(str) {
-    tokeniser.error(current, str);
+    tokeniser.error(str);
   }
 
   function probe(type) {
@@ -375,7 +374,7 @@ function parseByTokens(tokeniser) {
       const tokens = { base };
       const ret = new CallbackFunction({ source, tokens });
       tokens.name = consume(ID) || error("No name for callback");
-      current = ret;
+      tokeniser.current = ret;
       tokens.assign = consume("=") || error("No assignment in callback");
       ret.idlType = return_type() || error("Missing return type");
       tokens.open = consume("(") || error("No arguments in callback");
@@ -594,7 +593,7 @@ function parseByTokens(tokeniser) {
     static parse(instance, { type, inheritable, allowedMembers }) {
       const { tokens } = instance;
       tokens.name = consume(ID) || error("No name for interface");
-      current = instance;
+      tokeniser.current = instance;
       if (inheritable) {
         instance.inheritance = Inheritance.parse() || null;
       }
@@ -771,9 +770,9 @@ function parseByTokens(tokeniser) {
         return;
       }
       tokens.name = consume(ID) || error("No name for enum");
-      current = new Enum({ source, tokens });
+      const ret = tokeniser.current = new Enum({ source, tokens });
       tokens.open = consume("{") || error("Bodyless enum");
-      current.values = list(tokeniser, {
+      ret.values = list(tokeniser, {
         parser: EnumValue.parse,
         allowDangler: true,
         listName: "enumeration"
@@ -782,11 +781,11 @@ function parseByTokens(tokeniser) {
         error("No comma between enum values");
       }
       tokens.close = consume("}") || error("Unexpected value in enum");
-      if (!current.values.length) {
+      if (!ret.values.length) {
         error("No value in enum");
       }
       tokens.termination = consume(";") || error("No semicolon after enum");
-      return current;
+      return ret;
     }
 
     get type() {
@@ -823,7 +822,7 @@ function parseByTokens(tokeniser) {
       }
       ret.idlType = type_with_extended_attributes("typedef-type") || error("No type in typedef");
       tokens.name = consume(ID) || error("No name in typedef");
-      current = ret;
+      tokeniser.current = ret;
       tokens.termination = consume(";") || error("Unterminated typedef");
       return ret;
     }

--- a/test/invalid/baseline/dict-no-default.txt
+++ b/test/invalid/baseline/dict-no-default.txt
@@ -1,0 +1,3 @@
+Syntax error at line 2, since `dictionary GPUColorStateDescriptor`:
+    GPUColorWriteFlags writeMask = GPUColorWriteBits.ALL;
+                                   ^ No value for default

--- a/test/invalid/idl/dict-no-default.widl
+++ b/test/invalid/idl/dict-no-default.widl
@@ -1,0 +1,3 @@
+dictionary GPUColorStateDescriptor {
+    GPUColorWriteFlags writeMask = GPUColorWriteBits.ALL;
+};


### PR DESCRIPTION
The error message was incorrectly passed and thus caused things be undefined.

Caught in https://github.com/w3c/webidl2.js/issues/316#issuecomment-488042536, thanks @bglgwyng!