### PR TITLE
fix(productions/operation): warn if no operation identifier

### DIFF
--- a/lib/productions/operation.js
+++ b/lib/productions/operation.js
@@ -47,7 +47,7 @@ export class Operation extends Base {
 
   *validate(defs) {
     if (!this.name && ["", "static"].includes(this.special)) {
-      const message = `Regular or static operations must have an identifier.`;
+      const message = `Regular or static operations must have both a return type and an identifier.`;
       yield validationError(this.source, this.tokens.open, this, message);
     }
     if (this.idlType) {

--- a/lib/productions/operation.js
+++ b/lib/productions/operation.js
@@ -47,7 +47,7 @@ export class Operation extends Base {
 
   *validate(defs) {
     if (!this.name && ["", "static"].includes(this.special)) {
-      const message = `Regular or static operations need a proper identifier.`;
+      const message = `Regular or static operations must have an identifier.`;
       yield validationError(this.source, this.tokens.open, this, message);
     }
     if (this.idlType) {

--- a/lib/productions/operation.js
+++ b/lib/productions/operation.js
@@ -1,5 +1,6 @@
 import { Base } from "./base.js";
 import { return_type, argument_list, unescape } from "./helpers.js";
+import { validationError } from "../error.js";
 
 export class Operation extends Base {
   /**
@@ -45,6 +46,10 @@ export class Operation extends Base {
   }
 
   *validate(defs) {
+    if (!this.name && ["", "static"].includes(this.special)) {
+      const message = `Regular or static operations need a proper identifier.`;
+      yield validationError(this.source, this.tokens.open, this, message);
+    }
     if (this.idlType) {
       yield* this.idlType.validate(defs);
     }

--- a/test/invalid/baseline/operation-nameless.txt
+++ b/test/invalid/baseline/operation-nameless.txt
@@ -1,6 +1,6 @@
 Validation error at line 3 in operation-nameless.webidl:
   copy();
-      ^ Regular or static operations need a proper identifier.
+      ^ Regular or static operations must have both a return type and an identifier.
 Validation error at line 4 in operation-nameless.webidl:
   static create();
-               ^ Regular or static operations need a proper identifier.
+               ^ Regular or static operations must have both a return type and an identifier.

--- a/test/invalid/baseline/operation-nameless.txt
+++ b/test/invalid/baseline/operation-nameless.txt
@@ -1,0 +1,6 @@
+Validation error at line 3 in operation-nameless.webidl:
+  copy();
+      ^ Regular or static operations need a proper identifier.
+Validation error at line 4 in operation-nameless.webidl:
+  static create();
+               ^ Regular or static operations need a proper identifier.

--- a/test/invalid/idl/operation-nameless.webidl
+++ b/test/invalid/idl/operation-nameless.webidl
@@ -1,0 +1,9 @@
+[Exposed=Window]
+interface Anonymity {
+  copy();
+  static create();
+  getter DOMString ();
+  setter DOMString ();
+  stringifier DOMString ();
+  stringifier;
+};


### PR DESCRIPTION
[The syntax](https://heycam.github.io/webidl/#prod-OperationRest) somehow allows this, so this patch only warns when if no identifier [per the prose](https://heycam.github.io/webidl/#idl-operations):

>If an operation has no identifier, then it must be declared to be a special operation using one of the special keywords.

This patch includes:
- [x] A relevant test
