### PR TITLE
fix(productions/extended-attributes): unescape identifier values

### DIFF
--- a/lib/productions/extended-attributes.js
+++ b/lib/productions/extended-attributes.js
@@ -1,7 +1,7 @@
 import { Base } from "./base.js";
 import { ArrayBase } from "./array-base.js";
 import { Token } from "./token.js";
-import { list, argument_list, autoParenter } from "./helpers.js";
+import { list, argument_list, autoParenter, unescape } from "./helpers.js";
 import { validationError } from "../error.js";
 
 /**
@@ -96,7 +96,7 @@ export class SimpleExtendedAttribute extends Base {
     if (!type) {
       return null;
     }
-    const value = type === "identifier-list" ? list : tokens.secondaryName.value;
+    const value = type === "identifier-list" ? list : unescape(tokens.secondaryName.value);
     return { type, value };
   }
   get arguments() {

--- a/lib/productions/token.js
+++ b/lib/productions/token.js
@@ -1,4 +1,5 @@
 import { Base } from "./base.js";
+import { unescape } from "./helpers.js";
 
 export class Token extends Base {
   /**
@@ -15,6 +16,6 @@ export class Token extends Base {
   }
 
   get value() {
-    return this.tokens.value.value;
+    return unescape(this.tokens.value.value);
   }
 }

--- a/test/syntax/baseline/extended-attributes.json
+++ b/test/syntax/baseline/extended-attributes.json
@@ -65,6 +65,31 @@
                     "value": "\"abc\""
                 },
                 "arguments": []
+            },
+            {
+                "type": "extended-attribute",
+                "name": "IdentifierAttr",
+                "rhs": {
+                    "type": "identifier",
+                    "value": "null"
+                },
+                "arguments": []
+            },
+            {
+                "type": "extended-attribute",
+                "name": "IdentifiersAttr",
+                "rhs": {
+                    "type": "identifier-list",
+                    "value": [
+                        {
+                            "value": "null"
+                        },
+                        {
+                            "value": "const"
+                        }
+                    ]
+                },
+                "arguments": []
             }
         ],
         "partial": false

--- a/test/syntax/idl/extended-attributes.webidl
+++ b/test/syntax/idl/extended-attributes.webidl
@@ -7,7 +7,7 @@ interface ServiceWorkerGlobalScope : WorkerGlobalScope {
 
 // Conformance with ExtendedAttributeList grammar in http://www.w3.org/TR/WebIDL/#idl-extended-attributes
 // Section 3.11
-[IntAttr=0, FloatAttr=3.14, StringAttr="abc"]
+[IntAttr=0, FloatAttr=3.14, StringAttr="abc", IdentifierAttr=_null, IdentifiersAttr=(_null, _const)]
 interface IdInterface {};
 
 // Extracted from http://www.w3.org/TR/2016/REC-WebIDL-1-20161215/#Constructor on 2017-5-18 with whitespace differences


### PR DESCRIPTION
A regression found in https://github.com/jsdom/webidl2js/pull/138. cc: @domenic

This patch includes:
- [x] A relevant test
