### PR TITLE
BREAKING CHANGE: emit validation objects

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -72,5 +72,5 @@ export function syntaxError(source, position, current, message) {
  * @param {string} message error message
  */
 export function validationError(source, token, current, message) {
-  return error(source, token.index, current, message, "Validation").message;
+  return error(source, token.index, current, message, "Validation");
 }

--- a/test/invalid.js
+++ b/test/invalid.js
@@ -87,6 +87,7 @@ describe("Error object structure", () => {
     const x = parse("dictionary X {};", { name: "dict.webidl" });
     const y = parse("interface Y { void y(optional X x); };", { sourceName: "interface.webidl" });
     const validation = validate([x, y]);
+    expect(validation[0].line).toBe(1);
     expect(validation[0].sourceName).toContain("interface.webidl");
     expect(validation[0].message).toContain("interface.webidl");
   });

--- a/test/invalid.js
+++ b/test/invalid.js
@@ -13,9 +13,9 @@ describe("Parses all of the invalid IDLs to check that they blow up correctly", 
     it(`should produce the right error for ${test.path}`, () => {
       const err = test.readText();
       if (test.error) {
-        expect(test.error.message + "\n").toEqual(err);
+        expect(test.error.message + "\n").toBe(err);
       } else if (test.validation) {
-        expect(test.validation.join("\n") + "\n").toEqual(err);
+        expect(test.validation.map(v => v.message).join("\n") + "\n").toBe(err);
       } else {
         throw new Error("This test unexpectedly had no error");
       }
@@ -87,7 +87,8 @@ describe("Error object structure", () => {
     const x = parse("dictionary X {};", { name: "dict.webidl" });
     const y = parse("interface Y { void y(optional X x); };", { sourceName: "interface.webidl" });
     const validation = validate([x, y]);
-    expect(validation[0]).toContain("interface.webidl");
+    expect(validation[0].sourceName).toContain("interface.webidl");
+    expect(validation[0].message).toContain("interface.webidl");
   });
 });
 


### PR DESCRIPTION
Because emitting strings prevents programmatically track the right files, and potentially also prevents advanced features like tracking the problematic line instead of the whole IDL block.