### PR TITLE
fix(productions/interface): correct constructor indentation

### DIFF
--- a/lib/productions/helpers.js
+++ b/lib/productions/helpers.js
@@ -170,10 +170,11 @@ export function stringifier(tokeniser) {
 /**
  * @param {string} str
  */
-function getFirstIndentation(str) {
+export function getLastIndentation(str) {
   const lines = str.split("\n");
-  for (const line of lines) {
-    const match = line.match(/^\s+/);
+  // the first line visually binds to the preceding token
+  if (lines.length) {
+    const match = lines[lines.length - 1].match(/^\s+/);
     if (match) {
       return match[0];
     }
@@ -185,7 +186,7 @@ function getFirstIndentation(str) {
  * @param {string} parentTrivia
  */
 export function getMemberIndentation(parentTrivia) {
-  const indentation = getFirstIndentation(parentTrivia);
+  const indentation = getLastIndentation(parentTrivia);
   const indentCh = indentation.includes("\t") ? "\t" : "  ";
   return indentation + indentCh;
 }

--- a/lib/productions/interface.js
+++ b/lib/productions/interface.js
@@ -3,7 +3,7 @@ import { Attribute } from "./attribute.js";
 import { Operation } from "./operation.js";
 import { Constant } from "./constant.js";
 import { IterableLike } from "./iterable.js";
-import { stringifier, autofixAddExposedWindow, getMemberIndentation } from "./helpers.js";
+import { stringifier, autofixAddExposedWindow, getMemberIndentation, getLastIndentation } from "./helpers.js";
 import { validationError } from "../error.js";
 import { checkInterfaceMemberDuplication } from "../validators/interface.js";
 import { Constructor } from "./constructor.js";
@@ -82,11 +82,17 @@ for more information.`;
 
 function autofixConstructor(interfaceDef, constructorExtAttr) {
   return () => {
-    const indentation = getMemberIndentation(interfaceDef.tokens.close.trivia);
-    const constructorOp = Constructor.parse(new Tokeniser(`\n${indentation}constructor();`));
+    const indentation = getLastIndentation(interfaceDef.extAttrs.tokens.open.trivia);
+    const memberIndent = getMemberIndentation(indentation);
+    const constructorOp = Constructor.parse(new Tokeniser(`\n${memberIndent}constructor();`));
     constructorOp.extAttrs = [];
     constructorOp.arguments = constructorExtAttr.arguments;
     interfaceDef.members.unshift(constructorOp);
+    const { close }  = interfaceDef.tokens;
+    if (!close.trivia.includes("\n")) {
+      close.trivia += `\n${indentation}`;
+    }
+
     const { extAttrs } = interfaceDef;
     const index = extAttrs.indexOf(constructorExtAttr);
     const removed = extAttrs.splice(index, 1);

--- a/test/autofix.js
+++ b/test/autofix.js
@@ -112,6 +112,7 @@ describe("Writer template functions", () => {
        Exposed=Window]
       interface B {
         attribute any attr;
+        // attribute any popipa;
       };
     `;
     const output = `
@@ -120,8 +121,21 @@ describe("Writer template functions", () => {
       interface B {
         constructor(object arg);
         attribute any attr;
+        // attribute any popipa;
       };
     `;
     expect(autofix(input)).toBe(output);
+
+    const inputEmpty = `
+      [Exposed=Window, Constructor]
+      interface C {};
+    `;
+    const outputEmpty = `
+      [Exposed=Window]
+      interface C {
+        constructor();
+      };
+    `;
+    expect(autofix(inputEmpty)).toBe(outputEmpty);
   });
 });


### PR DESCRIPTION
There was a bug that `constructor()` get too much indentation or too less.

This patch includes:
- [x] A relevant test
