### PR TITLE
feat(lib/writer): add hook for nameless members

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ var result = WebIDL2.write(tree, {
      */
     generic: name => name,
     /**
+     * Called for each nameless members, e.g. `stringifier` for `stringifier;` and `constructor` for `constructor();`
+     * @param {string} name The keyword for syntax
+     */
+    nameless: (keyword, { data, parent }) => keyword,
+    /**
      * Called only once for each types, e.g. `Document`, `Promise<DOMString>`, or `sequence<long>`.
      * @param type The `wrap()`ed result of references and syntatic bracket strings.
      */

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -11,6 +11,7 @@ const templates = {
   reference: noop,
   type: noop,
   generic: noop,
+  nameless: noop,
   inheritance: noop,
   definition: noop,
   extendedAttribute: noop,
@@ -135,7 +136,7 @@ export function write(ast, { templates: ts = templates } = {}) {
     ] : [];
     return ts.definition(ts.wrap([
       extended_attributes(it.extAttrs),
-      token(it.tokens.special),
+      it.tokens.name ? token(it.tokens.special) : token(it.tokens.special, ts.nameless, { data: it, parent }),
       ...body,
       token(it.tokens.termination)
     ]), { data: it, parent });
@@ -156,7 +157,7 @@ export function write(ast, { templates: ts = templates } = {}) {
   function constructor(it, parent) {
     return ts.definition(ts.wrap([
       extended_attributes(it.extAttrs),
-      token(it.tokens.base),
+      token(it.tokens.base, ts.nameless, { data: it, parent }),
       token(it.tokens.open),
       ts.wrap(it.arguments.map(argument)),
       token(it.tokens.close),

--- a/test/writer.js
+++ b/test/writer.js
@@ -102,6 +102,15 @@ describe("Writer template functions", () => {
     expect(result).toBe("[Exposed=Window] interface Momo : Kudamono { attribute <Promise><Type> iro; <iterable><float>; };");
   });
 
+  it("catches nameless members", () => {
+    function rewriteNameless(text) {
+      return rewrite(text, { nameless: bracket });
+    }
+
+    const result = rewriteNameless("[Exposed=Window] interface Momo { stringifier; constructor(); getter DOMString (); getter DOMString something(); };");
+    expect(result).toBe("[Exposed=Window] interface Momo { <stringifier>; <constructor>(); <getter> DOMString (); getter DOMString something(); };");
+  });
+
   it("catches types", () => {
     const result = rewrite("interface Momo { attribute Promise<unsigned long> iro; };", {
       type: bracket


### PR DESCRIPTION
Not sure this is best, but it at least provide a way to link constructors and stringifiers (required in https://github.com/w3c/respec/issues/982)

This patch includes:
- [x] A relevant test
- [x] A relevant documentation update
