### PR TITLE
Revert "chore(package): add type field (#450)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "build-debug": "npx webpack --mode none"
   },
   "repository": "git://github.com/w3c/webidl2.js",
-  "type": "module",
   "main": "dist/webidl2.js",
   "module": "index.js",
   "files": [


### PR DESCRIPTION
This reverts commit 286942bad1afdbcc0aab1b54294174e8c688e11f.

This solves the failure in #457. [Per the document](https://nodejs.org/api/esm.html#esm_ecmascript_modules) it's still experimental (although [it's recommended](https://medium.com/@nodejs/announcing-core-node-js-support-for-ecmascript-modules-c5d6dc29b663)) and it conflicts with webpack.