### PR TITLE
feat(extended-attributes): support decimals/integers

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,6 +711,10 @@ Extended attributes look like this:
    * `"identifier-list"`
    * `"string"`
    * `"string-list"`
+   * `"decimal"`
+   * `"decimal-list"`
+   * `"integer"`
+   * `"integer-list"`
 * `parent`: The container of this type as an Object.
 
 ### Default and Const Values

--- a/lib/productions/extended-attributes.js
+++ b/lib/productions/extended-attributes.js
@@ -9,27 +9,26 @@ import { validationError } from "../error.js";
  * @param {string} tokenName
  */
 function tokens(tokeniser, tokenName) {
-  const toks = list(tokeniser, {
+  return list(tokeniser, {
     parser: Token.parser(tokeniser, tokenName),
     listName: tokenName + " list"
   });
-  return toks;
 }
 
+const extAttrValueSyntax = ["identifier", "decimal", "integer", "string"];
+
 /**
- * This will allow a set of identifiers or strings to be parsed.
+ * This will allow a set of extended attribute values to be parsed.
  * @param {import("../tokeniser").Tokeniser} tokeniser
  */
-function identifiersOrStrings(tokeniser) {
-  let toks = tokens(tokeniser, "identifier");
-  if (toks.length) {
-    return toks;
+function extAttrListItems(tokeniser) {
+  for (const syntax of extAttrValueSyntax) {
+    const toks = tokens(tokeniser, syntax);
+    if (toks.length) {
+      return toks;
+    }
   }
-  toks = tokens(tokeniser, "string");
-  if (toks.length) {
-    return toks;
-  }
-  tokeniser.error(`Expected identifiers or strings but none found`);
+  tokeniser.error(`Expected identifiers, strings, decimals, or integers but none found`);
 }
 
 
@@ -41,13 +40,13 @@ class ExtendedAttributeParameters extends Base {
     const tokens = { assign: tokeniser.consume("=") };
     const ret = autoParenter(new ExtendedAttributeParameters({ source: tokeniser.source, tokens }));
     if (tokens.assign) {
-      tokens.secondaryName = tokeniser.consume("identifier", "decimal", "integer", "string");
+      tokens.secondaryName = tokeniser.consume(...extAttrValueSyntax);
     }
     tokens.open = tokeniser.consume("(");
     if (tokens.open) {
       ret.list = ret.rhsIsList ?
         // [Exposed=(Window,Worker)]
-        identifiersOrStrings(tokeniser) :
+        extAttrListItems(tokeniser) :
         // [NamedConstructor=Audio(DOMString src)] or [Constructor(DOMString str)]
         argument_list(tokeniser);
       tokens.close = tokeniser.consume(")") || tokeniser.error("Unexpected token in extended attribute argument list");

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -93,7 +93,7 @@ export function write(ast, { templates: ts = templates } = {}) {
       token(arg.tokens.separator)
     ]);
   }
-  function string(str) {
+  function extended_attribute_listitem(str) {
     return ts.wrap([
       token(str.tokens.value),
       token(str.tokens.separator)
@@ -117,7 +117,7 @@ export function write(ast, { templates: ts = templates } = {}) {
         ...!it.params.list ? [] :
           it.params.list.map(
             rhsType === "identifier-list" ? id => identifier(id, it) :
-            rhsType === "string-list" ? string :
+            rhsType && rhsType.endsWith("-list") ? extended_attribute_listitem :
             argument
           ),
         token(it.params.tokens.close)

--- a/test/invalid/baseline/extattr-empty-ids.txt
+++ b/test/invalid/baseline/extattr-empty-ids.txt
@@ -1,3 +1,3 @@
 Syntax error at line 1 in extattr-empty-ids.webidl:
 [Exposed=()]
-          ^ Expected identifiers or strings but none found
+          ^ Expected identifiers, strings, decimals, or integers but none found

--- a/test/syntax/baseline/extended-attributes.json
+++ b/test/syntax/baseline/extended-attributes.json
@@ -90,6 +90,19 @@
                     ]
                 },
                 "arguments": []
+            },
+            {
+                "type": "extended-attribute",
+                "name": "FloatList",
+                "rhs": {
+                    "type": "decimal-list",
+                    "value": [
+                        {
+                            "value": "3.14"
+                        }
+                    ]
+                },
+                "arguments": []
             }
         ],
         "partial": false

--- a/test/syntax/baseline/reflector-interface.json
+++ b/test/syntax/baseline/reflector-interface.json
@@ -75,6 +75,44 @@
                 ],
                 "special": "",
                 "readonly": false
+            },
+            {
+                "type": "attribute",
+                "name": "span",
+                "idlType": {
+                    "type": "attribute-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "unsigned long"
+                },
+                "extAttrs": [
+                    {
+                        "type": "extended-attribute",
+                        "name": "Reflect",
+                        "rhs": null,
+                        "arguments": []
+                    },
+                    {
+                        "type": "extended-attribute",
+                        "name": "ReflectRange",
+                        "rhs": {
+                            "type": "integer-list",
+                            "value": [
+                                {
+                                    "value": "1"
+                                },
+                                {
+                                    "value": "4"
+                                }
+                            ]
+                        },
+                        "arguments": []
+                    }
+                ],
+                "special": "",
+                "readonly": false
             }
         ],
         "extAttrs": [],

--- a/test/syntax/idl/extended-attributes.webidl
+++ b/test/syntax/idl/extended-attributes.webidl
@@ -7,7 +7,7 @@ interface ServiceWorkerGlobalScope : WorkerGlobalScope {
 
 // Conformance with ExtendedAttributeList grammar in http://www.w3.org/TR/WebIDL/#idl-extended-attributes
 // Section 3.11
-[IntAttr=0, FloatAttr=3.14, StringAttr="abc", IdentifierAttr=_null, IdentifiersAttr=(_null, _const)]
+[IntAttr=0, FloatAttr=3.14, StringAttr="abc", IdentifierAttr=_null, IdentifiersAttr=(_null, _const), FloatList=(3.14)]
 interface IdInterface {};
 
 // Extracted from http://www.w3.org/TR/2016/REC-WebIDL-1-20161215/#Constructor on 2017-5-18 with whitespace differences

--- a/test/syntax/idl/reflector-interface.webidl
+++ b/test/syntax/idl/reflector-interface.webidl
@@ -2,4 +2,5 @@ interface mixin Reflector {
   [Reflect, ReflectOnly="on"] attribute DOMString toggle;
   // Parens may contain 2 to n values.
   [Reflect=q, ReflectOnly=("anonymous", "use-credentials")] attribute DOMString quarter;
+  [Reflect, ReflectRange=(1, 4)] attribute unsigned long span;
 };


### PR DESCRIPTION
This better conforms with the permissiveness of extended attributes.

This patch closes #455 and includes:
- [x] A relevant test
- [x] A relevant documentation update
