### PR TITLE
fix: suppress Exposed requirement when NoInterfaceObject

### DIFF
--- a/lib/productions/interface.js
+++ b/lib/productions/interface.js
@@ -45,8 +45,11 @@ export class Interface extends Container {
 
   *validate(defs) {
     yield* this.extAttrs.validate(defs);
-
-    if (!this.partial && this.extAttrs.every(extAttr => extAttr.name !== "Exposed")) {
+    if (
+      !this.partial &&
+      this.extAttrs.every(extAttr => extAttr.name !== "Exposed") &&
+      this.extAttrs.every(extAttr => extAttr.name !== "NoInterfaceObject")
+    ) {
       const message = `Interfaces must have \`[Exposed]\` extended attribute. \
 To fix, add, for example, \`[Exposed=Window]\`. Please also consider carefully \
 if your interface should also be exposed in a Worker scope. Refer to the \

--- a/test/invalid/baseline/exposed.txt
+++ b/test/invalid/baseline/exposed.txt
@@ -1,6 +1,6 @@
 Validation error at line 1 in exposed.webidl, inside `interface UnexposedInterface`:
 interface UnexposedInterface {};
           ^ Interfaces must have `[Exposed]` extended attribute. To fix, add, for example, `[Exposed=Window]`. Please also consider carefully if your interface should also be exposed in a Worker scope. Refer to the [WebIDL spec section on Exposed](https://heycam.github.io/webidl/#Exposed) for more information.
-Validation error at line 3 in exposed.webidl, inside `namespace UnexposedNamespace`:
+Validation error at line 5 in exposed.webidl, inside `namespace UnexposedNamespace`:
 namespace UnexposedNamespace {};
           ^ Namespaces must have [Exposed] extended attribute. To fix, add, for example, [Exposed=Window]. Please also consider carefully if your namespace should also be exposed in a Worker scope. Refer to the [WebIDL spec section on Exposed](https://heycam.github.io/webidl/#Exposed) for more information.

--- a/test/invalid/idl/exposed.webidl
+++ b/test/invalid/idl/exposed.webidl
@@ -1,4 +1,6 @@
 interface UnexposedInterface {};
 partial interface UnexposedInterface {};
+[NoInterfaceObject]
+interface IntentionallyUnexposedInterface {};
 namespace UnexposedNamespace {};
 partial namespace UnexposedNamespace {};


### PR DESCRIPTION
My understanding is NoInterfaceObject will be removed soon (https://github.com/heycam/webidl/pull/609) but that didn't happen yet.

Closes #370.