### PR TITLE
fix(validators): treat only non-nullables

### DIFF
--- a/lib/productions/argument.js
+++ b/lib/productions/argument.js
@@ -46,7 +46,7 @@ export class Argument extends Base {
 
   *validate(defs) {
     yield* this.idlType.validate(defs);
-    if (idlTypeIncludesDictionary(this.idlType, defs)) {
+    if (idlTypeIncludesDictionary(this.idlType, defs, { useNullableInner: true })) {
       if (this.idlType.nullable) {
         const message = `Dictionary arguments cannot be nullable.`;
         yield validationError(this.source, this.tokens.name, this, message);

--- a/lib/validators/helpers.js
+++ b/lib/validators/helpers.js
@@ -1,19 +1,11 @@
 /**
- * Yields direct references to dictionary within union.
- */
-export function* dictionaryWithinUnion(subtypes, defs) {
-  for (const subtype of subtypes) {
-    const def = defs.unique.get(subtype.idlType);
-    if (def && def.type === "dictionary") {
-      yield subtype;
-    }
-  }
-}
-
-/**
+ * @param {*} idlType
+ * @param {*[]} defs
+ * @param {object} [options]
+ * @param {boolean} [options.useNullableInner] use when the input idlType is nullable and you want to use its inner type
  * @return the type reference that ultimately includes dictionary.
  */
-export function idlTypeIncludesDictionary(idlType, defs) {
+export function idlTypeIncludesDictionary(idlType, defs, { useNullableInner } = {}) {
   if (!idlType.union) {
     const def = defs.unique.get(idlType.idlType);
     if (!def) {
@@ -33,7 +25,7 @@ export function idlTypeIncludesDictionary(idlType, defs) {
         return idlType;
       }
     }
-    if (def.type === "dictionary") {
+    if (def.type === "dictionary" && (useNullableInner || !idlType.nullable)) {
       return idlType;
     }
   }
@@ -46,12 +38,4 @@ export function idlTypeIncludesDictionary(idlType, defs) {
       return subtype;
     }
   }
-}
-
-/**
- * @return true if the idlType directly references a typedef.
- */
-export function referencesTypedef(idlType, defs) {
-  const result = defs.unique.get(idlType.idlType);
-  return result && result.type === "typedef";
 }

--- a/test/invalid/baseline/nullable-union-dictionary.txt
+++ b/test/invalid/baseline/nullable-union-dictionary.txt
@@ -13,21 +13,21 @@ typedef BooleanDict? ReferencingNullableBooleanDict;
 Validation error at line 9 in nullable-union-dictionary.webidl:
 typedef (boolean or RecursiveBooleanDict? or Dict)
                     ^ Nullable union cannot include a dictionary type
-Validation error at line 11 in nullable-union-dictionary.webidl:
+Validation error at line 16 in nullable-union-dictionary.webidl:
  Callback = (boolean or Dict)? ()
                         ^ Nullable union cannot include a dictionary type
-Validation error at line 14 in nullable-union-dictionary.webidl:
+Validation error at line 19 in nullable-union-dictionary.webidl:
   (boolean or Dict)? op(
               ^ Nullable union cannot include a dictionary type
-Validation error at line 15 in nullable-union-dictionary.webidl:
+Validation error at line 20 in nullable-union-dictionary.webidl:
  voidOp((boolean or Dict)? arg)
                     ^ Nullable union cannot include a dictionary type
-Validation error at line 15 in nullable-union-dictionary.webidl, inside `argument arg`:
+Validation error at line 20 in nullable-union-dictionary.webidl, inside `argument arg`:
 boolean or Dict)? arg);
                   ^ Dictionary arguments cannot be nullable.
-Validation error at line 16 in nullable-union-dictionary.webidl:
+Validation error at line 21 in nullable-union-dictionary.webidl:
   attribute (boolean or Dict)? attr;
                         ^ Nullable union cannot include a dictionary type
-Validation error at line 20 in nullable-union-dictionary.webidl:
+Validation error at line 25 in nullable-union-dictionary.webidl:
   (boolean or Dict)? dict;
               ^ Nullable union cannot include a dictionary type

--- a/test/invalid/idl/nullable-union-dictionary.webidl
+++ b/test/invalid/idl/nullable-union-dictionary.webidl
@@ -8,6 +8,11 @@ typedef (boolean or (short or Dict)?) NestedNullableBooleanDict;
 typedef BooleanDict? ReferencingNullableBooleanDict;
 typedef (boolean or RecursiveBooleanDict? or Dict) RecursiveBooleanDict;
 
+// Safe to have this, because Dict? is not a dictionary type but a nullable type,
+// with its inner type being a dictionary.
+// See: https://heycam.github.io/webidl/#idl-nullable-type
+typedef (boolean or Dict?)? NullableBooleanNullableDict;
+
 callback Callback = (boolean or Dict)? ();
 [Exposed=Window]
 interface Interface {


### PR DESCRIPTION
To align better with [the spec](https://heycam.github.io/webidl/#idl-nullable-type).