### PR TITLE
fix(productions/interface): whitespace cleanup after autofix

### DIFF
--- a/lib/productions/interface.js
+++ b/lib/productions/interface.js
@@ -89,11 +89,13 @@ function autofixConstructor(interfaceDef, constructorExtAttr) {
     interfaceDef.members.unshift(constructorOp);
     const { extAttrs } = interfaceDef;
     const index = extAttrs.indexOf(constructorExtAttr);
-    extAttrs.splice(index, 1);
+    const removed = extAttrs.splice(index, 1);
     if (!extAttrs.length) {
       extAttrs.tokens.open = extAttrs.tokens.close = undefined;
     } else if (extAttrs.length === index) {
       extAttrs[index - 1].tokens.separator = undefined;
+    } else if (!extAttrs[index].tokens.name.trivia.trim()) {
+      extAttrs[index].tokens.name.trivia = removed[0].tokens.name.trivia;
     }
   };
 }

--- a/test/autofix.js
+++ b/test/autofix.js
@@ -107,13 +107,16 @@ describe("Writer template functions", () => {
 
   it("should add `constructor()` for interfaces with [Constructor]", () => {
     const input = `
-      [Exposed=Window, Constructor(object arg)]
+      [SecureContext, // secure context
+       Constructor(object arg),
+       Exposed=Window]
       interface B {
         attribute any attr;
       };
     `;
     const output = `
-      [Exposed=Window]
+      [SecureContext, // secure context
+       Exposed=Window]
       interface B {
         constructor(object arg);
         attribute any attr;


### PR DESCRIPTION
Currently

```
[Constructor(),
 Exposed=Window]
```

Becomes:

```
[
 Exposed=Window]
```

and this patch generates simple `[Exposed=Window]` instead.


This patch includes:
- [x] A relevant test