### PR TITLE
fix(productions/argument): no default for nullable dictionary args

### DIFF
--- a/lib/productions/argument.js
+++ b/lib/productions/argument.js
@@ -47,15 +47,14 @@ export class Argument extends Base {
   *validate(defs) {
     yield* this.idlType.validate(defs);
     if (idlTypeIncludesDictionary(this.idlType, defs)) {
-      if (this.optional && !this.default) {
+      if (this.idlType.nullable) {
+        const message = `Dictionary arguments cannot be nullable.`;
+        yield validationError(this.source, this.tokens.name, this, message);
+      } else if (this.optional && !this.default) {
         const message = `Optional dictionary arguments must have a default value of \`{}\`.`;
         yield validationError(this.source, this.tokens.name, this, message, {
           autofix: autofixOptionalDictionaryDefaultValue(this)
         });
-      }
-      if (this.idlType.nullable) {
-        const message = `Dictionary arguments cannot be nullable.`;
-        yield validationError(this.source, this.tokens.name, this, message);
       }
     }
   }

--- a/test/invalid/baseline/argument-dict-nullable.txt
+++ b/test/invalid/baseline/argument-dict-nullable.txt
@@ -1,18 +1,21 @@
 Validation error at line 13 in argument-dict-nullable.webidl, inside `argument dict`:
+ x1(optional Dict? dict);
+                   ^ Dictionary arguments cannot be nullable.
+Validation error at line 14 in argument-dict-nullable.webidl, inside `argument dict`:
  x2(optional Dict? dict = {})
                    ^ Dictionary arguments cannot be nullable.
-Validation error at line 14 in argument-dict-nullable.webidl:
+Validation error at line 15 in argument-dict-nullable.webidl:
 (optional (boolean or Dict)? union =
                       ^ Nullable union cannot include a dictionary type
-Validation error at line 14 in argument-dict-nullable.webidl, inside `argument union`:
+Validation error at line 15 in argument-dict-nullable.webidl, inside `argument union`:
 boolean or Dict)? union = {})
                   ^ Dictionary arguments cannot be nullable.
-Validation error at line 15 in argument-dict-nullable.webidl:
+Validation error at line 16 in argument-dict-nullable.webidl:
   void z2(optional Union? union = {
                    ^ Nullable union cannot include a dictionary type
-Validation error at line 15 in argument-dict-nullable.webidl, inside `argument union`:
+Validation error at line 16 in argument-dict-nullable.webidl, inside `argument union`:
  z2(optional Union? union = {})
                     ^ Dictionary arguments cannot be nullable.
-Validation error at line 16 in argument-dict-nullable.webidl, inside `argument req`:
+Validation error at line 17 in argument-dict-nullable.webidl, inside `argument req`:
   void r(Required? req);
                    ^ Dictionary arguments cannot be nullable.

--- a/test/invalid/idl/argument-dict-nullable.webidl
+++ b/test/invalid/idl/argument-dict-nullable.webidl
@@ -10,6 +10,7 @@ typedef (short or Dict) Union;
 
 [Exposed=Window]
 interface X {
+  void x1(optional Dict? dict);
   void x2(optional Dict? dict = {});
   void y2(optional (boolean or Dict)? union = {});
   void z2(optional Union? union = {});


### PR DESCRIPTION
Currently the validator suggests adding a default dictionary value for a dictionary argument even it's nullable, but it's not a valid suggestion because a nullable dictionary type is not really a dictionary type. (https://github.com/heycam/webidl/issues/774#issuecomment-524229029)