### PR TITLE
fix(autofix): support arbitrary indentation

### DIFF
--- a/lib/productions/helpers.js
+++ b/lib/productions/helpers.js
@@ -214,3 +214,15 @@ export function autofixAddExposedWindow(def) {
     }
   };
 }
+
+/**
+ * Get the first syntax token for the given IDL object.
+ * @param {*} data
+ */
+export function getFirstToken(data) {
+  if (data.extAttrs.length) {
+    return data.extAttrs.tokens.open;
+  }
+  const tokens = Object.values(data.tokens).sort((x, y) => x.index - y.index);
+  return tokens[0];
+}

--- a/lib/productions/interface.js
+++ b/lib/productions/interface.js
@@ -3,7 +3,7 @@ import { Attribute } from "./attribute.js";
 import { Operation } from "./operation.js";
 import { Constant } from "./constant.js";
 import { IterableLike } from "./iterable.js";
-import { stringifier, autofixAddExposedWindow, getMemberIndentation, getLastIndentation } from "./helpers.js";
+import { stringifier, autofixAddExposedWindow, getMemberIndentation, getLastIndentation, getFirstToken } from "./helpers.js";
 import { validationError } from "../error.js";
 import { checkInterfaceMemberDuplication } from "../validators/interface.js";
 import { Constructor } from "./constructor.js";
@@ -83,7 +83,9 @@ for more information.`;
 function autofixConstructor(interfaceDef, constructorExtAttr) {
   return () => {
     const indentation = getLastIndentation(interfaceDef.extAttrs.tokens.open.trivia);
-    const memberIndent = getMemberIndentation(indentation);
+    const memberIndent = interfaceDef.members.length ?
+      getLastIndentation(getFirstToken(interfaceDef.members[0]).trivia) :
+      getMemberIndentation(indentation);
     const constructorOp = Constructor.parse(new Tokeniser(`\n${memberIndent}constructor();`));
     constructorOp.extAttrs = [];
     constructorOp.arguments = constructorExtAttr.arguments;

--- a/test/autofix.js
+++ b/test/autofix.js
@@ -139,5 +139,22 @@ describe("Writer template functions", () => {
       };
     `;
     expect(autofix(inputEmpty)).toBe(outputEmpty);
+
+    const input4space = `
+      [Exposed=Window, Constructor]
+      interface C {
+          // more indentation
+          attribute any koala;
+      };
+    `;
+    const output4space = `
+      [Exposed=Window]
+      interface C {
+          constructor();
+          // more indentation
+          attribute any koala;
+      };
+    `;
+    expect(autofix(input4space)).toBe(output4space);
   });
 });

--- a/test/autofix.js
+++ b/test/autofix.js
@@ -190,5 +190,22 @@ describe("Writer template functions", () => {
       };
     `;
     expect(autofix(inputTab)).toBe(outputTab);
+
+    const inputMixedIndent = `
+      [Exposed=Window, Constructor]
+      interface C {
+        attribute any koala;
+          attribute any elephant;
+      };
+    `;
+    const outputMixedIndent = `
+      [Exposed=Window]
+      interface C {
+        constructor();
+        attribute any koala;
+          attribute any elephant;
+      };
+    `;
+    expect(autofix(inputMixedIndent)).toBe(outputMixedIndent);
   });
 });

--- a/test/autofix.js
+++ b/test/autofix.js
@@ -156,5 +156,39 @@ describe("Writer template functions", () => {
       };
     `;
     expect(autofix(input4space)).toBe(output4space);
+
+    const input1space = `
+      [Exposed=Window, Constructor]
+      interface C {
+       // less indentation
+       attribute any koala;
+      };
+    `;
+    const output1space = `
+      [Exposed=Window]
+      interface C {
+       constructor();
+       // less indentation
+       attribute any koala;
+      };
+    `;
+    expect(autofix(input1space)).toBe(output1space);
+
+    const inputTab = `
+      [Exposed=Window, Constructor]
+      interface C {
+      \t// tabbed indentation
+      \tattribute any koala;
+      };
+    `;
+    const outputTab = `
+      [Exposed=Window]
+      interface C {
+      \tconstructor();
+      \t// tabbed indentation
+      \tattribute any koala;
+      };
+    `;
+    expect(autofix(inputTab)).toBe(outputTab);
   });
 });


### PR DESCRIPTION
Because people are using 4 spaces, 3 spaces, 1 space or even `\t`.

This patch includes:
- [x] A relevant test