### PR TITLE
chore(README): Update documentation for constant values

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,9 +728,9 @@ values, all of which have the following fields:
 
 * `type`: One of `"string"`, `"number"`, `"boolean"`, `"null"`, `"Infinity"`, `"NaN"`, `"sequence"` or `"dictionary"`.
 
-For `"string"`, `"number"`, `"boolean"`, and `"sequence"`:
+For `"boolean"`, `"string"`, `"number"`, and `"sequence"`:
 
-* `value`: The value of the given type, as a string. For sequence, the only possible value is `[]`.
+* `value`: The value of the given type.  For string and number types, the value is given as a string.  For booleans, the possible values are `true` and `false`. For sequence, the only possible value is `[]`.
 
 For `"Infinity"`:
 


### PR DESCRIPTION
Constant values of type boolean and sequence types are not stored as strings.

This patch closes #535 and includes:
- [ ] A relevant test
- [x] A relevant documentation update
