### PR TITLE
feat(validations): add rule name

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -15,7 +15,7 @@ function lastLine(text) {
  * @param {"Syntax" | "Validation"} kind error type
  * @param {WebIDL2ErrorOptions} [options]
  */
-function error(source, position, current, message, kind, { level = "error", autofix } = {}) {
+function error(source, position, current, message, kind, { level = "error", autofix, ruleName } = {}) {
   /**
    * @param {number} count
    */
@@ -65,6 +65,7 @@ function error(source, position, current, message, kind, { level = "error", auto
     line,
     sourceName: source.name,
     level,
+    ruleName,
     autofix,
     input: subsequentText,
     tokens: subsequentTokens
@@ -82,6 +83,7 @@ export function syntaxError(source, position, current, message) {
  * @param {string} message error message
  * @param {WebIDL2ErrorOptions} [options]
  */
-export function validationError(token, current, message, options) {
+export function validationError(token, current, ruleName, message, options = {}) {
+  options.ruleName = ruleName;
   return error(current.source, token.index, current, message, "Validation", options);
 }

--- a/lib/productions/argument.js
+++ b/lib/productions/argument.js
@@ -49,10 +49,10 @@ export class Argument extends Base {
     if (idlTypeIncludesDictionary(this.idlType, defs, { useNullableInner: true })) {
       if (this.idlType.nullable) {
         const message = `Dictionary arguments cannot be nullable.`;
-        yield validationError(this.tokens.name, this, message);
+        yield validationError(this.tokens.name, this, "no-nullable-dict-arg", message);
       } else if (this.optional && !this.default) {
         const message = `Optional dictionary arguments must have a default value of \`{}\`.`;
-        yield validationError(this.tokens.name, this, message, {
+        yield validationError(this.tokens.name, this, "dict-arg-default", message, {
           autofix: autofixOptionalDictionaryDefaultValue(this)
         });
       }

--- a/lib/productions/extended-attributes.js
+++ b/lib/productions/extended-attributes.js
@@ -82,7 +82,7 @@ export class SimpleExtendedAttribute extends Base {
 undesirable feature that may be removed from Web IDL in the future. Refer to the \
 [relevant upstream PR](https://github.com/heycam/webidl/pull/609) for more \
 information.`;
-      yield validationError(this.tokens.name, this, message, { level: "warning" });
+      yield validationError(this.tokens.name, this, "no-nointerfaceobject", message, { level: "warning" });
     }
     for (const arg of this.arguments) {
       yield* arg.validate(defs);

--- a/lib/productions/interface.js
+++ b/lib/productions/interface.js
@@ -58,7 +58,7 @@ To fix, add, for example, \`[Exposed=Window]\`. Please also consider carefully \
 if your interface should also be exposed in a Worker scope. Refer to the \
 [WebIDL spec section on Exposed](https://heycam.github.io/webidl/#Exposed) \
 for more information.`;
-      yield validationError(this.tokens.name, this, message, {
+      yield validationError(this.tokens.name, this, "require-exposed", message, {
         autofix: autofixAddExposedWindow(this)
       });
     }
@@ -68,7 +68,7 @@ for more information.`;
 instead of \`[Constructor]\` extended attribute. Refer to the \
 [WebIDL spec section on constructor operations](https://heycam.github.io/webidl/#idl-constructors) \
 for more information.`;
-      yield validationError(constructor.tokens.name, this, message, {
+      yield validationError(constructor.tokens.name, this, "constructor-member", message, {
         autofix: autofixConstructor(this, constructor)
       });
     }

--- a/lib/productions/namespace.js
+++ b/lib/productions/namespace.js
@@ -34,7 +34,7 @@ To fix, add, for example, [Exposed=Window]. Please also consider carefully \
 if your namespace should also be exposed in a Worker scope. Refer to the \
 [WebIDL spec section on Exposed](https://heycam.github.io/webidl/#Exposed) \
 for more information.`;
-      yield validationError(this.tokens.name, this, message, {
+      yield validationError(this.tokens.name, this, "require-exposed", message, {
         autofix: autofixAddExposedWindow(this)
       });
     }

--- a/lib/productions/operation.js
+++ b/lib/productions/operation.js
@@ -48,7 +48,7 @@ export class Operation extends Base {
   *validate(defs) {
     if (!this.name && ["", "static"].includes(this.special)) {
       const message = `Regular or static operations must have both a return type and an identifier.`;
-      yield validationError(this.tokens.open, this, message);
+      yield validationError(this.tokens.open, this, "deficient-op", message);
     }
     if (this.idlType) {
       yield* this.idlType.validate(defs);

--- a/lib/productions/type.js
+++ b/lib/productions/type.js
@@ -162,7 +162,7 @@ export class Type extends Base {
       if (reference) {
         const targetToken = (this.union ? reference : this).tokens.base;
         const message = `Nullable union cannot include a dictionary type`;
-        yield validationError(targetToken, this, message);
+        yield validationError(targetToken, this, "no-nullable-union-dict", message);
       }
     } else {
       // allow some dictionary

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -59,7 +59,7 @@ function* checkDuplicatedNames({ unique, duplicates }) {
   for (const dup of duplicates) {
     const { name } = dup;
     const message = `The name "${name}" of type "${unique.get(name).type}" was already seen`;
-    yield error(dup.tokens.name, dup, message);
+    yield error(dup.tokens.name, dup, "no-duplicate", message);
   }
 }
 

--- a/lib/validators/interface.js
+++ b/lib/validators/interface.js
@@ -17,7 +17,7 @@ export function* checkInterfaceMemberDuplication(defs, i) {
       const { name } = addition;
       if (name && existings.has(name)) {
         const message = `The operation "${name}" has already been defined for the base interface "${base.name}" either in itself or in a mixin`;
-        yield validationError(addition.tokens.name, ext, message);
+        yield validationError(addition.tokens.name, ext, "no-cross-overload", message);
       }
     }
   }


### PR DESCRIPTION
Closes #413 

This change adds `ruleName` field for validations object, so that users can explicitly ignore some potentially breaking validations until users are fully ready to apply them.

(TODO: check the following boxes)

This patch includes:
- [ ] A relevant test
- [ ] A relevant documentation update
