### PR TITLE
fix(tokeniser): prevent escaping reserved identifiers

### DIFF
--- a/lib/tokeniser.js
+++ b/lib/tokeniser.js
@@ -1,4 +1,5 @@
 import { syntaxError } from "./error.js";
+import { unescape } from "./productions/helpers.js";
 
 // These regular expressions use the sticky flag so they will only match at
 // the current location (ie. the offset of lastIndex).
@@ -132,7 +133,7 @@ function tokenise(str) {
         const token = tokens[lastIndex];
         if (result !== -1) {
           if (reserved.includes(token.value)) {
-            const message = `${token.value} is a reserved identifier and must not be used.`;
+            const message = `${unescape(token.value)} is a reserved identifier and must not be used.`;
             throw new WebIDLParseError(syntaxError(tokens, lastIndex, null, message));
           } else if (nonRegexTerminals.includes(token.value)) {
             token.type = token.value;

--- a/lib/tokeniser.js
+++ b/lib/tokeniser.js
@@ -90,6 +90,13 @@ const punctuations = [
   "}"
 ];
 
+const reserved = [
+  // "constructor" is now a keyword
+  "_constructor",
+  "toString",
+  "_toString",
+];
+
 /**
  * @param {string} str
  */
@@ -124,8 +131,8 @@ function tokenise(str) {
         const lastIndex = tokens.length - 1;
         const token = tokens[lastIndex];
         if (result !== -1) {
-          if (token.value === "toString") {
-            const message = "toString is a reserved identifier and must not be used.";
+          if (reserved.includes(token.value)) {
+            const message = `${token.value} is a reserved identifier and must not be used.`;
             throw new WebIDLParseError(syntaxError(tokens, lastIndex, null, message));
           } else if (nonRegexTerminals.includes(token.value)) {
             token.type = token.value;

--- a/test/invalid/baseline/constructor-escaped.txt
+++ b/test/invalid/baseline/constructor-escaped.txt
@@ -1,0 +1,3 @@
+Syntax error at line 2:
+  object _constructor
+         ^ _constructor is a reserved identifier and must not be used.

--- a/test/invalid/baseline/constructor-escaped.txt
+++ b/test/invalid/baseline/constructor-escaped.txt
@@ -1,3 +1,3 @@
 Syntax error at line 2:
   object _constructor
-         ^ _constructor is a reserved identifier and must not be used.
+         ^ constructor is a reserved identifier and must not be used.

--- a/test/invalid/baseline/tostring-escaped.txt
+++ b/test/invalid/baseline/tostring-escaped.txt
@@ -1,3 +1,3 @@
 Syntax error at line 2:
   DOMString _toString
-            ^ _toString is a reserved identifier and must not be used.
+            ^ toString is a reserved identifier and must not be used.

--- a/test/invalid/baseline/tostring-escaped.txt
+++ b/test/invalid/baseline/tostring-escaped.txt
@@ -1,0 +1,3 @@
+Syntax error at line 2:
+  DOMString _toString
+            ^ _toString is a reserved identifier and must not be used.

--- a/test/invalid/idl/constructor-escaped.webidl
+++ b/test/invalid/idl/constructor-escaped.webidl
@@ -1,0 +1,3 @@
+interface mixin Constructor {
+  object _constructor();
+};

--- a/test/invalid/idl/tostring-escaped.webidl
+++ b/test/invalid/idl/tostring-escaped.webidl
@@ -1,0 +1,3 @@
+interface mixin ToString {
+  DOMString _toString();
+};


### PR DESCRIPTION
Because [the spec says](https://heycam.github.io/webidl/#idl-names):

>For all of these constructs, the identifier is the value of the identifier token with any leading U+005F LOW LINE ("_") character (underscore) removed.

>The identifier of any of the abovementioned IDL constructs must not be "constructor", "toString", or begin with a U+005F LOW LINE ("_") character. These are known as reserved identifiers.

This patch includes:
- [x] A relevant test
