### PR TITLE
refactor: wrap EOF token

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,8 +331,7 @@ The fields are as follows:
 ### Callback Interfaces
 
 These are captured by the same structure as [Interfaces](#interface) except that
-their `type` field is "callback interface". Its trivia object additionally
-includes a new field `callback`.
+their `type` field is "callback interface".
 
 ### Callback
 
@@ -775,8 +774,7 @@ The fields are as follows:
 ```js
 {
   "type": "eof",
-  "value": "",
-  "trivia": "\n"
+  "value": ""
 }
 ```
 
@@ -787,7 +785,6 @@ The fields are as follows:
 
 * `type`: Always "eof"
 * `value`: Always an empty string.
-* `trivia`: Any whitespaces and comments after the last token and before the EOF.
 
 ## Testing
 

--- a/lib/productions/argument.js
+++ b/lib/productions/argument.js
@@ -140,9 +140,9 @@ function autofixDictionaryArgumentOptionality(arg) {
   return () => {
     const firstToken = getFirstToken(arg.idlType);
     arg.tokens.optional = {
+      ...firstToken,
       type: "optional",
       value: "optional",
-      trivia: firstToken.trivia,
     };
     firstToken.trivia = " ";
     autofixOptionalDictionaryDefaultValue(arg)();

--- a/lib/productions/extended-attributes.js
+++ b/lib/productions/extended-attributes.js
@@ -92,12 +92,6 @@ class ExtendedAttributeParameters extends Base {
 
   /** @param {import("../writer.js").Writer)} w */
   write(w) {
-    function extended_attribute_listitem(item) {
-      return w.ts.wrap([
-        w.token(item.tokens.value),
-        w.token(item.tokens.separator),
-      ]);
-    }
     const { rhsType } = this;
     return w.ts.wrap([
       w.token(this.tokens.assign),
@@ -108,8 +102,6 @@ class ExtendedAttributeParameters extends Base {
         : this.list.map((p) => {
             return rhsType === "identifier-list"
               ? w.identifier(p, this)
-              : rhsType && rhsType.endsWith("-list")
-              ? extended_attribute_listitem(p)
               : p.write(w);
           })),
       w.token(this.tokens.close),

--- a/lib/productions/token.js
+++ b/lib/productions/token.js
@@ -20,4 +20,28 @@ export class Token extends Base {
   get value() {
     return unescape(this.tokens.value.value);
   }
+
+  /** @param {import("../writer").Writer} w */
+  write(w) {
+    return w.ts.wrap([
+      w.token(this.tokens.value),
+      w.token(this.tokens.separator),
+    ]);
+  }
+}
+
+export class Eof extends Token {
+  /**
+   * @param {import("../tokeniser").Tokeniser} tokeniser
+   */
+  static parse(tokeniser) {
+    const value = tokeniser.consumeType("eof");
+    if (value) {
+      return new Eof({ source: tokeniser.source, tokens: { value } });
+    }
+  }
+
+  get type() {
+    return "eof";
+  }
 }

--- a/lib/productions/token.js
+++ b/lib/productions/token.js
@@ -33,7 +33,7 @@ export class WrappedToken extends Base {
   }
 }
 
-export class Eof extends Token {
+export class Eof extends WrappedToken {
   /**
    * @param {import("../tokeniser").Tokeniser} tokeniser
    */

--- a/lib/tokeniser.js
+++ b/lib/tokeniser.js
@@ -196,6 +196,8 @@ function tokenise(str) {
     type: "eof",
     value: "",
     trivia,
+    line,
+    index,
   });
 
   return tokens;

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -10,6 +10,7 @@ import { Dictionary } from "./productions/dictionary.js";
 import { Namespace } from "./productions/namespace.js";
 import { CallbackInterface } from "./productions/callback-interface.js";
 import { autoParenter } from "./productions/helpers.js";
+import { Eof } from "./productions/token.js";
 
 /**
  * @param {Tokeniser} tokeniser
@@ -83,7 +84,7 @@ function parseByTokens(tokeniser, options) {
       autoParenter(def).extAttrs = ea;
       defs.push(def);
     }
-    const eof = tokeniser.consumeType("eof");
+    const eof = Eof.parse(tokeniser);
     if (options.concrete) {
       defs.push(eof);
     }

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -57,11 +57,5 @@ export function write(ast, { templates: ts = templates } = {}) {
 
   const w = new Writer(ts);
 
-  function dispatch(it) {
-    if (it.type === "eof") {
-      return ts.trivia(it.trivia);
-    }
-    return it.write(w);
-  }
-  return ts.wrap(ast.map(dispatch));
+  return ts.wrap(ast.map((it) => it.write(w)));
 }

--- a/test/syntax.js
+++ b/test/syntax.js
@@ -27,6 +27,6 @@ describe("Newlines", () => {
   it("should match CRLF within a comment", () => {
     const comment = "/*\r\n * this comment is multiline with CRLF\r\n*/";
     const parsed = parse(comment, { concrete: true });
-    expect(parsed[0].trivia).toBe(comment);
+    expect(parsed[0].tokens.value.trivia).toBe(comment);
   });
 });

--- a/test/syntax/baseline/allowany.json
+++ b/test/syntax/baseline/allowany.json
@@ -96,7 +96,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/argument-constructor.json
+++ b/test/syntax/baseline/argument-constructor.json
@@ -52,7 +52,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/argument-extattrs.json
+++ b/test/syntax/baseline/argument-extattrs.json
@@ -56,7 +56,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/async-iterable.json
+++ b/test/syntax/baseline/async-iterable.json
@@ -279,7 +279,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/async-name.json
+++ b/test/syntax/baseline/async-name.json
@@ -67,7 +67,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/attributes.json
+++ b/test/syntax/baseline/attributes.json
@@ -40,7 +40,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/bigint.json
+++ b/test/syntax/baseline/bigint.json
@@ -151,7 +151,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/buffersource.json
+++ b/test/syntax/baseline/buffersource.json
@@ -500,7 +500,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/callback.json
+++ b/test/syntax/baseline/callback.json
@@ -120,7 +120,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/comment.json
+++ b/test/syntax/baseline/comment.json
@@ -1,7 +1,6 @@
 [
     {
         "type": "eof",
-        "value": "",
-        "trivia": "/** 25 **/\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/constants.json
+++ b/test/syntax/baseline/constants.json
@@ -162,7 +162,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/constructor.json
+++ b/test/syntax/baseline/constructor.json
@@ -192,7 +192,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/default.json
+++ b/test/syntax/baseline/default.json
@@ -97,7 +97,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/dictionary-inherits.json
+++ b/test/syntax/baseline/dictionary-inherits.json
@@ -84,7 +84,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": ""
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/dictionary.json
+++ b/test/syntax/baseline/dictionary.json
@@ -158,7 +158,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/documentation-dos.json
+++ b/test/syntax/baseline/documentation-dos.json
@@ -9,7 +9,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/documentation.json
+++ b/test/syntax/baseline/documentation.json
@@ -9,7 +9,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": ""
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/enum.json
+++ b/test/syntax/baseline/enum.json
@@ -126,7 +126,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/equivalent-decl.json
+++ b/test/syntax/baseline/equivalent-decl.json
@@ -289,7 +289,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/escaped-name.json
+++ b/test/syntax/baseline/escaped-name.json
@@ -15,7 +15,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/escaped-type.json
+++ b/test/syntax/baseline/escaped-type.json
@@ -36,7 +36,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/extended-attributes.json
+++ b/test/syntax/baseline/extended-attributes.json
@@ -266,7 +266,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/generic.json
+++ b/test/syntax/baseline/generic.json
@@ -214,7 +214,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/getter-setter.json
+++ b/test/syntax/baseline/getter-setter.json
@@ -105,7 +105,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/identifier-hyphen.json
+++ b/test/syntax/baseline/identifier-hyphen.json
@@ -42,7 +42,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/identifier-qualified-names.json
+++ b/test/syntax/baseline/identifier-qualified-names.json
@@ -167,7 +167,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/includes-name.json
+++ b/test/syntax/baseline/includes-name.json
@@ -35,7 +35,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/indexed-properties.json
+++ b/test/syntax/baseline/indexed-properties.json
@@ -249,7 +249,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/inherits-getter.json
+++ b/test/syntax/baseline/inherits-getter.json
@@ -64,7 +64,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/interface-inherits.json
+++ b/test/syntax/baseline/interface-inherits.json
@@ -73,7 +73,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": ""
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/iterable.json
+++ b/test/syntax/baseline/iterable.json
@@ -94,7 +94,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": ""
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/maplike.json
+++ b/test/syntax/baseline/maplike.json
@@ -117,7 +117,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/mixin.json
+++ b/test/syntax/baseline/mixin.json
@@ -69,7 +69,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/namedconstructor.json
+++ b/test/syntax/baseline/namedconstructor.json
@@ -45,7 +45,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": ""
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/namespace.json
+++ b/test/syntax/baseline/namespace.json
@@ -137,7 +137,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/nointerfaceobject.json
+++ b/test/syntax/baseline/nointerfaceobject.json
@@ -49,7 +49,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": ""
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/nullable.json
+++ b/test/syntax/baseline/nullable.json
@@ -25,7 +25,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/nullableobjects.json
+++ b/test/syntax/baseline/nullableobjects.json
@@ -90,7 +90,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/obsolete-keywords.json
+++ b/test/syntax/baseline/obsolete-keywords.json
@@ -40,7 +40,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/operation-optional-arg.json
+++ b/test/syntax/baseline/operation-optional-arg.json
@@ -93,7 +93,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": ""
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/overloading.json
+++ b/test/syntax/baseline/overloading.json
@@ -297,7 +297,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/overridebuiltins.json
+++ b/test/syntax/baseline/overridebuiltins.json
@@ -64,7 +64,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": ""
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/partial-interface.json
+++ b/test/syntax/baseline/partial-interface.json
@@ -49,7 +49,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": ""
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/primitives.json
+++ b/test/syntax/baseline/primitives.json
@@ -265,7 +265,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/promise-void.json
+++ b/test/syntax/baseline/promise-void.json
@@ -34,7 +34,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/prototyperoot.json
+++ b/test/syntax/baseline/prototyperoot.json
@@ -32,7 +32,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": ""
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/putforwards.json
+++ b/test/syntax/baseline/putforwards.json
@@ -50,7 +50,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": ""
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/record.json
+++ b/test/syntax/baseline/record.json
@@ -206,7 +206,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/reflector-interface.json
+++ b/test/syntax/baseline/reflector-interface.json
@@ -120,7 +120,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/reg-operations.json
+++ b/test/syntax/baseline/reg-operations.json
@@ -144,7 +144,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/replaceable.json
+++ b/test/syntax/baseline/replaceable.json
@@ -47,7 +47,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/sequence.json
+++ b/test/syntax/baseline/sequence.json
@@ -132,7 +132,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/setlike.json
+++ b/test/syntax/baseline/setlike.json
@@ -86,7 +86,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/static.json
+++ b/test/syntax/baseline/static.json
@@ -142,7 +142,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": ""
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/stringifier-attribute.json
+++ b/test/syntax/baseline/stringifier-attribute.json
@@ -47,7 +47,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": ""
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/stringifier-custom.json
+++ b/test/syntax/baseline/stringifier-custom.json
@@ -77,7 +77,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": ""
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/stringifier.json
+++ b/test/syntax/baseline/stringifier.json
@@ -41,7 +41,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": ""
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/treatasnull.json
+++ b/test/syntax/baseline/treatasnull.json
@@ -82,7 +82,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": ""
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/treatasundefined.json
+++ b/test/syntax/baseline/treatasundefined.json
@@ -82,7 +82,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": ""
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/typedef-union.json
+++ b/test/syntax/baseline/typedef-union.json
@@ -47,7 +47,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/typedef.json
+++ b/test/syntax/baseline/typedef.json
@@ -209,7 +209,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/typesuffixes.json
+++ b/test/syntax/baseline/typesuffixes.json
@@ -51,7 +51,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/undefined.json
+++ b/test/syntax/baseline/undefined.json
@@ -108,7 +108,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/uniontype.json
+++ b/test/syntax/baseline/uniontype.json
@@ -123,7 +123,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": ""
+        "value": ""
     }
 ]

--- a/test/syntax/baseline/variadic-operations.json
+++ b/test/syntax/baseline/variadic-operations.json
@@ -89,7 +89,6 @@
     },
     {
         "type": "eof",
-        "value": "",
-        "trivia": "\n"
+        "value": ""
     }
 ]


### PR DESCRIPTION
This adds write() to eof object so that writer can stop special casing it. The tokeniser now also adds line/index fields to eof token for consistency with other tokens.

This removes `trivia` field from EOF. Theoretically it can be a breaking change, but trivia strings are not intended to be accessed outside of the writer function since #306. So I think it's safe to not mark it as breaking.

This patch closes #__ and includes:
- [x] A relevant test (N/A)
- [x] A relevant documentation update
