### PR TITLE
fix(tokeniser): prevent any use of toString

### DIFF
--- a/lib/tokeniser.js
+++ b/lib/tokeniser.js
@@ -121,9 +121,15 @@ function tokenise(str) {
       }
       if (result === -1) {
         result = attemptTokenMatch("identifier");
-        const token = tokens[tokens.length - 1];
-        if (result !== -1 && nonRegexTerminals.includes(token.value)) {
-          token.type = token.value;
+        const lastIndex = tokens.length - 1;
+        const token = tokens[lastIndex];
+        if (result !== -1) {
+          if (token.value === "toString") {
+            const message = "toString is a reserved identifier and must not be used.";
+            throw new WebIDLParseError(syntaxError(tokens, lastIndex, null, message));
+          } else if (nonRegexTerminals.includes(token.value)) {
+            token.type = token.value;
+          }
         }
       }
     } else if (nextChar === '"') {

--- a/test/invalid/baseline/tostring.txt
+++ b/test/invalid/baseline/tostring.txt
@@ -1,0 +1,3 @@
+Syntax error at line 2:
+  DOMString toString
+            ^ toString is a reserved identifier and must not be used.

--- a/test/invalid/idl/tostring.webidl
+++ b/test/invalid/idl/tostring.webidl
@@ -1,0 +1,3 @@
+interface mixin ToString {
+  DOMString toString();
+};


### PR DESCRIPTION
Closes #230.

I think throwing early on tokenising phase is easiest and best.

This patch includes:
- [x] A relevant test
