### PR TITLE
refactor: rename consumeType to consumeKind

### DIFF
--- a/lib/productions/argument.js
+++ b/lib/productions/argument.js
@@ -37,7 +37,7 @@ export class Argument extends Base {
       tokens.variadic = tokeniser.consume("...");
     }
     tokens.name =
-      tokeniser.consumeType("identifier") ||
+      tokeniser.consumeKind("identifier") ||
       tokeniser.consume(...argumentNameKeywords);
     if (!tokens.name) {
       return tokeniser.unconsume(start_position);

--- a/lib/productions/attribute.js
+++ b/lib/productions/attribute.js
@@ -39,7 +39,7 @@ export class Attribute extends Base {
       type_with_extended_attributes(tokeniser, "attribute-type") ||
       tokeniser.error("Attribute lacks a type");
     tokens.name =
-      tokeniser.consumeType("identifier") ||
+      tokeniser.consumeKind("identifier") ||
       tokeniser.consume("async", "required") ||
       tokeniser.error("Attribute lacks a name");
     tokens.termination =

--- a/lib/productions/callback.js
+++ b/lib/productions/callback.js
@@ -16,7 +16,7 @@ export class CallbackFunction extends Base {
       new CallbackFunction({ source: tokeniser.source, tokens })
     );
     tokens.name =
-      tokeniser.consumeType("identifier") ||
+      tokeniser.consumeKind("identifier") ||
       tokeniser.error("Callback lacks a name");
     tokeniser.current = ret.this;
     tokens.assign =

--- a/lib/productions/constant.js
+++ b/lib/productions/constant.js
@@ -22,7 +22,7 @@ export class Constant extends Base {
     let idlType = primitive_type(tokeniser);
     if (!idlType) {
       const base =
-        tokeniser.consumeType("identifier") ||
+        tokeniser.consumeKind("identifier") ||
         tokeniser.error("Const lacks a type");
       idlType = new Type({ source: tokeniser.source, tokens: { base } });
     }
@@ -31,7 +31,7 @@ export class Constant extends Base {
     }
     idlType.type = "const-type";
     tokens.name =
-      tokeniser.consumeType("identifier") ||
+      tokeniser.consumeKind("identifier") ||
       tokeniser.error("Const lacks a name");
     tokens.assign =
       tokeniser.consume("=") || tokeniser.error("Const lacks value assignment");

--- a/lib/productions/container.js
+++ b/lib/productions/container.js
@@ -11,7 +11,7 @@ function inheritance(tokeniser) {
     return {};
   }
   const inheritance =
-    tokeniser.consumeType("identifier") ||
+    tokeniser.consumeKind("identifier") ||
     tokeniser.error("Inheritance lacks a type");
   return { colon, inheritance };
 }
@@ -26,7 +26,7 @@ export class Container extends Base {
   static parse(tokeniser, instance, { type, inheritable, allowedMembers }) {
     const { tokens } = instance;
     tokens.name =
-      tokeniser.consumeType("identifier") ||
+      tokeniser.consumeKind("identifier") ||
       tokeniser.error(`Missing name in ${instance.type}`);
     tokeniser.current = instance;
     instance = autoParenter(instance);

--- a/lib/productions/default.js
+++ b/lib/productions/default.js
@@ -12,7 +12,7 @@ export class Default extends Base {
     }
     const def =
       const_value(tokeniser) ||
-      tokeniser.consumeType("string") ||
+      tokeniser.consumeKind("string") ||
       tokeniser.consume("null", "[", "{") ||
       tokeniser.error("No value for default");
     const expression = [def];

--- a/lib/productions/enum.js
+++ b/lib/productions/enum.js
@@ -7,7 +7,7 @@ class EnumValue extends Token {
    * @param {import("../tokeniser").Tokeniser} tokeniser
    */
   static parse(tokeniser) {
-    const value = tokeniser.consumeType("string");
+    const value = tokeniser.consumeKind("string");
     if (value) {
       return new EnumValue({ source: tokeniser.source, tokens: { value } });
     }
@@ -46,7 +46,7 @@ export class Enum extends Base {
       return;
     }
     tokens.name =
-      tokeniser.consumeType("identifier") ||
+      tokeniser.consumeKind("identifier") ||
       tokeniser.error("No name for enum");
     const ret = autoParenter(new Enum({ source: tokeniser.source, tokens }));
     tokeniser.current = ret.this;
@@ -56,7 +56,7 @@ export class Enum extends Base {
       allowDangler: true,
       listName: "enumeration",
     });
-    if (tokeniser.probeType("string")) {
+    if (tokeniser.probeKind("string")) {
       tokeniser.error("No comma between enum values");
     }
     tokens.close =

--- a/lib/productions/extended-attributes.js
+++ b/lib/productions/extended-attributes.js
@@ -58,7 +58,7 @@ class ExtendedAttributeParameters extends Base {
       new ExtendedAttributeParameters({ source: tokeniser.source, tokens })
     );
     if (tokens.assign) {
-      tokens.secondaryName = tokeniser.consumeType(...extAttrValueSyntax);
+      tokens.secondaryName = tokeniser.consumeKind(...extAttrValueSyntax);
     }
     tokens.open = tokeniser.consume("(");
     if (tokens.open) {
@@ -122,7 +122,7 @@ export class SimpleExtendedAttribute extends Base {
    * @param {import("../tokeniser").Tokeniser} tokeniser
    */
   static parse(tokeniser) {
-    const name = tokeniser.consumeType("identifier");
+    const name = tokeniser.consumeKind("identifier");
     if (name) {
       return new SimpleExtendedAttribute({
         source: tokeniser.source,

--- a/lib/productions/field.js
+++ b/lib/productions/field.js
@@ -21,7 +21,7 @@ export class Field extends Base {
       type_with_extended_attributes(tokeniser, "dictionary-type") ||
       tokeniser.error("Dictionary member lacks a type");
     tokens.name =
-      tokeniser.consumeType("identifier") ||
+      tokeniser.consumeKind("identifier") ||
       tokeniser.error("Dictionary member lacks a name");
     ret.default = Default.parse(tokeniser);
     if (tokens.required && ret.default)

--- a/lib/productions/helpers.js
+++ b/lib/productions/helpers.js
@@ -50,7 +50,7 @@ export function list(tokeniser, { parser, allowDangler, listName = "list" }) {
  */
 export function const_value(tokeniser) {
   return (
-    tokeniser.consumeType("decimal", "integer") ||
+    tokeniser.consumeKind("decimal", "integer") ||
     tokeniser.consume("true", "false", "Infinity", "-Infinity", "NaN")
   );
 }

--- a/lib/productions/includes.js
+++ b/lib/productions/includes.js
@@ -8,7 +8,7 @@ export class Includes extends Base {
    * @param {import("../tokeniser").Tokeniser} tokeniser
    */
   static parse(tokeniser) {
-    const target = tokeniser.consumeType("identifier");
+    const target = tokeniser.consumeKind("identifier");
     if (!target) {
       return;
     }
@@ -19,7 +19,7 @@ export class Includes extends Base {
       return;
     }
     tokens.mixin =
-      tokeniser.consumeType("identifier") ||
+      tokeniser.consumeKind("identifier") ||
       tokeniser.error("Incomplete includes statement");
     tokens.termination =
       tokeniser.consume(";") ||

--- a/lib/productions/operation.js
+++ b/lib/productions/operation.js
@@ -34,7 +34,7 @@ export class Operation extends Base {
     ret.idlType =
       return_type(tokeniser) || tokeniser.error("Missing return type");
     tokens.name =
-      tokeniser.consumeType("identifier") || tokeniser.consume("includes");
+      tokeniser.consumeKind("identifier") || tokeniser.consume("includes");
     tokens.open =
       tokeniser.consume("(") || tokeniser.error("Invalid operation");
     ret.arguments = argument_list(tokeniser);

--- a/lib/productions/token.js
+++ b/lib/productions/token.js
@@ -38,7 +38,7 @@ export class Eof extends WrappedToken {
    * @param {import("../tokeniser").Tokeniser} tokeniser
    */
   static parse(tokeniser) {
-    const value = tokeniser.consumeType("eof");
+    const value = tokeniser.consumeKind("eof");
     if (value) {
       return new Eof({ source: tokeniser.source, tokens: { value } });
     }

--- a/lib/productions/token.js
+++ b/lib/productions/token.js
@@ -10,7 +10,7 @@ export class Token extends Base {
    */
   static parser(tokeniser, type) {
     return () => {
-      const value = tokeniser.consumeType(type);
+      const value = tokeniser.consumeKind(type);
       if (value) {
         return new Token({ source: tokeniser.source, tokens: { value } });
       }

--- a/lib/productions/type.js
+++ b/lib/productions/type.js
@@ -98,7 +98,7 @@ function single_type(tokeniser, typeName) {
   let ret = generic_type(tokeniser, typeName) || primitive_type(tokeniser);
   if (!ret) {
     const base =
-      tokeniser.consumeType("identifier") ||
+      tokeniser.consumeKind("identifier") ||
       tokeniser.consume(...stringTypes, ...typeNameKeywords);
     if (!base) {
       return;

--- a/lib/productions/typedef.js
+++ b/lib/productions/typedef.js
@@ -21,7 +21,7 @@ export class Typedef extends Base {
       type_with_extended_attributes(tokeniser, "typedef-type") ||
       tokeniser.error("Typedef lacks a type");
     tokens.name =
-      tokeniser.consumeType("identifier") ||
+      tokeniser.consumeKind("identifier") ||
       tokeniser.error("Typedef lacks a name");
     tokeniser.current = ret.this;
     tokens.termination =

--- a/lib/tokeniser.js
+++ b/lib/tokeniser.js
@@ -242,7 +242,7 @@ export class Tokeniser {
   /**
    * @param {string} type
    */
-  probeType(type) {
+  probeKind(type) {
     return (
       this.source.length > this.position &&
       this.source[this.position].type === type
@@ -254,16 +254,16 @@ export class Tokeniser {
    */
   probe(value) {
     return (
-      this.probeType("inline") && this.source[this.position].value === value
+      this.probeKind("inline") && this.source[this.position].value === value
     );
   }
 
   /**
    * @param  {...string} candidates
    */
-  consumeType(...candidates) {
+  consumeKind(...candidates) {
     for (const type of candidates) {
-      if (!this.probeType(type)) continue;
+      if (!this.probeKind(type)) continue;
       const token = this.source[this.position];
       this.position++;
       return token;
@@ -274,7 +274,7 @@ export class Tokeniser {
    * @param  {...string} candidates
    */
   consume(...candidates) {
-    if (!this.probeType("inline")) return;
+    if (!this.probeKind("inline")) return;
     const token = this.source[this.position];
     for (const value of candidates) {
       if (token.value !== value) continue;

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -83,7 +83,7 @@ function parseByTokens(tokeniser, options) {
       autoParenter(def).extAttrs = ea;
       defs.push(def);
     }
-    const eof = tokeniser.consumeType("eof");
+    const eof = tokeniser.consumeKind("eof");
     if (options.concrete) {
       defs.push(eof);
     }


### PR DESCRIPTION
"type" has a special meaning in Web IDL (idl type), so probably better to use "kind" rather than overloading the word.

This patch closes #__ and includes:
- [x] A relevant test
- [x] A relevant documentation update
