### PR TITLE
Add file extensions

### DIFF
--- a/lib/productions/callback.js
+++ b/lib/productions/callback.js
@@ -1,5 +1,5 @@
-import { Base } from "./base";
-import { return_type, argument_list, unescape } from "./helpers";
+import { Base } from "./base.js";
+import { return_type, argument_list, unescape } from "./helpers.js";
 
 export class CallbackFunction extends Base {
   /**


### PR DESCRIPTION
Brave Browser was giving me 404s and not loading the files at load because it didn't automatically add the JS file extension to imports, so I added `.js` to both of the imports.