### PR TITLE
fix(productions/interface): put constructor on the top position

### DIFF
--- a/lib/productions/helpers.js
+++ b/lib/productions/helpers.js
@@ -168,6 +168,20 @@ export function stringifier(tokeniser) {
 }
 
 /**
+ * @param {string} str
+ */
+export function getFirstIndentation(str) {
+  const lines = str.split("\n");
+  for (const line of lines) {
+    const match = line.match(/^\s+/);
+    if (match) {
+      return match[0];
+    }
+  }
+  return "";
+}
+
+/**
  * @param {object} def
  * @param {import("./extended-attributes.js").ExtendedAttributes} def.extAttrs
  */

--- a/lib/productions/helpers.js
+++ b/lib/productions/helpers.js
@@ -170,7 +170,7 @@ export function stringifier(tokeniser) {
 /**
  * @param {string} str
  */
-export function getFirstIndentation(str) {
+function getFirstIndentation(str) {
   const lines = str.split("\n");
   for (const line of lines) {
     const match = line.match(/^\s+/);
@@ -179,6 +179,15 @@ export function getFirstIndentation(str) {
     }
   }
   return "";
+}
+
+/**
+ * @param {string} parentTrivia
+ */
+export function getMemberIndentation(parentTrivia) {
+  const indentation = getFirstIndentation(parentTrivia);
+  const indentCh = indentation.includes("\t") ? "\t" : "  ";
+  return indentation + indentCh;
 }
 
 /**

--- a/lib/productions/interface.js
+++ b/lib/productions/interface.js
@@ -85,7 +85,7 @@ function autofixConstructor(interfaceDef, constructorExtAttr) {
     const constructorOp = Constructor.parse(new Tokeniser("\nconstructor();"));
     constructorOp.extAttrs = [];
     constructorOp.arguments = constructorExtAttr.arguments;
-    interfaceDef.members.push(constructorOp);
+    interfaceDef.members.unshift(constructorOp);
     const { extAttrs } = interfaceDef;
     const index = extAttrs.indexOf(constructorExtAttr);
     extAttrs.splice(index, 1);

--- a/lib/productions/interface.js
+++ b/lib/productions/interface.js
@@ -3,7 +3,7 @@ import { Attribute } from "./attribute.js";
 import { Operation } from "./operation.js";
 import { Constant } from "./constant.js";
 import { IterableLike } from "./iterable.js";
-import { stringifier, autofixAddExposedWindow } from "./helpers.js";
+import { stringifier, autofixAddExposedWindow, getFirstIndentation } from "./helpers.js";
 import { validationError } from "../error.js";
 import { checkInterfaceMemberDuplication } from "../validators/interface.js";
 import { Constructor } from "./constructor.js";
@@ -82,7 +82,9 @@ for more information.`;
 
 function autofixConstructor(interfaceDef, constructorExtAttr) {
   return () => {
-    const constructorOp = Constructor.parse(new Tokeniser("\nconstructor();"));
+    const indentation = getFirstIndentation(interfaceDef.tokens.close.trivia);
+    const indentCh = indentation.includes("\t") ? "\t" : "  ";
+    const constructorOp = Constructor.parse(new Tokeniser(`\n${indentation + indentCh}constructor();`));
     constructorOp.extAttrs = [];
     constructorOp.arguments = constructorExtAttr.arguments;
     interfaceDef.members.unshift(constructorOp);

--- a/lib/productions/interface.js
+++ b/lib/productions/interface.js
@@ -3,7 +3,7 @@ import { Attribute } from "./attribute.js";
 import { Operation } from "./operation.js";
 import { Constant } from "./constant.js";
 import { IterableLike } from "./iterable.js";
-import { stringifier, autofixAddExposedWindow, getFirstIndentation } from "./helpers.js";
+import { stringifier, autofixAddExposedWindow, getMemberIndentation } from "./helpers.js";
 import { validationError } from "../error.js";
 import { checkInterfaceMemberDuplication } from "../validators/interface.js";
 import { Constructor } from "./constructor.js";
@@ -82,9 +82,8 @@ for more information.`;
 
 function autofixConstructor(interfaceDef, constructorExtAttr) {
   return () => {
-    const indentation = getFirstIndentation(interfaceDef.tokens.close.trivia);
-    const indentCh = indentation.includes("\t") ? "\t" : "  ";
-    const constructorOp = Constructor.parse(new Tokeniser(`\n${indentation + indentCh}constructor();`));
+    const indentation = getMemberIndentation(interfaceDef.tokens.close.trivia);
+    const constructorOp = Constructor.parse(new Tokeniser(`\n${indentation}constructor();`));
     constructorOp.extAttrs = [];
     constructorOp.arguments = constructorExtAttr.arguments;
     interfaceDef.members.unshift(constructorOp);

--- a/test/autofix.js
+++ b/test/autofix.js
@@ -109,12 +109,14 @@ describe("Writer template functions", () => {
     const input = `
       [Exposed=Window, Constructor(object arg)]
       interface B {
+        attribute any attr;
       };
     `;
     const output = `
       [Exposed=Window]
       interface B {
 constructor(object arg);
+        attribute any attr;
       };
     `;
     expect(autofix(input)).toBe(output);

--- a/test/autofix.js
+++ b/test/autofix.js
@@ -115,7 +115,7 @@ describe("Writer template functions", () => {
     const output = `
       [Exposed=Window]
       interface B {
-constructor(object arg);
+        constructor(object arg);
         attribute any attr;
       };
     `;


### PR DESCRIPTION
Because... It seems this is what people do, https://github.com/heycam/webidl/pull/780 and https://github.com/w3c/speech-api/pull/63 for example.

This patch includes:
- [x] A relevant test