### PR TITLE
feat(productions/iterable): support async iterable arguments 

### DIFF
--- a/README.md
+++ b/README.md
@@ -742,6 +742,7 @@ These appear as members of interfaces that look like this:
   "idlType": /* One or two types */ ,
   "readonly": false, // only for maplike and setlike
   "async": false, // iterable can be async
+  "arguments": [], // only for async iterable
   "extAttrs": [],
   "parent": { ... }
 }
@@ -753,6 +754,7 @@ The fields are as follows:
 * `idlType`: An array with one or more [IDL Types](#idl-type) representing the declared type arguments.
 * `readonly`: `true` if the maplike or setlike is declared as read only.
 * `async`: `true` if the type is async iterable.
+* `arguments`: An array of arguments if exists, empty otherwise. Currently only `async iterable` supports the syntax.
 * `extAttrs`: An array of [extended attributes](#extended-attributes).
 * `parent`: The container of this type as an Object.
 

--- a/lib/productions/iterable.js
+++ b/lib/productions/iterable.js
@@ -68,4 +68,10 @@ export class IterableLike extends Base {
   get async() {
     return !!this.tokens.async;
   }
+
+  *validate(defs) {
+    for (const argument of this.arguments) {
+      yield* argument.validate(defs);
+    }
+  }
 }

--- a/lib/productions/iterable.js
+++ b/lib/productions/iterable.js
@@ -46,9 +46,9 @@ export class IterableLike extends Base {
 
     if (tokeniser.probe("(")) {
       if (argumentAllowed) {
-        tokens.open = tokeniser.consume("(");
+        tokens.argsOpen = tokeniser.consume("(");
         ret.arguments.push(...argument_list(tokeniser));
-        tokens.close = tokeniser.consume(")") || tokeniser.error("Unterminated async iterable argument list");
+        tokens.argsClose = tokeniser.consume(")") || tokeniser.error("Unterminated async iterable argument list");
       } else {
         tokeniser.error(`Arguments are only allowed for \`async iterable\``);
       }

--- a/lib/productions/iterable.js
+++ b/lib/productions/iterable.js
@@ -1,5 +1,5 @@
 import { Base } from "./base.js";
-import { type_with_extended_attributes, autoParenter } from "./helpers.js";
+import { type_with_extended_attributes, autoParenter, argument_list } from "./helpers.js";
 
 export class IterableLike extends Base {
   /**
@@ -25,10 +25,13 @@ export class IterableLike extends Base {
     const { type } = ret;
     const secondTypeRequired = type === "maplike";
     const secondTypeAllowed = secondTypeRequired || type === "iterable";
+    const argumentAllowed = ret.async && type === "iterable";
 
     tokens.open = tokeniser.consume("<") || tokeniser.error(`Missing less-than sign \`<\` in ${type} declaration`);
     const first = type_with_extended_attributes(tokeniser) || tokeniser.error(`Missing a type argument in ${type} declaration`);
     ret.idlType = [first];
+    ret.arguments = [];
+
     if (secondTypeAllowed) {
       first.tokens.separator = tokeniser.consume(",");
       if (first.tokens.separator) {
@@ -38,7 +41,19 @@ export class IterableLike extends Base {
         tokeniser.error(`Missing second type argument in ${type} declaration`);
       }
     }
+
     tokens.close = tokeniser.consume(">") || tokeniser.error(`Missing greater-than sign \`>\` in ${type} declaration`);
+
+    if (tokeniser.probe("(")) {
+      if (argumentAllowed) {
+        tokens.open = tokeniser.consume("(");
+        ret.arguments.push(...argument_list(tokeniser));
+        tokens.close = tokeniser.consume(")") || tokeniser.error("Unterminated async iterable argument list");
+      } else {
+        tokeniser.error(`Arguments are only allowed for \`async iterable\``);
+      }
+    }
+
     tokens.termination = tokeniser.consume(";") || tokeniser.error(`Missing semicolon after ${type} declaration`);
 
     return ret.this;

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -282,6 +282,9 @@ export function write(ast, { templates: ts = templates } = {}) {
       token(it.tokens.open),
       ts.wrap(it.idlType.map(type)),
       token(it.tokens.close),
+      token(it.tokens.argsOpen),
+      ts.wrap(it.arguments.map(argument)),
+      token(it.tokens.argsClose),
       token(it.tokens.termination)
     ]), { data: it, parent });
   }

--- a/test/invalid/baseline/argument-dict-default.txt
+++ b/test/invalid/baseline/argument-dict-default.txt
@@ -10,3 +10,6 @@
 (dict-arg-default) Validation error at line 18 in argument-dict-default.webidl, inside `argument union`:
   void z(optional Union union);
                         ^ Optional dictionary arguments must have a default value of `{}`.
+(dict-arg-default) Validation error at line 22 in argument-dict-default.webidl, inside `argument union`:
+DOMString>(optional Union union);
+                          ^ Optional dictionary arguments must have a default value of `{}`.

--- a/test/invalid/baseline/argument-dict-nullable.txt
+++ b/test/invalid/baseline/argument-dict-nullable.txt
@@ -19,3 +19,6 @@ boolean or Dict)? union = {})
 (no-nullable-dict-arg) Validation error at line 17 in argument-dict-nullable.webidl, inside `argument req`:
   void r(Required? req);
                    ^ Dictionary arguments cannot be nullable.
+(no-nullable-dict-arg) Validation error at line 19 in argument-dict-nullable.webidl, inside `argument dict`:
+>(optional Dict? dict);
+                 ^ Dictionary arguments cannot be nullable.

--- a/test/invalid/baseline/argument-dict-optional.txt
+++ b/test/invalid/baseline/argument-dict-optional.txt
@@ -13,3 +13,6 @@
 (dict-arg-optional) Validation error at line 36 in argument-dict-optional.webidl, inside `argument lastRequired`:
   void op8(Optional lastRequired, optional DOMString yay
                     ^ Dictionary argument must be optional if it has no required fields
+(dict-arg-optional) Validation error at line 42 in argument-dict-optional.webidl, inside `argument shouldBeOptional`:
+<DOMString>(Optional shouldBeOptional);
+                     ^ Dictionary argument must be optional if it has no required fields

--- a/test/invalid/baseline/async-iterable-unterminated-args.txt
+++ b/test/invalid/baseline/async-iterable-unterminated-args.txt
@@ -1,0 +1,3 @@
+Syntax error at line 3 in async-iterable-unterminated-args.webidl, since `interface X`:
+};
+^ Unterminated async iterable argument list

--- a/test/invalid/baseline/iterable-args.txt
+++ b/test/invalid/baseline/iterable-args.txt
@@ -1,0 +1,3 @@
+Syntax error at line 2 in iterable-args.webidl, since `interface X`:
+  iterable<DOMString>();
+                     ^ Arguments are only allowed for `async iterable`

--- a/test/invalid/baseline/maplike-args.txt
+++ b/test/invalid/baseline/maplike-args.txt
@@ -1,0 +1,3 @@
+Syntax error at line 2 in maplike-args.webidl, since `interface X`:
+<DOMString, ByteString>();
+                       ^ Arguments are only allowed for `async iterable`

--- a/test/invalid/baseline/setlike-args.txt
+++ b/test/invalid/baseline/setlike-args.txt
@@ -1,0 +1,3 @@
+Syntax error at line 2 in setlike-args.webidl, since `interface X`:
+  setlike<DOMString>();
+                    ^ Arguments are only allowed for `async iterable`

--- a/test/invalid/idl/argument-dict-default.webidl
+++ b/test/invalid/idl/argument-dict-default.webidl
@@ -18,4 +18,6 @@ interface X {
   void z(optional Union union);
   void z2(optional Union union = {});
   void r(Required req);
+
+  async iterable<DOMString>(optional Union union);
 };

--- a/test/invalid/idl/argument-dict-nullable.webidl
+++ b/test/invalid/idl/argument-dict-nullable.webidl
@@ -15,4 +15,6 @@ interface X {
   void y2(optional (boolean or Dict)? union = {});
   void z2(optional Union? union = {});
   void r(Required? req);
+
+  async iterable<DOMString>(optional Dict? dict);
 };

--- a/test/invalid/idl/argument-dict-optional.webidl
+++ b/test/invalid/idl/argument-dict-optional.webidl
@@ -36,3 +36,8 @@ interface mixin Container {
   void op8(Optional lastRequired, optional DOMString yay);
   void op9(Optional notLast, DOMString yay);
 };
+
+[Exposed=Window]
+interface ContainerInterface {
+  async iterable<DOMString>(Optional shouldBeOptional);
+};

--- a/test/invalid/idl/async-iterable-unterminated-args.webidl
+++ b/test/invalid/idl/async-iterable-unterminated-args.webidl
@@ -1,0 +1,3 @@
+interface X {
+  async iterable<DOMString>(
+};

--- a/test/invalid/idl/iterable-args.webidl
+++ b/test/invalid/idl/iterable-args.webidl
@@ -1,0 +1,3 @@
+interface X {
+  iterable<DOMString>();
+};

--- a/test/invalid/idl/maplike-args.webidl
+++ b/test/invalid/idl/maplike-args.webidl
@@ -1,0 +1,3 @@
+interface X {
+  maplike<DOMString, ByteString>();
+};

--- a/test/invalid/idl/setlike-args.webidl
+++ b/test/invalid/idl/setlike-args.webidl
@@ -1,0 +1,3 @@
+interface X {
+  setlike<DOMString>();
+};

--- a/test/syntax/baseline/async-iterable.json
+++ b/test/syntax/baseline/async-iterable.json
@@ -24,6 +24,7 @@
                         "idlType": "float"
                     }
                 ],
+                "arguments": [],
                 "extAttrs": [],
                 "readonly": false,
                 "async": true
@@ -71,6 +72,92 @@
                         "idlType": "long"
                     }
                 ],
+                "arguments": [],
+                "extAttrs": [],
+                "readonly": false,
+                "async": true
+            }
+        ],
+        "extAttrs": [],
+        "partial": false
+    },
+    {
+        "type": "interface",
+        "name": "AsyncIterableWithNoParam",
+        "inheritance": null,
+        "members": [
+            {
+                "type": "iterable",
+                "idlType": [
+                    {
+                        "type": null,
+                        "extAttrs": [],
+                        "generic": "",
+                        "nullable": false,
+                        "union": false,
+                        "idlType": "float"
+                    },
+                    {
+                        "type": null,
+                        "extAttrs": [],
+                        "generic": "",
+                        "nullable": false,
+                        "union": false,
+                        "idlType": "ByteString"
+                    }
+                ],
+                "arguments": [],
+                "extAttrs": [],
+                "readonly": false,
+                "async": true
+            }
+        ],
+        "extAttrs": [],
+        "partial": false
+    },
+    {
+        "type": "interface",
+        "name": "AsyncIterableWithParam",
+        "inheritance": null,
+        "members": [
+            {
+                "type": "iterable",
+                "idlType": [
+                    {
+                        "type": null,
+                        "extAttrs": [],
+                        "generic": "",
+                        "nullable": false,
+                        "union": false,
+                        "idlType": "float"
+                    },
+                    {
+                        "type": null,
+                        "extAttrs": [],
+                        "generic": "",
+                        "nullable": false,
+                        "union": false,
+                        "idlType": "ByteString"
+                    }
+                ],
+                "arguments": [
+                    {
+                        "type": "argument",
+                        "name": "str",
+                        "extAttrs": [],
+                        "idlType": {
+                            "type": "argument-type",
+                            "extAttrs": [],
+                            "generic": "",
+                            "nullable": false,
+                            "union": false,
+                            "idlType": "USVString"
+                        },
+                        "default": null,
+                        "optional": false,
+                        "variadic": false
+                    }
+                ],
                 "extAttrs": [],
                 "readonly": false,
                 "async": true
@@ -94,6 +181,92 @@
                         "nullable": false,
                         "union": false,
                         "idlType": "float"
+                    }
+                ],
+                "arguments": [],
+                "extAttrs": [],
+                "readonly": false,
+                "async": true
+            }
+        ],
+        "extAttrs": [],
+        "partial": false
+    },
+    {
+        "type": "interface",
+        "name": "AsyncValueIterableWithNoParam",
+        "inheritance": null,
+        "members": [
+            {
+                "type": "iterable",
+                "idlType": [
+                    {
+                        "type": null,
+                        "extAttrs": [],
+                        "generic": "",
+                        "nullable": false,
+                        "union": false,
+                        "idlType": "float"
+                    }
+                ],
+                "arguments": [],
+                "extAttrs": [],
+                "readonly": false,
+                "async": true
+            }
+        ],
+        "extAttrs": [],
+        "partial": false
+    },
+    {
+        "type": "interface",
+        "name": "AsyncValueIterableWithParams",
+        "inheritance": null,
+        "members": [
+            {
+                "type": "iterable",
+                "idlType": [
+                    {
+                        "type": null,
+                        "extAttrs": [],
+                        "generic": "",
+                        "nullable": false,
+                        "union": false,
+                        "idlType": "float"
+                    }
+                ],
+                "arguments": [
+                    {
+                        "type": "argument",
+                        "name": "str",
+                        "extAttrs": [],
+                        "idlType": {
+                            "type": "argument-type",
+                            "extAttrs": [],
+                            "generic": "",
+                            "nullable": false,
+                            "union": false,
+                            "idlType": "DOMString"
+                        },
+                        "default": null,
+                        "optional": false,
+                        "variadic": false
+                    },
+                    {
+                        "type": "argument",
+                        "name": "s",
+                        "extAttrs": [],
+                        "idlType": {
+                            "type": "argument-type",
+                            "extAttrs": [],
+                            "generic": "",
+                            "nullable": false,
+                            "union": false,
+                            "idlType": "short"
+                        },
+                        "default": null,
+                        "optional": false,
+                        "variadic": false
                     }
                 ],
                 "extAttrs": [],

--- a/test/syntax/baseline/iterable.json
+++ b/test/syntax/baseline/iterable.json
@@ -16,6 +16,7 @@
                         "idlType": "long"
                     }
                 ],
+                "arguments": [],
                 "extAttrs": [],
                 "readonly": false,
                 "async": false
@@ -49,6 +50,7 @@
                         "idlType": "double"
                     }
                 ],
+                "arguments": [],
                 "extAttrs": [],
                 "readonly": false,
                 "async": false
@@ -81,6 +83,7 @@
                         "idlType": "long"
                     }
                 ],
+                "arguments": [],
                 "extAttrs": [],
                 "readonly": false,
                 "async": false

--- a/test/syntax/baseline/maplike.json
+++ b/test/syntax/baseline/maplike.json
@@ -24,6 +24,7 @@
                         "idlType": "float"
                     }
                 ],
+                "arguments": [],
                 "extAttrs": [],
                 "readonly": false,
                 "async": false
@@ -57,6 +58,7 @@
                         "idlType": "float"
                     }
                 ],
+                "arguments": [],
                 "extAttrs": [],
                 "readonly": true,
                 "async": false
@@ -104,6 +106,7 @@
                         "idlType": "long"
                     }
                 ],
+                "arguments": [],
                 "extAttrs": [],
                 "readonly": false,
                 "async": false

--- a/test/syntax/baseline/setlike.json
+++ b/test/syntax/baseline/setlike.json
@@ -16,6 +16,7 @@
                         "idlType": "long"
                     }
                 ],
+                "arguments": [],
                 "extAttrs": [],
                 "readonly": false,
                 "async": false
@@ -41,6 +42,7 @@
                         "idlType": "long"
                     }
                 ],
+                "arguments": [],
                 "extAttrs": [],
                 "readonly": true,
                 "async": false
@@ -73,6 +75,7 @@
                         "idlType": "long"
                     }
                 ],
+                "arguments": [],
                 "extAttrs": [],
                 "readonly": false,
                 "async": false

--- a/test/syntax/idl/async-iterable.webidl
+++ b/test/syntax/idl/async-iterable.webidl
@@ -6,6 +6,22 @@ interface AsyncIterableWithExtAttr {
   async iterable<[XAttr2] DOMString, [XAttr3] long>;
 };
 
+interface AsyncIterableWithNoParam {
+  async iterable<float, ByteString>();
+};
+
+interface AsyncIterableWithParam {
+  async iterable<float, ByteString>(USVString str);
+};
+
 interface AsyncValueIterable {
   async iterable<float>;
+};
+
+interface AsyncValueIterableWithNoParam {
+  async iterable<float>();
+};
+
+interface AsyncValueIterableWithParams {
+  async iterable<float>(DOMString str, short s);
 };


### PR DESCRIPTION
This patch closes #464 and includes:
- [x] A relevant test
- [x] A relevant documentation update
