### PR TITLE
Allow `async` and `includes` as member names

### DIFF
--- a/lib/productions/attribute.js
+++ b/lib/productions/attribute.js
@@ -29,7 +29,7 @@ export class Attribute extends Base {
       case "sequence":
       case "record": tokeniser.error(`Attributes cannot accept ${ret.idlType.generic} types`);
     }
-    tokens.name = tokeniser.consume("identifier", "required") || tokeniser.error("Attribute lacks a name");
+    tokens.name = tokeniser.consume("identifier", "async", "required") || tokeniser.error("Attribute lacks a name");
     tokens.termination = tokeniser.consume(";") || tokeniser.error("Unterminated attribute, expected `;`");
     return ret;
   }

--- a/lib/productions/operation.js
+++ b/lib/productions/operation.js
@@ -19,7 +19,7 @@ export class Operation extends Base {
       tokens.special = tokeniser.consume("getter", "setter", "deleter");
     }
     ret.idlType = return_type(tokeniser) || tokeniser.error("Missing return type");
-    tokens.name = tokeniser.consume("identifier");
+    tokens.name = tokeniser.consume("identifier", "includes");
     tokens.open = tokeniser.consume("(") || tokeniser.error("Invalid operation");
     ret.arguments = argument_list(tokeniser);
     tokens.close = tokeniser.consume(")") || tokeniser.error("Unterminated operation");

--- a/lib/tokeniser.js
+++ b/lib/tokeniser.js
@@ -21,6 +21,7 @@ export const stringTypes = [
 ];
 
 export const argumentNameKeywords = [
+  "async",
   "attribute",
   "callback",
   "const",

--- a/test/syntax/baseline/async-name.json
+++ b/test/syntax/baseline/async-name.json
@@ -1,0 +1,73 @@
+[
+    {
+        "type": "interface",
+        "name": "Async",
+        "inheritance": null,
+        "members": [
+            {
+                "type": "attribute",
+                "name": "async",
+                "idlType": {
+                    "type": "attribute-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "boolean"
+                },
+                "extAttrs": [],
+                "special": "",
+                "readonly": false
+            },
+            {
+                "type": "operation",
+                "name": "asyncOp",
+                "idlType": {
+                    "type": "return-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "void"
+                },
+                "arguments": [
+                    {
+                        "type": "argument",
+                        "name": "async",
+                        "extAttrs": [],
+                        "idlType": {
+                            "type": "argument-type",
+                            "extAttrs": [],
+                            "generic": "",
+                            "nullable": false,
+                            "union": false,
+                            "idlType": "boolean"
+                        },
+                        "default": null,
+                        "optional": false,
+                        "variadic": false
+                    }
+                ],
+                "extAttrs": [],
+                "special": ""
+            }
+        ],
+        "extAttrs": [
+            {
+                "type": "extended-attribute",
+                "name": "Exposed",
+                "rhs": {
+                    "type": "identifier",
+                    "value": "Window"
+                },
+                "arguments": []
+            }
+        ],
+        "partial": false
+    },
+    {
+        "type": "eof",
+        "value": "",
+        "trivia": "\n"
+    }
+]

--- a/test/syntax/baseline/includes-name.json
+++ b/test/syntax/baseline/includes-name.json
@@ -1,0 +1,41 @@
+[
+    {
+        "type": "interface",
+        "name": "Includes",
+        "inheritance": null,
+        "members": [
+            {
+                "type": "operation",
+                "name": "includes",
+                "idlType": {
+                    "type": "return-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "void"
+                },
+                "arguments": [],
+                "extAttrs": [],
+                "special": ""
+            }
+        ],
+        "extAttrs": [
+            {
+                "type": "extended-attribute",
+                "name": "Exposed",
+                "rhs": {
+                    "type": "identifier",
+                    "value": "Window"
+                },
+                "arguments": []
+            }
+        ],
+        "partial": false
+    },
+    {
+        "type": "eof",
+        "value": "",
+        "trivia": "\n"
+    }
+]

--- a/test/syntax/idl/async-name.webidl
+++ b/test/syntax/idl/async-name.webidl
@@ -1,0 +1,6 @@
+
+[Exposed=Window]
+interface Async {
+  attribute boolean async;
+  void asyncOp(boolean async);
+};

--- a/test/syntax/idl/includes-name.webidl
+++ b/test/syntax/idl/includes-name.webidl
@@ -1,0 +1,4 @@
+[Exposed=Window]
+interface Includes {
+  void includes();
+};


### PR DESCRIPTION
Corresponds to https://github.com/heycam/webidl/pull/769.