### PR TITLE
fix(package): allow require() for commonjs use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
-dist/
+dist/*
+!dist/package.json

--- a/dist/package.json
+++ b/dist/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,10 @@
   },
   "repository": "git://github.com/w3c/webidl2.js",
   "main": "dist/webidl2.js",
-  "exports": "./index.js",
+  "exports": {
+    "import": "./index.js",
+    "require": "./dist/webidl2.js"
+  },
   "type": "module",
   "files": [
     "dist/*",

--- a/test/commonjs.cjs
+++ b/test/commonjs.cjs
@@ -1,0 +1,8 @@
+const expect = require("expect");
+const webidl2 = require("webidl2");
+
+describe("CommonJS import", () => {
+  it("require() gets the relevant items", () => {
+    expect(webidl2.parse).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Okay, it turns out @exe-boss was right, and simple `exports` blocks CommonJS imports. I should have read https://github.com/w3c/webidl2.js/pull/556#discussion_r609879465 more carefully, especially https://nodejs.org/api/packages.html#packages_conditional_exports 😬

Somehow I thought Node would wrap ES modules to CommonJS as they do vise versa, but it doesn't.