### PR TITLE
 feat(lib/error): add .bareMessage and .context 

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -38,21 +38,21 @@ function error(source, position, current, message, type) {
     source.length > 1 ? source[position - 1].line :
     1;
 
-  const precedingLine = lastLine(
+  const precedingLastLine = lastLine(
     tokensToText(sliceTokens(-maxTokens), { precedes: true })
   );
 
   const subsequentTokens = sliceTokens(maxTokens);
   const subsequentText = tokensToText(subsequentTokens);
-  const sobsequentLine = subsequentText.split("\n")[0];
+  const subsequentFirstLine = subsequentText.split("\n")[0];
 
-  const spaced = " ".repeat(precedingLine.length) + "^";
-  const contextualMessage = precedingLine + sobsequentLine + "\n" + spaced;
+  const spaced = " ".repeat(precedingLastLine.length) + "^";
+  const sourceContext = precedingLastLine + subsequentFirstLine + "\n" + spaced;
 
   const contextType = type === "Syntax" ? "since" : "inside";
-  const sourceContext = source.name ? ` in ${source.name}` : "";
+  const inSourceName = source.name ? ` in ${source.name}` : "";
   const grammaticalContext = current ? `, ${contextType} \`${current.partial ? "partial " : ""}${current.type} ${current.name}\`` : "";
-  const context = `${type} error at line ${line}${sourceContext}${grammaticalContext}:\n${contextualMessage}`;
+  const context = `${type} error at line ${line}${inSourceName}${grammaticalContext}:\n${sourceContext}`;
   return {
     message: `${context} ${message}`,
     bareMessage: message,

--- a/lib/error.js
+++ b/lib/error.js
@@ -46,14 +46,17 @@ function error(source, position, current, message, type) {
   const subsequentText = tokensToText(subsequentTokens);
   const sobsequentLine = subsequentText.split("\n")[0];
 
-  const spaced = " ".repeat(precedingLine.length) + "^ " + message;
+  const spaced = " ".repeat(precedingLine.length) + "^";
   const contextualMessage = precedingLine + sobsequentLine + "\n" + spaced;
 
   const contextType = type === "Syntax" ? "since" : "inside";
   const sourceContext = source.name ? ` in ${source.name}` : "";
   const grammaticalContext = current ? `, ${contextType} \`${current.partial ? "partial " : ""}${current.type} ${current.name}\`` : "";
+  const context = `${type} error at line ${line}${sourceContext}${grammaticalContext}:\n${contextualMessage}`;
   return {
-    message: `${type} error at line ${line}${sourceContext}${grammaticalContext}:\n${contextualMessage}`,
+    message: `${context} ${message}`,
+    bareMessage: message,
+    context,
     line,
     sourceName: source.name,
     input: subsequentText,

--- a/lib/productions/interface.js
+++ b/lib/productions/interface.js
@@ -45,8 +45,8 @@ export class Interface extends Container {
 
   *validate(defs) {
     if (!this.partial && this.extAttrs.every(extAttr => extAttr.name !== "Exposed")) {
-      const message = `Interfaces must have [Exposed] extended attribute. \
-To fix, add, for example, [Exposed=Window]. Please also consider carefully \
+      const message = `Interfaces must have \`[Exposed]\` extended attribute. \
+To fix, add, for example, \`[Exposed=Window]\`. Please also consider carefully \
 if your interface should also be exposed in a Worker scope. Refer to the \
 [WebIDL spec section on Exposed](https://heycam.github.io/webidl/#Exposed) \
 for more information.`;

--- a/lib/tokeniser.js
+++ b/lib/tokeniser.js
@@ -223,9 +223,12 @@ export class Tokeniser {
 }
 
 class WebIDLParseError extends Error {
-  constructor({ message, line, sourceName, input, tokens }) {
+  constructor({ message, bareMessage, context, line, sourceName, input, tokens }) {
     super(message);
+
     this.name = "WebIDLParseError"; // not to be mangled
+    this.bareMessage = bareMessage;
+    this.context = context;
     this.line = line;
     this.sourceName = sourceName;
     this.input = input;

--- a/test/invalid.js
+++ b/test/invalid.js
@@ -101,16 +101,18 @@ describe("Error object structure", () => {
   it("should contain bareMessage field", () => {
     const x = parse("interface X {};");
     const validation = validate(x);
-    expect(validation[0].bareMessage).toContain("Exposed");
-    expect(validation[0].message.endsWith(validation[0].bareMessage)).toBe(true);
+    const { bareMessage, message } = validation[0];
+    expect(bareMessage).toContain("Exposed");
+    expect(message.endsWith(bareMessage)).toBe(true);
   });
 
   it("should contain context field", () => {
     const x = parse("interface X {};", { sourceName: "Biblia" });
     const validation = validate(x);
-    expect(validation[0].context).toContain("Biblia");
-    expect(validation[0].context.endsWith("^")).toBe(true);
-    expect(validation[0].message.startsWith(validation[0].context)).toBe(true);
+    const { context, message } = validation[0];
+    expect(context).toContain("Biblia");
+    expect(context.endsWith("^")).toBe(true);
+    expect(message.startsWith(context)).toBe(true);
   });
 });
 

--- a/test/invalid.js
+++ b/test/invalid.js
@@ -97,6 +97,21 @@ describe("Error object structure", () => {
     const validation = validate(x);
     expect(validation[0].sourceName).toBe(0);
   });
+
+  it("should contain bareMessage field", () => {
+    const x = parse("interface X {};");
+    const validation = validate(x);
+    expect(validation[0].bareMessage).toContain("Exposed");
+    expect(validation[0].message.endsWith(validation[0].bareMessage)).toBe(true);
+  });
+
+  it("should contain context field", () => {
+    const x = parse("interface X {};", { sourceName: "Biblia" });
+    const validation = validate(x);
+    expect(validation[0].context).toContain("Biblia");
+    expect(validation[0].context.endsWith("^")).toBe(true);
+    expect(validation[0].message.startsWith(validation[0].context)).toBe(true);
+  });
 });
 
 describe("Validation", () => {

--- a/test/invalid/baseline/exposed.txt
+++ b/test/invalid/baseline/exposed.txt
@@ -1,6 +1,6 @@
 Validation error at line 1 in exposed.webidl, inside `interface UnexposedInterface`:
 interface UnexposedInterface {};
-          ^ Interfaces must have [Exposed] extended attribute. To fix, add, for example, [Exposed=Window]. Please also consider carefully if your interface should also be exposed in a Worker scope. Refer to the [WebIDL spec section on Exposed](https://heycam.github.io/webidl/#Exposed) for more information.
+          ^ Interfaces must have `[Exposed]` extended attribute. To fix, add, for example, `[Exposed=Window]`. Please also consider carefully if your interface should also be exposed in a Worker scope. Refer to the [WebIDL spec section on Exposed](https://heycam.github.io/webidl/#Exposed) for more information.
 Validation error at line 3 in exposed.webidl, inside `namespace UnexposedNamespace`:
 namespace UnexposedNamespace {};
           ^ Namespaces must have [Exposed] extended attribute. To fix, add, for example, [Exposed=Window]. Please also consider carefully if your namespace should also be exposed in a Worker scope. Refer to the [WebIDL spec section on Exposed](https://heycam.github.io/webidl/#Exposed) for more information.

--- a/test/util/acquire.js
+++ b/test/util/acquire.js
@@ -10,7 +10,7 @@ for (const test of collect("syntax")) {
 for (const test of collect("invalid", { expectError: true, raw: true })) {
   const content =
     test.error ? test.error.message :
-    test.validation ? test.validation.join("\n") :
+    test.validation ? test.validation.map(v => v.message).join("\n") :
     "";
 
   fs.writeFileSync(test.baselinePath, `${content}\n`);


### PR DESCRIPTION
Splitting code context and error message will ease tools to format them user friendly, e.g. by wrapping `context` with `<pre>` and treating `bareMessage` as markdown.