### PR TITLE
feat(productions/operation): require default value for dictionary arguments

### DIFF
--- a/lib/productions/container.js
+++ b/lib/productions/container.js
@@ -63,4 +63,12 @@ export class Container extends Base {
       }
       return unescape(this.tokens.inheritance.value);
     }
+
+    *validate(defs) {
+      for (const member of this.members) {
+        if (member.validate) {
+          yield* member.validate(defs);
+        }
+      }
+    }
   }

--- a/lib/productions/operation.js
+++ b/lib/productions/operation.js
@@ -1,5 +1,7 @@
 import { Base } from "./base.js";
 import { return_type, argument_list, unescape } from "./helpers.js";
+import { validationError } from "../error.js";
+import { idlTypeIncludesDictionary } from "../validators/helper.js";
 
 export class Operation extends Base {
   /**
@@ -42,5 +44,16 @@ export class Operation extends Base {
       return "";
     }
     return this.tokens.special.value;
+  }
+
+  *validate(defs) {
+    for (const argument of this.arguments) {
+      if (idlTypeIncludesDictionary(argument.idlType, defs)) {
+        if (!argument.default) {
+          const message = `Optional dictionary arguments must have a default value of \`{}\`.`;
+          yield validationError(this.source, argument.tokens.name, this, message);
+        }
+      }
+    }
   }
 }

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -91,10 +91,17 @@ function* checkInterfaceMemberDuplication(defs) {
   }
 }
 
-export function validate(ast) {
+function* validateIterable(ast) {
   const defs = groupDefinitions(ast);
-  return [
-    ...checkDuplicatedNames(defs),
-    ...checkInterfaceMemberDuplication(defs)
-  ];
+  for (const def of defs.all) {
+    if (def.validate) {
+      yield* def.validate(defs);
+    }
+  }
+  yield* checkDuplicatedNames(defs);
+  yield* checkInterfaceMemberDuplication(defs);
+}
+
+export function validate(ast) {
+  return [...validateIterable(ast)];
 }

--- a/lib/validators/helper.js
+++ b/lib/validators/helper.js
@@ -1,0 +1,18 @@
+export function idlTypeIncludesDictionary(idlType, defs) {
+  if (!idlType.union) {
+    const def = defs.unique.get(idlType.idlType);
+    if (!def) {
+      return false;
+    }
+    if (def.type === "typedef") {
+      return idlTypeIncludesDictionary(def.idlType, defs);
+    }
+    return def.type === "dictionary";
+  }
+  for (const subtype of idlType.subtype) {
+    if (idlTypeIncludesDictionary(subtype, defs)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/test/invalid/baseline/operation-dict-default.txt
+++ b/test/invalid/baseline/operation-dict-default.txt
@@ -1,0 +1,9 @@
+Validation error at line 8, inside `operation x`:
+  void x(optional Dict dict);
+                       ^ Optional dictionary arguments must have a default value of `{}`.
+Validation error at line 10, inside `operation y`:
+ (boolean or Dict) union);
+                   ^ Optional dictionary arguments must have a default value of `{}`.
+Validation error at line 12, inside `operation z`:
+  void z(optional Union union);
+                        ^ Optional dictionary arguments must have a default value of `{}`.

--- a/test/invalid/idl/operation-dict-default.widl
+++ b/test/invalid/idl/operation-dict-default.widl
@@ -1,0 +1,14 @@
+dictionary Dict {
+  short x = 0;
+};
+
+typedef (short or Dict) Union;
+
+interface X {
+  void x(optional Dict dict);
+  void x2(optional Dict dict = {});
+  void y(optional (boolean or Dict) union);
+  void y2(optional (boolean or Dict) union = {});
+  void z(optional Union union);
+  void z2(optional Union union = {});
+};


### PR DESCRIPTION
So this is for ReSpec and WPT to match the new spec change (#338). We still need a way to insert xref data into validator, but that can probably be done in ReSpec without webidl2 changes.