### PR TITLE
docs(lib/webidl2): document `eof`

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,6 +665,22 @@ The fields are as follows:
 * `readonly`: `true` if the maplike or setlike is declared as read only.
 * `extAttrs`: An array of [extended attributes](#extended-attributes).
 
+### End of file
+
+```js
+{
+  "type": "eof",
+  "value": "",
+  "trivia": "\n"
+}
+```
+
+The fields are as follows:
+
+* `type`: Always "eof"
+* `value`: Always an empty string.
+* `trivia`: Any whitespaces and comments after the last token and before the EOF.
+
 ## Testing
 
 ### Running


### PR DESCRIPTION
Requested from #327. Not introducing an option yet.