### PR TITLE
fix(productions/constant): unescape name

### DIFF
--- a/lib/productions/constant.js
+++ b/lib/productions/constant.js
@@ -1,6 +1,6 @@
 import { Base } from "./base.js";
 import { Type } from "./type.js";
-import { const_data, const_value, primitive_type, autoParenter } from "./helpers.js";
+import { const_data, const_value, primitive_type, autoParenter, unescape } from "./helpers.js";
 
 export class Constant extends Base {
   /**

--- a/test/syntax/baseline/constants.json
+++ b/test/syntax/baseline/constants.json
@@ -138,6 +138,23 @@
                 "value": {
                     "type": "NaN"
                 }
+            },
+            {
+                "type": "const",
+                "name": "const",
+                "idlType": {
+                    "type": "const-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "boolean"
+                },
+                "extAttrs": [],
+                "value": {
+                    "type": "boolean",
+                    "value": true
+                }
             }
         ],
         "extAttrs": [],
@@ -146,6 +163,6 @@
     {
         "type": "eof",
         "value": "",
-        "trivia": ""
+        "trivia": "\n"
     }
 ]

--- a/test/syntax/idl/constants.webidl
+++ b/test/syntax/idl/constants.webidl
@@ -8,4 +8,5 @@ interface Util {
   const unrestricted float sobig = Infinity;
   const unrestricted double minusonedividedbyzero = -Infinity;
   const short notanumber = NaN;
+  const boolean _const = true;
 };


### PR DESCRIPTION
Quickfix for https://github.com/jsdom/webidl2js/pull/138#issuecomment-541604206. Thanks for finding bugs, @domenic 👍

This patch closes #__ and includes:
- [x] A relevant test