### PR TITLE
fix(autofix): correct constructor ordering

### DIFF
--- a/lib/productions/interface.js
+++ b/lib/productions/interface.js
@@ -89,7 +89,10 @@ function autofixConstructor(interfaceDef, constructorExtAttr) {
     const constructorOp = Constructor.parse(new Tokeniser(`\n${memberIndent}constructor();`));
     constructorOp.extAttrs = [];
     constructorOp.arguments = constructorExtAttr.arguments;
-    interfaceDef.members.unshift(constructorOp);
+
+    const existingIndex = interfaceDef.members.findIndex(m => m.type === "constructor");
+    interfaceDef.members.splice(existingIndex + 1, 0, constructorOp);
+
     const { close }  = interfaceDef.tokens;
     if (!close.trivia.includes("\n")) {
       close.trivia += `\n${indentation}`;

--- a/test/autofix.js
+++ b/test/autofix.js
@@ -207,5 +207,21 @@ describe("Writer template functions", () => {
       };
     `;
     expect(autofix(inputMixedIndent)).toBe(outputMixedIndent);
+
+    const inputMultiple = `
+      [Exposed=Window, Constructor, Constructor(any chocolate)]
+      interface C {
+        attribute any koala;
+      };
+    `;
+    const outputMultiple = `
+      [Exposed=Window]
+      interface C {
+        constructor();
+        constructor(any chocolate);
+        attribute any koala;
+      };
+    `;
+    expect(autofix(inputMultiple)).toBe(outputMultiple);
   });
 });


### PR DESCRIPTION
Because simple `unshift()` causes reversed order 😄


This patch includes:
- [x] A relevant test
