### PR TITLE
feat(productions/iterable): support async value iterable

### DIFF
--- a/README.md
+++ b/README.md
@@ -732,7 +732,7 @@ For `"Infinity"`:
 
 * `negative`: Boolean indicating whether this is negative Infinity or not.
 
-### `iterable<>`, `maplike<>`, `setlike<>` declarations
+### `iterable<>`, `async iterable<>`, `maplike<>`, and `setlike<>` declarations
 
 These appear as members of interfaces that look like this:
 
@@ -741,6 +741,7 @@ These appear as members of interfaces that look like this:
   "type": "maplike", // or "iterable" / "setlike"
   "idlType": /* One or two types */ ,
   "readonly": false, // only for maplike and setlike
+  "async": false, // iterable can be async
   "extAttrs": [],
   "parent": { ... }
 }
@@ -751,6 +752,7 @@ The fields are as follows:
 * `type`: Always one of "iterable", "maplike" or "setlike".
 * `idlType`: An array with one or more [IDL Types](#idl-type) representing the declared type arguments.
 * `readonly`: `true` if the maplike or setlike is declared as read only.
+* `async`: `true` if the type is async iterable.
 * `extAttrs`: An array of [extended attributes](#extended-attributes).
 * `parent`: The container of this type as an Object.
 

--- a/lib/productions/iterable.js
+++ b/lib/productions/iterable.js
@@ -23,7 +23,7 @@ export class IterableLike extends Base {
     }
 
     const { type } = ret;
-    const secondTypeRequired = type === "maplike" || ret.async;
+    const secondTypeRequired = type === "maplike";
     const secondTypeAllowed = secondTypeRequired || type === "iterable";
 
     tokens.open = tokeniser.consume("<") || tokeniser.error(`Missing less-than sign \`<\` in ${type} declaration`);

--- a/test/invalid/baseline/async-iterable-single.txt
+++ b/test/invalid/baseline/async-iterable-single.txt
@@ -1,3 +1,0 @@
-Syntax error at line 3 in async-iterable-single.webidl, since `interface AsyncIterable`:
-  async iterable<long>;
-                     ^ Missing second type argument in iterable declaration

--- a/test/invalid/idl/async-iterable-single.webidl
+++ b/test/invalid/idl/async-iterable-single.webidl
@@ -1,4 +1,0 @@
-[Exposed=Window]
-interface AsyncIterable {
-  async iterable<long>;
-};

--- a/test/syntax/baseline/async-iterable.json
+++ b/test/syntax/baseline/async-iterable.json
@@ -80,6 +80,31 @@
         "partial": false
     },
     {
+        "type": "interface",
+        "name": "AsyncValueIterable",
+        "inheritance": null,
+        "members": [
+            {
+                "type": "iterable",
+                "idlType": [
+                    {
+                        "type": null,
+                        "extAttrs": [],
+                        "generic": "",
+                        "nullable": false,
+                        "union": false,
+                        "idlType": "float"
+                    }
+                ],
+                "extAttrs": [],
+                "readonly": false,
+                "async": true
+            }
+        ],
+        "extAttrs": [],
+        "partial": false
+    },
+    {
         "type": "eof",
         "value": "",
         "trivia": "\n"

--- a/test/syntax/idl/async-iterable.webidl
+++ b/test/syntax/idl/async-iterable.webidl
@@ -3,5 +3,9 @@ interface AsyncIterable {
 };
 
 interface AsyncIterableWithExtAttr {
-    async iterable<[XAttr2] DOMString, [XAttr3] long>;
+  async iterable<[XAttr2] DOMString, [XAttr3] long>;
+};
+
+interface AsyncValueIterable {
+  async iterable<float>;
 };


### PR DESCRIPTION
This patch implements async value iterable for #464 and includes:
- [x] A relevant test
- [x] A relevant documentation update
