### PR TITLE
fix(autofix): properly detect operation indentation

### DIFF
--- a/lib/productions/helpers.js
+++ b/lib/productions/helpers.js
@@ -223,6 +223,9 @@ export function getFirstToken(data) {
   if (data.extAttrs.length) {
     return data.extAttrs.tokens.open;
   }
+  if (data.type === "operation") {
+    return getFirstToken(data.idlType);
+  }
   const tokens = Object.values(data.tokens).sort((x, y) => x.index - y.index);
   return tokens[0];
 }

--- a/test/autofix.js
+++ b/test/autofix.js
@@ -191,6 +191,23 @@ describe("Writer template functions", () => {
     `;
     expect(autofix(inputTab)).toBe(outputTab);
 
+    const inputTabOp = `
+      [Exposed=Window, Constructor]
+      interface C {
+      \t// tabbed indentation
+      \tvoid koala();
+      };
+    `;
+    const outputTabOp = `
+      [Exposed=Window]
+      interface C {
+      \tconstructor();
+      \t// tabbed indentation
+      \tvoid koala();
+      };
+    `;
+    expect(autofix(inputTabOp)).toBe(outputTabOp);
+
     const inputMixedIndent = `
       [Exposed=Window, Constructor]
       interface C {


### PR DESCRIPTION
Because operations does not have keywords in front of them.

This patch includes:
- [x] A relevant test