### PR TITLE
fix(lib/webidl2): inherited attributes cannot be readonly

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -416,6 +416,9 @@ function parseByTokens(tokeniser) {
       if (!special && !noInherit) {
         tokens.special = consume("inherit");
       }
+      if (ret.special === "inherit" && probe("readonly")) {
+        error("Inherited attributes cannot be read-only");
+      }
       tokens.readonly = consume("readonly");
       if (readonly && !tokens.readonly && probe("attribute")) {
         error("Attributes must be readonly in this context");

--- a/test/invalid/baseline/inherit-readonly.txt
+++ b/test/invalid/baseline/inherit-readonly.txt
@@ -1,0 +1,3 @@
+Syntax error at line 2, since `interface Claudine`:
+  inherit readonly attribute DOMString maya;
+          ^ Inherited attributes cannot be read-only

--- a/test/invalid/idl/inherit-readonly.widl
+++ b/test/invalid/idl/inherit-readonly.widl
@@ -1,0 +1,3 @@
+interface Claudine {
+  inherit readonly attribute DOMString maya;
+};

--- a/test/syntax/baseline/inherits-getter.json
+++ b/test/syntax/baseline/inherits-getter.json
@@ -63,30 +63,6 @@
         "partial": false
     },
     {
-        "type": "interface",
-        "name": "Ghost",
-        "inheritance": "Person",
-        "members": [
-            {
-                "type": "attribute",
-                "name": "name",
-                "idlType": {
-                    "type": "attribute-type",
-                    "extAttrs": [],
-                    "generic": "",
-                    "nullable": false,
-                    "union": false,
-                    "idlType": "DOMString"
-                },
-                "extAttrs": [],
-                "special": "inherit",
-                "readonly": true
-            }
-        ],
-        "extAttrs": [],
-        "partial": false
-    },
-    {
         "type": "eof",
         "value": "",
         "trivia": "\n"

--- a/test/syntax/idl/inherits-getter.widl
+++ b/test/syntax/idl/inherits-getter.widl
@@ -14,9 +14,3 @@ interface Person : Animal {
   // the description of Person.
   inherit attribute DOMString name;
 };
-
-interface Ghost : Person {
-
-  // An attribute that only inherits the getter behavior
-  inherit readonly attribute DOMString name;
-};


### PR DESCRIPTION
Follows https://github.com/heycam/webidl/pull/704, but it has been already invalid.