### PR TITLE
BREAKING CHANGE(lib/webidl2): allow argument-wise extended attributes

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -332,7 +332,7 @@ function parseByTokens(tokeniser) {
         error("Found an empty extended attribute");
       }
       if (probe("[")) {
-        error("Illegal double extended attribute list, consider merging them");
+        error("Illegal double extended attribute lists, consider merging them");
       }
       return ret;
     }

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -208,6 +208,7 @@ function parseByTokens(tokeniser) {
       const start_position = tokeniser.position;
       const tokens = {};
       const ret = new Argument({ source, tokens });
+      ret.extAttrs = ExtendedAttributes.parse();
       tokens.optional = consume("optional");
       ret.idlType = type_with_extended_attributes("argument-type");
       if (!ret.idlType) {
@@ -329,6 +330,9 @@ function parseByTokens(tokeniser) {
       tokens.close = consume("]") || error("Unexpected form of extended attribute");
       if (!ret.items.length) {
         error("Found an empty extended attribute");
+      }
+      if (probe("[")) {
+        error("Illegal double extended attribute list, consider merging them");
       }
       return ret;
     }

--- a/test/invalid/baseline/extattr-double-field.txt
+++ b/test/invalid/baseline/extattr-double-field.txt
@@ -1,3 +1,3 @@
 Syntax error at line 2, since `dictionary Foo`:
   [Clamp] [Clamp] unsigned long
-          ^ Illegal double extended attribute list, consider merging them
+          ^ Illegal double extended attribute lists, consider merging them

--- a/test/invalid/baseline/extattr-double-field.txt
+++ b/test/invalid/baseline/extattr-double-field.txt
@@ -1,0 +1,3 @@
+Syntax error at line 2, since `dictionary Foo`:
+  [Clamp] [Clamp] unsigned long
+          ^ Illegal double extended attribute list, consider merging them

--- a/test/invalid/baseline/extattr-double.txt
+++ b/test/invalid/baseline/extattr-double.txt
@@ -1,3 +1,3 @@
 Syntax error at line 1:
 Constructor([Clamp] [Clamp] unsigned long
-                    ^ Illegal double extended attribute list, consider merging them
+                    ^ Illegal double extended attribute lists, consider merging them

--- a/test/invalid/baseline/extattr-double.txt
+++ b/test/invalid/baseline/extattr-double.txt
@@ -1,3 +1,3 @@
 Syntax error at line 1:
-[Constructor([Clamp] [Clamp
-             ^ Unexpected token in extended attribute argument list
+Constructor([Clamp] [Clamp] unsigned long
+                    ^ Illegal double extended attribute list, consider merging them

--- a/test/invalid/idl/extattr-double-field.widl
+++ b/test/invalid/idl/extattr-double-field.widl
@@ -1,0 +1,3 @@
+dictionary Foo {
+  [Clamp] [Clamp] unsigned long value;
+};

--- a/test/syntax/baseline/allowany.json
+++ b/test/syntax/baseline/allowany.json
@@ -38,6 +38,7 @@
                     "arguments": [
                         {
                             "name": "b",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -71,18 +72,19 @@
                     "arguments": [
                         {
                             "name": "s",
+                            "extAttrs": {
+                                "items": [
+                                    {
+                                        "type": "extended-attribute",
+                                        "name": "AllowAny",
+                                        "rhs": null,
+                                        "arguments": []
+                                    }
+                                ]
+                            },
                             "idlType": {
                                 "type": "argument-type",
-                                "extAttrs": {
-                                    "items": [
-                                        {
-                                            "type": "extended-attribute",
-                                            "name": "AllowAny",
-                                            "rhs": null,
-                                            "arguments": []
-                                        }
-                                    ]
-                                },
+                                "extAttrs": null,
                                 "generic": "",
                                 "nullable": false,
                                 "union": false,

--- a/test/syntax/baseline/argument-extattrs.json
+++ b/test/syntax/baseline/argument-extattrs.json
@@ -63,6 +63,6 @@
     {
         "type": "eof",
         "value": "",
-        "trivia": "\r\n"
+        "trivia": "\n"
     }
 ]

--- a/test/syntax/baseline/argument-extattrs.json
+++ b/test/syntax/baseline/argument-extattrs.json
@@ -1,0 +1,68 @@
+[
+    {
+        "type": "interface",
+        "name": "Foo",
+        "inheritance": null,
+        "members": [
+            {
+                "type": "operation",
+                "name": "foo",
+                "body": {
+                    "name": "foo",
+                    "idlType": {
+                        "type": "return-type",
+                        "extAttrs": null,
+                        "generic": "",
+                        "nullable": false,
+                        "union": false,
+                        "idlType": "void"
+                    },
+                    "arguments": [
+                        {
+                            "name": "argname",
+                            "extAttrs": {
+                                "items": [
+                                    {
+                                        "type": "extended-attribute",
+                                        "name": "ExtAttr",
+                                        "rhs": null,
+                                        "arguments": []
+                                    }
+                                ]
+                            },
+                            "idlType": {
+                                "type": "argument-type",
+                                "extAttrs": {
+                                    "items": [
+                                        {
+                                            "type": "extended-attribute",
+                                            "name": "Clamp",
+                                            "rhs": null,
+                                            "arguments": []
+                                        }
+                                    ]
+                                },
+                                "generic": "",
+                                "nullable": false,
+                                "union": false,
+                                "idlType": "short"
+                            },
+                            "default": null,
+                            "optional": true,
+                            "variadic": false
+                        }
+                    ]
+                },
+                "extAttrs": null,
+                "special": ""
+            }
+        ],
+        "extAttrs": null,
+        "partial": false
+    },
+    {
+        "type": "eof",
+        "value": "",
+        "trivia": "\r\n"
+    }
+]

--- a/test/syntax/baseline/callback.json
+++ b/test/syntax/baseline/callback.json
@@ -13,6 +13,7 @@
         "arguments": [
             {
                 "name": "status",
+                "extAttrs": null,
                 "idlType": {
                     "type": "argument-type",
                     "extAttrs": null,
@@ -49,6 +50,7 @@
                     "arguments": [
                         {
                             "name": "details",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -84,6 +86,7 @@
         "arguments": [
             {
                 "name": "a",
+                "extAttrs": null,
                 "idlType": {
                     "type": "argument-type",
                     "extAttrs": null,
@@ -98,6 +101,7 @@
             },
             {
                 "name": "b",
+                "extAttrs": null,
                 "idlType": {
                     "type": "argument-type",
                     "extAttrs": null,

--- a/test/syntax/baseline/constructor.json
+++ b/test/syntax/baseline/constructor.json
@@ -80,6 +80,7 @@
                     "arguments": [
                         {
                             "name": "radius",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,

--- a/test/syntax/baseline/enum.json
+++ b/test/syntax/baseline/enum.json
@@ -69,6 +69,7 @@
                     "arguments": [
                         {
                             "name": "type",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -83,6 +84,7 @@
                         },
                         {
                             "name": "size",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,

--- a/test/syntax/baseline/equivalent-decl.json
+++ b/test/syntax/baseline/equivalent-decl.json
@@ -35,6 +35,7 @@
                     "arguments": [
                         {
                             "name": "propertyName",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -68,6 +69,7 @@
                     "arguments": [
                         {
                             "name": "propertyName",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -82,6 +84,7 @@
                         },
                         {
                             "name": "propertyValue",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -139,6 +142,7 @@
                     "arguments": [
                         {
                             "name": "propertyName",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -172,6 +176,7 @@
                     "arguments": [
                         {
                             "name": "propertyName",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -186,6 +191,7 @@
                         },
                         {
                             "name": "propertyValue",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -219,6 +225,7 @@
                     "arguments": [
                         {
                             "name": "propertyName",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -252,6 +259,7 @@
                     "arguments": [
                         {
                             "name": "propertyName",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -266,6 +274,7 @@
                         },
                         {
                             "name": "propertyValue",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,

--- a/test/syntax/baseline/extended-attributes.json
+++ b/test/syntax/baseline/extended-attributes.json
@@ -156,6 +156,7 @@
                     "arguments": [
                         {
                             "name": "radius",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,

--- a/test/syntax/baseline/getter-setter.json
+++ b/test/syntax/baseline/getter-setter.json
@@ -35,6 +35,7 @@
                     "arguments": [
                         {
                             "name": "propertyName",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -68,6 +69,7 @@
                     "arguments": [
                         {
                             "name": "propertyName",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -82,6 +84,7 @@
                         },
                         {
                             "name": "propertyValue",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,

--- a/test/syntax/baseline/identifier-qualified-names.json
+++ b/test/syntax/baseline/identifier-qualified-names.json
@@ -33,6 +33,7 @@
                     "arguments": [
                         {
                             "name": "interface",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -66,6 +67,7 @@
                     "arguments": [
                         {
                             "name": "keyName",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -147,6 +149,7 @@
                     "arguments": [
                         {
                             "name": "callback",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,

--- a/test/syntax/baseline/indexed-properties.json
+++ b/test/syntax/baseline/indexed-properties.json
@@ -35,6 +35,7 @@
                     "arguments": [
                         {
                             "name": "index",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -68,6 +69,7 @@
                     "arguments": [
                         {
                             "name": "index",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -82,6 +84,7 @@
                         },
                         {
                             "name": "value",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -115,6 +118,7 @@
                     "arguments": [
                         {
                             "name": "index",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -148,6 +152,7 @@
                     "arguments": [
                         {
                             "name": "name",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -181,6 +186,7 @@
                     "arguments": [
                         {
                             "name": "name",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -195,6 +201,7 @@
                         },
                         {
                             "name": "value",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -228,6 +235,7 @@
                     "arguments": [
                         {
                             "name": "name",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,

--- a/test/syntax/baseline/namedconstructor.json
+++ b/test/syntax/baseline/namedconstructor.json
@@ -27,6 +27,7 @@
                     "arguments": [
                         {
                             "name": "src",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,

--- a/test/syntax/baseline/namespace.json
+++ b/test/syntax/baseline/namespace.json
@@ -34,6 +34,7 @@
                     "arguments": [
                         {
                             "name": "x",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -48,6 +49,7 @@
                         },
                         {
                             "name": "y",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -81,6 +83,7 @@
                     "arguments": [
                         {
                             "name": "x",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -95,6 +98,7 @@
                         },
                         {
                             "name": "y",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,

--- a/test/syntax/baseline/nointerfaceobject.json
+++ b/test/syntax/baseline/nointerfaceobject.json
@@ -20,6 +20,7 @@
                     "arguments": [
                         {
                             "name": "key",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,

--- a/test/syntax/baseline/nullableobjects.json
+++ b/test/syntax/baseline/nullableobjects.json
@@ -36,6 +36,7 @@
                     "arguments": [
                         {
                             "name": "x",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -69,6 +70,7 @@
                     "arguments": [
                         {
                             "name": "x",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,

--- a/test/syntax/baseline/operation-optional-arg.json
+++ b/test/syntax/baseline/operation-optional-arg.json
@@ -20,6 +20,7 @@
                     "arguments": [
                         {
                             "name": "v1",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -34,6 +35,7 @@
                         },
                         {
                             "name": "v2",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -48,6 +50,7 @@
                         },
                         {
                             "name": "v3",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -62,6 +65,7 @@
                         },
                         {
                             "name": "alpha",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,

--- a/test/syntax/baseline/overloading.json
+++ b/test/syntax/baseline/overloading.json
@@ -36,6 +36,7 @@
                     "arguments": [
                         {
                             "name": "x",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -69,6 +70,7 @@
                     "arguments": [
                         {
                             "name": "x",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -111,6 +113,7 @@
                     "arguments": [
                         {
                             "name": "a",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -144,18 +147,19 @@
                     "arguments": [
                         {
                             "name": "a",
+                            "extAttrs": {
+                                "items": [
+                                    {
+                                        "type": "extended-attribute",
+                                        "name": "AllowAny",
+                                        "rhs": null,
+                                        "arguments": []
+                                    }
+                                ]
+                            },
                             "idlType": {
                                 "type": "argument-type",
-                                "extAttrs": {
-                                    "items": [
-                                        {
-                                            "type": "extended-attribute",
-                                            "name": "AllowAny",
-                                            "rhs": null,
-                                            "arguments": []
-                                        }
-                                    ]
-                                },
+                                "extAttrs": null,
                                 "generic": "",
                                 "nullable": false,
                                 "union": false,
@@ -167,6 +171,7 @@
                         },
                         {
                             "name": "b",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -181,6 +186,7 @@
                         },
                         {
                             "name": "c",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -232,6 +238,7 @@
                     "arguments": [
                         {
                             "name": "a",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -246,6 +253,7 @@
                         },
                         {
                             "name": "b",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -260,6 +268,7 @@
                         },
                         {
                             "name": "c",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -274,6 +283,7 @@
                         },
                         {
                             "name": "d",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,

--- a/test/syntax/baseline/overridebuiltins.json
+++ b/test/syntax/baseline/overridebuiltins.json
@@ -35,6 +35,7 @@
                     "arguments": [
                         {
                             "name": "key",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,

--- a/test/syntax/baseline/record.json
+++ b/test/syntax/baseline/record.json
@@ -20,6 +20,7 @@
                     "arguments": [
                         {
                             "name": "param",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -125,6 +126,7 @@
                     "arguments": [
                         {
                             "name": "init",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,

--- a/test/syntax/baseline/reg-operations.json
+++ b/test/syntax/baseline/reg-operations.json
@@ -77,6 +77,7 @@
                     "arguments": [
                         {
                             "name": "size",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -110,6 +111,7 @@
                     "arguments": [
                         {
                             "name": "width",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -124,6 +126,7 @@
                         },
                         {
                             "name": "height",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,

--- a/test/syntax/baseline/sequence.json
+++ b/test/syntax/baseline/sequence.json
@@ -20,6 +20,7 @@
                     "arguments": [
                         {
                             "name": "coordinates",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -98,6 +99,7 @@
                     "arguments": [
                         {
                             "name": "arg",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,

--- a/test/syntax/baseline/static.json
+++ b/test/syntax/baseline/static.json
@@ -88,6 +88,7 @@
                     "arguments": [
                         {
                             "name": "c1",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -102,6 +103,7 @@
                         },
                         {
                             "name": "c2",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -116,6 +118,7 @@
                         },
                         {
                             "name": "c3",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,

--- a/test/syntax/baseline/treatasnull.json
+++ b/test/syntax/baseline/treatasnull.json
@@ -50,21 +50,22 @@
                     "arguments": [
                         {
                             "name": "breedName",
+                            "extAttrs": {
+                                "items": [
+                                    {
+                                        "type": "extended-attribute",
+                                        "name": "TreatNullAs",
+                                        "rhs": {
+                                            "type": "identifier",
+                                            "value": "EmptyString"
+                                        },
+                                        "arguments": []
+                                    }
+                                ]
+                            },
                             "idlType": {
                                 "type": "argument-type",
-                                "extAttrs": {
-                                    "items": [
-                                        {
-                                            "type": "extended-attribute",
-                                            "name": "TreatNullAs",
-                                            "rhs": {
-                                                "type": "identifier",
-                                                "value": "EmptyString"
-                                            },
-                                            "arguments": []
-                                        }
-                                    ]
-                                },
+                                "extAttrs": null,
                                 "generic": "",
                                 "nullable": false,
                                 "union": false,

--- a/test/syntax/baseline/treatasundefined.json
+++ b/test/syntax/baseline/treatasundefined.json
@@ -50,21 +50,22 @@
                     "arguments": [
                         {
                             "name": "breedName",
+                            "extAttrs": {
+                                "items": [
+                                    {
+                                        "type": "extended-attribute",
+                                        "name": "TreatUndefinedAs",
+                                        "rhs": {
+                                            "type": "identifier",
+                                            "value": "EmptyString"
+                                        },
+                                        "arguments": []
+                                    }
+                                ]
+                            },
                             "idlType": {
                                 "type": "argument-type",
-                                "extAttrs": {
-                                    "items": [
-                                        {
-                                            "type": "extended-attribute",
-                                            "name": "TreatUndefinedAs",
-                                            "rhs": {
-                                                "type": "identifier",
-                                                "value": "EmptyString"
-                                            },
-                                            "arguments": []
-                                        }
-                                    ]
-                                },
+                                "extAttrs": null,
                                 "generic": "",
                                 "nullable": false,
                                 "union": false,

--- a/test/syntax/baseline/typedef.json
+++ b/test/syntax/baseline/typedef.json
@@ -135,6 +135,7 @@
                     "arguments": [
                         {
                             "name": "p",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -168,6 +169,7 @@
                     "arguments": [
                         {
                             "name": "ps",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,

--- a/test/syntax/baseline/typesuffixes.json
+++ b/test/syntax/baseline/typesuffixes.json
@@ -20,6 +20,7 @@
                     "arguments": [
                         {
                             "name": "foo",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,

--- a/test/syntax/baseline/variadic-operations.json
+++ b/test/syntax/baseline/variadic-operations.json
@@ -35,6 +35,7 @@
                     "arguments": [
                         {
                             "name": "ints",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,
@@ -68,6 +69,7 @@
                     "arguments": [
                         {
                             "name": "ints",
+                            "extAttrs": null,
                             "idlType": {
                                 "type": "argument-type",
                                 "extAttrs": null,

--- a/test/syntax/idl/argument-extattrs.widl
+++ b/test/syntax/idl/argument-extattrs.widl
@@ -1,0 +1,3 @@
+interface Foo {
+  void foo([ExtAttr] optional [Clamp] short argname);
+};


### PR DESCRIPTION
Fixes #320 

This is after some discussion on https://github.com/heycam/webidl/issues/691. This reverts #248.