### PR TITLE
BREAKING CHANGE: merge *-types as idl-type

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ attached to a field called `idlType`:
 
 ```JS
 {
-  "type": "attribute-type",
+  "type": "idl-type",
   "generic": "",
   "idlType": "unsigned short",
   "nullable": false,
@@ -234,7 +234,7 @@ attached to a field called `idlType`:
 
 Where the fields are as follows:
 
-* `type`: String indicating where this type is used. Can be `null` if not applicable.
+* `type`: Always `"idl-type"`.
 * `generic`: String indicating the generic type (e.g. "Promise", "sequence").
 * `idlType`: String indicating the type name, or array of subtypes if the type is
   generic or a union.
@@ -266,7 +266,7 @@ Interfaces look like this:
 
 The fields are as follows:
 
-* `type`: Always "interface".
+* `type`: Always `"interface"`.
 * `name`: The name of the interface.
 * `partial`: `true` if the type is a partial interface.
 * `members`: An array of interface members (attributes, operations, etc.). Empty if there are none.
@@ -297,7 +297,7 @@ Interfaces mixins look like this:
 
 The fields are as follows:
 
-* `type`: Always "interface mixin".
+* `type`: Always `"interface mixin"`.
 * `name`: The name of the interface mixin.
 * `inheritance`: Always `null`.
 * `partial`: `true if the type is a partial interface mixin.
@@ -321,7 +321,7 @@ Namespaces look like this:
 
 The fields are as follows:
 
-* `type`: Always "namespace".
+* `type`: Always `"namespace"`.
 * `name`: The name of the namespace.
 * `inheritance`: Always `null`.
 * `partial`: `true if the type is a partial namespace.
@@ -343,7 +343,7 @@ A callback looks like this:
   "type": "callback",
   "name": "AsyncOperationCallback",
   "idlType": {
-    "type": "return-type",
+    "type": "idl-type",
     "generic": "",
     "nullable": false,
     "union": false,
@@ -357,7 +357,7 @@ A callback looks like this:
 
 The fields are as follows:
 
-* `type`: Always "callback".
+* `type`: Always `"callback"`.
 * `name`: The name of the callback.
 * `idlType`: An [IDL Type](#idl-type) describing what the callback returns.
 * `arguments`: A list of [arguments](#arguments), as in function paramters.
@@ -377,7 +377,7 @@ A dictionary looks like this:
     "name": "fillPattern",
     "required": false,
     "idlType": {
-      "type": "dictionary-type",
+      "type": "idl-type",
       "generic": "",
       "nullable": true
       "union": false,
@@ -397,7 +397,7 @@ A dictionary looks like this:
 
 The fields are as follows:
 
-* `type`: Always "dictionary".
+* `type`: Always `"dictionary"`.
 * `name`: The dictionary name.
 * `partial`: `true` if the type is a partial dictionary.
 * `members`: An array of members (see below).
@@ -406,7 +406,7 @@ The fields are as follows:
 
 All the members are fields as follows:
 
-* `type`: Always "field".
+* `type`: Always `"field"`.
 * `name`: The name of the field.
 * `required`: `true` if the field is required.
 * `idlType`: An [IDL Type](#idl-type) describing what field's type.
@@ -441,7 +441,7 @@ An enum looks like this:
 
 The fields are as follows:
 
-* `type`: Always "enum".
+* `type`: Always `"enum"`.
 * `name`: The enum's name.
 * `values`: An array of values. The type of value is "enum-value".
 * `extAttrs`: An array of [extended attributes](#extended-attributes).
@@ -454,13 +454,13 @@ A typedef looks like this:
 {
   "type": "typedef",
   "idlType": {
-    "type": "typedef-type",
+    "type": "idl-type",
     "generic": "sequence",
     "nullable": false,
     "union": false,
     "idlType": [
       {
-        "type": "typedef-type",
+        "type": "idl-type",
         "generic": "",
         "nullable": false,
         "union": false,
@@ -478,7 +478,7 @@ A typedef looks like this:
 
 The fields are as follows:
 
-* `type`: Always "typedef".
+* `type`: Always `"typedef"`.
 * `name`: The typedef's name.
 * `idlType`: An [IDL Type](#idl-type) describing what typedef's type.
 * `extAttrs`: An array of [extended attributes](#extended-attributes).
@@ -498,7 +498,7 @@ An includes definition looks like this:
 
 The fields are as follows:
 
-* `type`: Always "includes".
+* `type`: Always `"includes"`.
 * `target`: The interface that includes an interface mixin.
 * `includes`: The interface mixin that is being included by the target.
 * `extAttrs`: An array of [extended attributes](#extended-attributes).
@@ -512,7 +512,7 @@ An operation looks like this:
   "type": "operation",
   "special": "",
   "idlType": {
-    "type": "return-type",
+    "type": "idl-type",
     "generic": "",
     "nullable": false,
     "union": false,
@@ -526,7 +526,7 @@ An operation looks like this:
     "variadic": true,
     "extAttrs": [],
     "idlType": {
-      "type": "argument-type",
+      "type": "idl-type",
       "generic": "",
       "nullable": false,
       "union": false,
@@ -542,7 +542,7 @@ An operation looks like this:
 
 The fields are as follows:
 
-* `type`: Always "operation".
+* `type`: Always `"operation"`.
 * `special`: One of `"getter"`, `"setter"`, `"deleter"`, `"static"`, `"stringifier"`, or `""`.
 * `idlType`: An [IDL Type](#idl-type) of what the operation returns, if exists.
 * `name`: The name of the operation if exists.
@@ -563,7 +563,7 @@ A constructor operation member looks like this:
     "variadic": true,
     "extAttrs": [],
     "idlType": {
-      "type": "argument-type",
+      "type": "idl-type",
       "generic": "",
       "nullable": false,
       "union": false,
@@ -579,7 +579,7 @@ A constructor operation member looks like this:
 
 The fields are as follows:
 
-* `type`: Always "constructor".
+* `type`: Always `"constructor"`.
 * `arguments`: An array of [arguments](#arguments) for the constructor operation.
 * `extAttrs`: An array of [extended attributes](#extended-attributes).
 * `parent`: The container of this type as an Object.
@@ -594,7 +594,7 @@ An attribute member looks like this:
   "special": "",
   "readonly": false,
   "idlType": {
-    "type": "attribute-type",
+    "type": "idl-type",
     "generic": "",
     "nullable": false,
     "union": false,
@@ -609,7 +609,7 @@ An attribute member looks like this:
 
 The fields are as follows:
 
-* `type`: Always "attribute".
+* `type`: Always `"attribute"`.
 * `name`: The attribute's name.
 * `special`: One of `"static"`, `"stringifier"`, `"inherit"`, or `""`.
 * `readonly`: `true` if the attribute is read-only.
@@ -625,7 +625,7 @@ A constant member looks like this:
 {
   "type": "const",
   "idlType": {
-    "type": "const-type",
+    "type": "idl-type",
     "generic": "",
     "nullable": false,
     "union": false,
@@ -644,7 +644,7 @@ A constant member looks like this:
 
 The fields are as follows:
 
-* `type`: Always "const".
+* `type`: Always `"const"`.
 * `idlType`: An [IDL Type](#idl-type) of the constant that represents a simple type, the type name.
 * `name`: The name of the constant.
 * `value`: The constant value as described by [Const Values](#default-and-const-values)
@@ -664,7 +664,7 @@ The arguments (e.g. for an operation) look like this:
     "variadic": true
     "extAttrs": []
     "idlType": {
-      "type": "argument-type",
+      "type": "idl-type",
       "generic": "",
       "nullable": false,
       "union": false,
@@ -785,7 +785,7 @@ This is needed for the writer to keep any comments or whitespaces at the end of 
 
 The fields are as follows:
 
-* `type`: Always "eof"
+* `type`: Always `"eof"`
 * `value`: Always an empty string.
 * `trivia`: Any whitespaces and comments after the last token and before the EOF.
 

--- a/lib/productions/argument.js
+++ b/lib/productions/argument.js
@@ -29,7 +29,7 @@ export class Argument extends Base {
     );
     ret.extAttrs = ExtendedAttributes.parse(tokeniser);
     tokens.optional = tokeniser.consume("optional");
-    ret.idlType = type_with_extended_attributes(tokeniser, "argument-type");
+    ret.idlType = type_with_extended_attributes(tokeniser);
     if (!ret.idlType) {
       return tokeniser.unconsume(start_position);
     }

--- a/lib/productions/attribute.js
+++ b/lib/productions/attribute.js
@@ -36,7 +36,7 @@ export class Attribute extends Base {
       return;
     }
     ret.idlType =
-      type_with_extended_attributes(tokeniser, "attribute-type") ||
+      type_with_extended_attributes(tokeniser) ||
       tokeniser.error("Attribute lacks a type");
     tokens.name =
       tokeniser.consumeType("identifier") ||

--- a/lib/productions/constant.js
+++ b/lib/productions/constant.js
@@ -29,7 +29,6 @@ export class Constant extends Base {
     if (tokeniser.probe("?")) {
       tokeniser.error("Unexpected nullable constant type");
     }
-    idlType.type = "const-type";
     tokens.name =
       tokeniser.consumeType("identifier") ||
       tokeniser.error("Const lacks a name");

--- a/lib/productions/field.js
+++ b/lib/productions/field.js
@@ -18,7 +18,7 @@ export class Field extends Base {
     ret.extAttrs = ExtendedAttributes.parse(tokeniser);
     tokens.required = tokeniser.consume("required");
     ret.idlType =
-      type_with_extended_attributes(tokeniser, "dictionary-type") ||
+      type_with_extended_attributes(tokeniser) ||
       tokeniser.error("Dictionary member lacks a type");
     tokens.name =
       tokeniser.consumeType("identifier") ||

--- a/lib/productions/helpers.js
+++ b/lib/productions/helpers.js
@@ -135,21 +135,19 @@ export function argument_list(tokeniser) {
 
 /**
  * @param {import("../tokeniser").Tokeniser} tokeniser
- * @param {string} typeName
  */
-export function type_with_extended_attributes(tokeniser, typeName) {
+export function type_with_extended_attributes(tokeniser) {
   const extAttrs = ExtendedAttributes.parse(tokeniser);
-  const ret = Type.parse(tokeniser, typeName);
+  const ret = Type.parse(tokeniser);
   if (ret) autoParenter(ret).extAttrs = extAttrs;
   return ret;
 }
 
 /**
  * @param {import("../tokeniser").Tokeniser} tokeniser
- * @param {string} typeName
  */
-export function return_type(tokeniser, typeName) {
-  const typ = Type.parse(tokeniser, typeName || "return-type");
+export function return_type(tokeniser) {
+  const typ = Type.parse(tokeniser);
   if (typ) {
     return typ;
   }
@@ -159,7 +157,6 @@ export function return_type(tokeniser, typeName) {
       source: tokeniser.source,
       tokens: { base: voidToken },
     });
-    ret.type = "return-type";
     return ret;
   }
 }

--- a/lib/productions/type.js
+++ b/lib/productions/type.js
@@ -13,9 +13,8 @@ import { ExtendedAttributes } from "./extended-attributes.js";
 
 /**
  * @param {import("../tokeniser").Tokeniser} tokeniser
- * @param {string} typeName
  */
-function generic_type(tokeniser, typeName) {
+function generic_type(tokeniser) {
   const base = tokeniser.consume(
     "FrozenArray",
     "ObservableArray",
@@ -37,8 +36,7 @@ function generic_type(tokeniser, typeName) {
       if (tokeniser.probe("["))
         tokeniser.error("Promise type cannot have extended attribute");
       const subtype =
-        return_type(tokeniser, typeName) ||
-        tokeniser.error("Missing Promise subtype");
+        return_type(tokeniser) || tokeniser.error("Missing Promise subtype");
       ret.subtype.push(subtype);
       break;
     }
@@ -46,7 +44,7 @@ function generic_type(tokeniser, typeName) {
     case "FrozenArray":
     case "ObservableArray": {
       const subtype =
-        type_with_extended_attributes(tokeniser, typeName) ||
+        type_with_extended_attributes(tokeniser) ||
         tokeniser.error(`Missing ${base.value} subtype`);
       ret.subtype.push(subtype);
       break;
@@ -64,9 +62,8 @@ function generic_type(tokeniser, typeName) {
       keyIdlType.tokens.separator =
         tokeniser.consume(",") ||
         tokeniser.error("Missing comma after record key type");
-      keyIdlType.type = typeName;
       const valueType =
-        type_with_extended_attributes(tokeniser, typeName) ||
+        type_with_extended_attributes(tokeniser) ||
         tokeniser.error("Error parsing generic type record");
       ret.subtype.push(keyIdlType, valueType);
       break;
@@ -92,10 +89,9 @@ function type_suffix(tokeniser, obj) {
 
 /**
  * @param {import("../tokeniser").Tokeniser} tokeniser
- * @param {string} typeName
  */
-function single_type(tokeniser, typeName) {
-  let ret = generic_type(tokeniser, typeName) || primitive_type(tokeniser);
+function single_type(tokeniser) {
+  let ret = generic_type(tokeniser) || primitive_type(tokeniser);
   if (!ret) {
     const base =
       tokeniser.consumeType("identifier") ||
@@ -110,7 +106,6 @@ function single_type(tokeniser, typeName) {
   if (ret.generic === "Promise" && tokeniser.probe("?")) {
     tokeniser.error("Promise type cannot be nullable");
   }
-  ret.type = typeName || null;
   type_suffix(tokeniser, ret);
   if (ret.nullable && ret.idlType === "any")
     tokeniser.error("Type `any` cannot be made nullable");
@@ -119,14 +114,12 @@ function single_type(tokeniser, typeName) {
 
 /**
  * @param {import("../tokeniser").Tokeniser} tokeniser
- * @param {string} type
  */
-function union_type(tokeniser, type) {
+function union_type(tokeniser) {
   const tokens = {};
   tokens.open = tokeniser.consume("(");
   if (!tokens.open) return;
   const ret = autoParenter(new Type({ source: tokeniser.source, tokens }));
-  ret.type = type || null;
   while (true) {
     const typ =
       type_with_extended_attributes(tokeniser) ||
@@ -155,10 +148,9 @@ function union_type(tokeniser, type) {
 export class Type extends Base {
   /**
    * @param {import("../tokeniser").Tokeniser} tokeniser
-   * @param {string} typeName
    */
-  static parse(tokeniser, typeName) {
-    return single_type(tokeniser, typeName) || union_type(tokeniser, typeName);
+  static parse(tokeniser) {
+    return single_type(tokeniser) || union_type(tokeniser);
   }
 
   constructor({ source, tokens }) {
@@ -167,6 +159,9 @@ export class Type extends Base {
     this.extAttrs = new ExtendedAttributes({});
   }
 
+  get type() {
+    return "idl-type";
+  }
   get generic() {
     if (this.subtype.length && this.tokens.base) {
       return this.tokens.base.value;

--- a/lib/productions/typedef.js
+++ b/lib/productions/typedef.js
@@ -18,7 +18,7 @@ export class Typedef extends Base {
       return;
     }
     ret.idlType =
-      type_with_extended_attributes(tokeniser, "typedef-type") ||
+      type_with_extended_attributes(tokeniser) ||
       tokeniser.error("Typedef lacks a type");
     tokens.name =
       tokeniser.consumeType("identifier") ||

--- a/test/invalid/baseline/renamed-legacy-extattrs.txt
+++ b/test/invalid/baseline/renamed-legacy-extattrs.txt
@@ -13,7 +13,7 @@
 (renamed-legacy) Validation error at line 7 in renamed-legacy-extattrs.webidl, inside `interface HTMLTimeCapsule -> attribute lenientThis -> extended-attribute LenientThis`:
   [LenientThis] readonly attribute DOMString
    ^ `[LenientThis]` extended attribute is a legacy feature that is now renamed to `[LegacyLenientThis]`. Refer to the [relevant upstream PR](https://github.com/heycam/webidl/pull/870) for more information.
-(renamed-legacy) Validation error at line 8 in renamed-legacy-extattrs.webidl, inside `interface HTMLTimeCapsule -> attribute treatNullAs -> attribute-type -> extended-attribute TreatNullAs`:
+(renamed-legacy) Validation error at line 8 in renamed-legacy-extattrs.webidl, inside `interface HTMLTimeCapsule -> attribute treatNullAs -> idl-type -> extended-attribute TreatNullAs`:
   attribute [TreatNullAs=EmptyString] DOMString
              ^ `[TreatNullAs]` extended attribute is a legacy feature that is now renamed to `[LegacyNullToEmptyString]`. Refer to the [relevant upstream PR](https://github.com/heycam/webidl/pull/870) for more information.
 (renamed-legacy) Validation error at line 9 in renamed-legacy-extattrs.webidl, inside `interface HTMLTimeCapsule -> attribute unforgeable -> extended-attribute Unforgeable`:

--- a/test/syntax/baseline/allowany.json
+++ b/test/syntax/baseline/allowany.json
@@ -8,7 +8,7 @@
                 "type": "operation",
                 "name": "g",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -23,7 +23,7 @@
                 "type": "operation",
                 "name": "g",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -36,7 +36,7 @@
                         "name": "b",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -55,7 +55,7 @@
                 "type": "operation",
                 "name": "g",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -75,7 +75,7 @@
                             }
                         ],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,

--- a/test/syntax/baseline/argument-constructor.json
+++ b/test/syntax/baseline/argument-constructor.json
@@ -8,7 +8,7 @@
                 "type": "operation",
                 "name": "foo",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -21,7 +21,7 @@
                         "name": "constructor",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,

--- a/test/syntax/baseline/argument-extattrs.json
+++ b/test/syntax/baseline/argument-extattrs.json
@@ -8,7 +8,7 @@
                 "type": "operation",
                 "name": "foo",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -28,7 +28,7 @@
                             }
                         ],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [
                                 {
                                     "type": "extended-attribute",

--- a/test/syntax/baseline/async-iterable.json
+++ b/test/syntax/baseline/async-iterable.json
@@ -8,7 +8,7 @@
                 "type": "iterable",
                 "idlType": [
                     {
-                        "type": null,
+                        "type": "idl-type",
                         "extAttrs": [],
                         "generic": "",
                         "nullable": false,
@@ -16,7 +16,7 @@
                         "idlType": "long"
                     },
                     {
-                        "type": null,
+                        "type": "idl-type",
                         "extAttrs": [],
                         "generic": "",
                         "nullable": false,
@@ -42,7 +42,7 @@
                 "type": "iterable",
                 "idlType": [
                     {
-                        "type": null,
+                        "type": "idl-type",
                         "extAttrs": [
                             {
                                 "type": "extended-attribute",
@@ -57,7 +57,7 @@
                         "idlType": "DOMString"
                     },
                     {
-                        "type": null,
+                        "type": "idl-type",
                         "extAttrs": [
                             {
                                 "type": "extended-attribute",
@@ -90,7 +90,7 @@
                 "type": "iterable",
                 "idlType": [
                     {
-                        "type": null,
+                        "type": "idl-type",
                         "extAttrs": [],
                         "generic": "",
                         "nullable": false,
@@ -98,7 +98,7 @@
                         "idlType": "float"
                     },
                     {
-                        "type": null,
+                        "type": "idl-type",
                         "extAttrs": [],
                         "generic": "",
                         "nullable": false,
@@ -124,7 +124,7 @@
                 "type": "iterable",
                 "idlType": [
                     {
-                        "type": null,
+                        "type": "idl-type",
                         "extAttrs": [],
                         "generic": "",
                         "nullable": false,
@@ -132,7 +132,7 @@
                         "idlType": "float"
                     },
                     {
-                        "type": null,
+                        "type": "idl-type",
                         "extAttrs": [],
                         "generic": "",
                         "nullable": false,
@@ -146,7 +146,7 @@
                         "name": "str",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -175,7 +175,7 @@
                 "type": "iterable",
                 "idlType": [
                     {
-                        "type": null,
+                        "type": "idl-type",
                         "extAttrs": [],
                         "generic": "",
                         "nullable": false,
@@ -201,7 +201,7 @@
                 "type": "iterable",
                 "idlType": [
                     {
-                        "type": null,
+                        "type": "idl-type",
                         "extAttrs": [],
                         "generic": "",
                         "nullable": false,
@@ -227,7 +227,7 @@
                 "type": "iterable",
                 "idlType": [
                     {
-                        "type": null,
+                        "type": "idl-type",
                         "extAttrs": [],
                         "generic": "",
                         "nullable": false,
@@ -241,7 +241,7 @@
                         "name": "str",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -257,7 +257,7 @@
                         "name": "s",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,

--- a/test/syntax/baseline/async-name.json
+++ b/test/syntax/baseline/async-name.json
@@ -8,7 +8,7 @@
                 "type": "attribute",
                 "name": "async",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -23,7 +23,7 @@
                 "type": "operation",
                 "name": "asyncOp",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -36,7 +36,7 @@
                         "name": "async",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,

--- a/test/syntax/baseline/attributes.json
+++ b/test/syntax/baseline/attributes.json
@@ -8,7 +8,7 @@
                 "type": "attribute",
                 "name": "age",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -23,7 +23,7 @@
                 "type": "attribute",
                 "name": "required",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,

--- a/test/syntax/baseline/bigint.json
+++ b/test/syntax/baseline/bigint.json
@@ -8,7 +8,7 @@
                 "type": "attribute",
                 "name": "bigint",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -23,7 +23,7 @@
                 "type": "operation",
                 "name": "getBig",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -38,7 +38,7 @@
                 "type": "operation",
                 "name": "setBig",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -51,7 +51,7 @@
                         "name": "big",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -90,7 +90,7 @@
                 "name": "big",
                 "extAttrs": [],
                 "idlType": {
-                    "type": "dictionary-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -105,7 +105,7 @@
                 "name": "another",
                 "extAttrs": [],
                 "idlType": {
-                    "type": "dictionary-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -123,14 +123,14 @@
         "type": "typedef",
         "name": "allowed",
         "idlType": {
-            "type": "typedef-type",
+            "type": "idl-type",
             "extAttrs": [],
             "generic": "",
             "nullable": false,
             "union": true,
             "idlType": [
                 {
-                    "type": null,
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -138,7 +138,7 @@
                     "idlType": "bigint"
                 },
                 {
-                    "type": null,
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,

--- a/test/syntax/baseline/callback.json
+++ b/test/syntax/baseline/callback.json
@@ -3,7 +3,7 @@
         "type": "callback",
         "name": "AsyncOperationCallback",
         "idlType": {
-            "type": "return-type",
+            "type": "idl-type",
             "extAttrs": [],
             "generic": "",
             "nullable": false,
@@ -16,7 +16,7 @@
                 "name": "status",
                 "extAttrs": [],
                 "idlType": {
-                    "type": "argument-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -39,7 +39,7 @@
                 "type": "operation",
                 "name": "eventOccurred",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -52,7 +52,7 @@
                         "name": "details",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -75,7 +75,7 @@
         "type": "callback",
         "name": "SortCallback",
         "idlType": {
-            "type": "return-type",
+            "type": "idl-type",
             "extAttrs": [],
             "generic": "",
             "nullable": false,
@@ -88,7 +88,7 @@
                 "name": "a",
                 "extAttrs": [],
                 "idlType": {
-                    "type": "argument-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -104,7 +104,7 @@
                 "name": "b",
                 "extAttrs": [],
                 "idlType": {
-                    "type": "argument-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,

--- a/test/syntax/baseline/constants.json
+++ b/test/syntax/baseline/constants.json
@@ -8,7 +8,7 @@
                 "type": "const",
                 "name": "DEBUG",
                 "idlType": {
-                    "type": "const-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -25,7 +25,7 @@
                 "type": "const",
                 "name": "negative",
                 "idlType": {
-                    "type": "const-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -42,7 +42,7 @@
                 "type": "const",
                 "name": "LF",
                 "idlType": {
-                    "type": "const-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -59,7 +59,7 @@
                 "type": "const",
                 "name": "BIT_MASK",
                 "idlType": {
-                    "type": "const-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -76,7 +76,7 @@
                 "type": "const",
                 "name": "AVOGADRO",
                 "idlType": {
-                    "type": "const-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -93,7 +93,7 @@
                 "type": "const",
                 "name": "sobig",
                 "idlType": {
-                    "type": "const-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -110,7 +110,7 @@
                 "type": "const",
                 "name": "minusonedividedbyzero",
                 "idlType": {
-                    "type": "const-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -127,7 +127,7 @@
                 "type": "const",
                 "name": "notanumber",
                 "idlType": {
-                    "type": "const-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -143,7 +143,7 @@
                 "type": "const",
                 "name": "const",
                 "idlType": {
-                    "type": "const-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,

--- a/test/syntax/baseline/constructor.json
+++ b/test/syntax/baseline/constructor.json
@@ -17,7 +17,7 @@
                         "name": "radius",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -39,7 +39,7 @@
                         "name": "str",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -64,14 +64,14 @@
                         "name": "seq",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "sequence",
                             "nullable": false,
                             "union": false,
                             "idlType": [
                                 {
-                                    "type": "argument-type",
+                                    "type": "idl-type",
                                     "extAttrs": [],
                                     "generic": "",
                                     "nullable": false,
@@ -95,14 +95,14 @@
                         "name": "union",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
                             "union": true,
                             "idlType": [
                                 {
-                                    "type": null,
+                                    "type": "idl-type",
                                     "extAttrs": [],
                                     "generic": "",
                                     "nullable": false,
@@ -110,7 +110,7 @@
                                     "idlType": "Type1"
                                 },
                                 {
-                                    "type": null,
+                                    "type": "idl-type",
                                     "extAttrs": [],
                                     "generic": "",
                                     "nullable": false,
@@ -130,7 +130,7 @@
                 "type": "attribute",
                 "name": "r",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -145,7 +145,7 @@
                 "type": "attribute",
                 "name": "cx",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -160,7 +160,7 @@
                 "type": "attribute",
                 "name": "cy",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -175,7 +175,7 @@
                 "type": "attribute",
                 "name": "circumference",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,

--- a/test/syntax/baseline/default.json
+++ b/test/syntax/baseline/default.json
@@ -9,7 +9,7 @@
                 "name": "caseSensitive",
                 "extAttrs": [],
                 "idlType": {
-                    "type": "dictionary-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -35,7 +35,7 @@
                 "type": "operation",
                 "name": "hasAddressForName",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -48,7 +48,7 @@
                         "name": "name",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -64,7 +64,7 @@
                         "name": "options",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,

--- a/test/syntax/baseline/dictionary-inherits.json
+++ b/test/syntax/baseline/dictionary-inherits.json
@@ -9,7 +9,7 @@
                 "name": "fillPattern",
                 "extAttrs": [],
                 "idlType": {
-                    "type": "dictionary-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": true,
@@ -27,7 +27,7 @@
                 "name": "strokePattern",
                 "extAttrs": [],
                 "idlType": {
-                    "type": "dictionary-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": true,
@@ -44,7 +44,7 @@
                 "name": "position",
                 "extAttrs": [],
                 "idlType": {
-                    "type": "dictionary-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -68,7 +68,7 @@
                 "name": "hydrometry",
                 "extAttrs": [],
                 "idlType": {
-                    "type": "dictionary-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,

--- a/test/syntax/baseline/dictionary.json
+++ b/test/syntax/baseline/dictionary.json
@@ -9,7 +9,7 @@
                 "name": "fillPattern",
                 "extAttrs": [],
                 "idlType": {
-                    "type": "dictionary-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": true,
@@ -27,7 +27,7 @@
                 "name": "strokePattern",
                 "extAttrs": [],
                 "idlType": {
-                    "type": "dictionary-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": true,
@@ -44,7 +44,7 @@
                 "name": "position",
                 "extAttrs": [],
                 "idlType": {
-                    "type": "dictionary-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -59,14 +59,14 @@
                 "name": "seq",
                 "extAttrs": [],
                 "idlType": {
-                    "type": "dictionary-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "sequence",
                     "nullable": false,
                     "union": false,
                     "idlType": [
                         {
-                            "type": "dictionary-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -86,7 +86,7 @@
                 "name": "reqSeq",
                 "extAttrs": [],
                 "idlType": {
-                    "type": "dictionary-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -101,7 +101,7 @@
                 "name": "dict",
                 "extAttrs": [],
                 "idlType": {
-                    "type": "dictionary-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -127,7 +127,7 @@
                 "name": "h",
                 "extAttrs": [],
                 "idlType": {
-                    "type": "dictionary-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -142,7 +142,7 @@
                 "name": "d",
                 "extAttrs": [],
                 "idlType": {
-                    "type": "dictionary-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,

--- a/test/syntax/baseline/enum.json
+++ b/test/syntax/baseline/enum.json
@@ -27,7 +27,7 @@
                 "type": "attribute",
                 "name": "type",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -42,7 +42,7 @@
                 "type": "attribute",
                 "name": "size",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -57,7 +57,7 @@
                 "type": "operation",
                 "name": "initialize",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -70,7 +70,7 @@
                         "name": "type",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -86,7 +86,7 @@
                         "name": "size",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,

--- a/test/syntax/baseline/equivalent-decl.json
+++ b/test/syntax/baseline/equivalent-decl.json
@@ -8,7 +8,7 @@
                 "type": "attribute",
                 "name": "propertyCount",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -23,7 +23,7 @@
                 "type": "operation",
                 "name": "getProperty",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -36,7 +36,7 @@
                         "name": "propertyName",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -55,7 +55,7 @@
                 "type": "operation",
                 "name": "setProperty",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -68,7 +68,7 @@
                         "name": "propertyName",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -84,7 +84,7 @@
                         "name": "propertyValue",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -112,7 +112,7 @@
                 "type": "attribute",
                 "name": "propertyCount",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -127,7 +127,7 @@
                 "type": "operation",
                 "name": "getProperty",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -140,7 +140,7 @@
                         "name": "propertyName",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -159,7 +159,7 @@
                 "type": "operation",
                 "name": "setProperty",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -172,7 +172,7 @@
                         "name": "propertyName",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -188,7 +188,7 @@
                         "name": "propertyValue",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -207,7 +207,7 @@
                 "type": "operation",
                 "name": "",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -220,7 +220,7 @@
                         "name": "propertyName",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -239,7 +239,7 @@
                 "type": "operation",
                 "name": "",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -252,7 +252,7 @@
                         "name": "propertyName",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -268,7 +268,7 @@
                         "name": "propertyValue",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,

--- a/test/syntax/baseline/escaped-type.json
+++ b/test/syntax/baseline/escaped-type.json
@@ -3,7 +3,7 @@
         "type": "typedef",
         "name": "EscapedType",
         "idlType": {
-            "type": "typedef-type",
+            "type": "idl-type",
             "extAttrs": [],
             "generic": "",
             "nullable": false,
@@ -16,14 +16,14 @@
         "type": "typedef",
         "name": "EscapedSequence",
         "idlType": {
-            "type": "typedef-type",
+            "type": "idl-type",
             "extAttrs": [],
             "generic": "sequence",
             "nullable": false,
             "union": false,
             "idlType": [
                 {
-                    "type": "typedef-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,

--- a/test/syntax/baseline/extended-attributes.json
+++ b/test/syntax/baseline/extended-attributes.json
@@ -116,7 +116,7 @@
                 "type": "attribute",
                 "name": "r",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -131,7 +131,7 @@
                 "type": "attribute",
                 "name": "cx",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -146,7 +146,7 @@
                 "type": "attribute",
                 "name": "cy",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -161,7 +161,7 @@
                 "type": "attribute",
                 "name": "circumference",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -190,7 +190,7 @@
                         "name": "radius",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -215,7 +215,7 @@
                 "type": "attribute",
                 "name": "attrib",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [
                         {
                             "type": "extended-attribute",
@@ -229,7 +229,7 @@
                     "union": true,
                     "idlType": [
                         {
-                            "type": null,
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -237,7 +237,7 @@
                             "idlType": "long"
                         },
                         {
-                            "type": null,
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,

--- a/test/syntax/baseline/generic.json
+++ b/test/syntax/baseline/generic.json
@@ -8,28 +8,28 @@
                 "type": "operation",
                 "name": "bar",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "Promise",
                     "nullable": false,
                     "union": false,
                     "idlType": [
                         {
-                            "type": "return-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "Promise",
                             "nullable": false,
                             "union": false,
                             "idlType": [
                                 {
-                                    "type": "return-type",
+                                    "type": "idl-type",
                                     "extAttrs": [],
                                     "generic": "sequence",
                                     "nullable": false,
                                     "union": false,
                                     "idlType": [
                                         {
-                                            "type": "return-type",
+                                            "type": "idl-type",
                                             "extAttrs": [],
                                             "generic": "",
                                             "nullable": true,
@@ -50,14 +50,14 @@
                 "type": "attribute",
                 "name": "baz",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "Promise",
                     "nullable": false,
                     "union": false,
                     "idlType": [
                         {
-                            "type": "attribute-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -74,14 +74,14 @@
                 "type": "attribute",
                 "name": "frozen",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "FrozenArray",
                     "nullable": false,
                     "union": false,
                     "idlType": [
                         {
-                            "type": "attribute-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -98,14 +98,14 @@
                 "type": "attribute",
                 "name": "observable",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "ObservableArray",
                     "nullable": false,
                     "union": false,
                     "idlType": [
                         {
-                            "type": "attribute-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -131,14 +131,14 @@
                 "type": "operation",
                 "name": "getServiced",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "Promise",
                     "nullable": false,
                     "union": false,
                     "idlType": [
                         {
-                            "type": "return-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": true,
@@ -155,14 +155,14 @@
                 "type": "operation",
                 "name": "reloadAll",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "Promise",
                     "nullable": false,
                     "union": false,
                     "idlType": [
                         {
-                            "type": "return-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -188,14 +188,14 @@
                 "type": "operation",
                 "name": "default",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "Promise",
                     "nullable": false,
                     "union": false,
                     "idlType": [
                         {
-                            "type": "return-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,

--- a/test/syntax/baseline/getter-setter.json
+++ b/test/syntax/baseline/getter-setter.json
@@ -8,7 +8,7 @@
                 "type": "attribute",
                 "name": "propertyCount",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -23,7 +23,7 @@
                 "type": "operation",
                 "name": "",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -36,7 +36,7 @@
                         "name": "propertyName",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -55,7 +55,7 @@
                 "type": "operation",
                 "name": "",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -68,7 +68,7 @@
                         "name": "propertyName",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -84,7 +84,7 @@
                         "name": "propertyValue",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,

--- a/test/syntax/baseline/identifier-hyphen.json
+++ b/test/syntax/baseline/identifier-hyphen.json
@@ -8,7 +8,7 @@
                 "type": "attribute",
                 "name": "-will-change",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [
                         {
                             "type": "extended-attribute",

--- a/test/syntax/baseline/identifier-qualified-names.json
+++ b/test/syntax/baseline/identifier-qualified-names.json
@@ -3,7 +3,7 @@
         "type": "typedef",
         "name": "number",
         "idlType": {
-            "type": "typedef-type",
+            "type": "idl-type",
             "extAttrs": [],
             "generic": "",
             "nullable": false,
@@ -21,7 +21,7 @@
                 "type": "operation",
                 "name": "createObject",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -34,7 +34,7 @@
                         "name": "interface",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -53,7 +53,7 @@
                 "type": "operation",
                 "name": "",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -66,7 +66,7 @@
                         "name": "keyName",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -94,7 +94,7 @@
                 "type": "attribute",
                 "name": "const",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -109,7 +109,7 @@
                 "type": "attribute",
                 "name": "value",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": true,
@@ -133,7 +133,7 @@
                 "type": "operation",
                 "name": "addEventListener",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -146,7 +146,7 @@
                         "name": "callback",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": true,

--- a/test/syntax/baseline/includes-name.json
+++ b/test/syntax/baseline/includes-name.json
@@ -8,7 +8,7 @@
                 "type": "operation",
                 "name": "includes",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,

--- a/test/syntax/baseline/indexed-properties.json
+++ b/test/syntax/baseline/indexed-properties.json
@@ -8,7 +8,7 @@
                 "type": "attribute",
                 "name": "size",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -23,7 +23,7 @@
                 "type": "operation",
                 "name": "getByIndex",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -36,7 +36,7 @@
                         "name": "index",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -55,7 +55,7 @@
                 "type": "operation",
                 "name": "setByIndex",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -68,7 +68,7 @@
                         "name": "index",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -84,7 +84,7 @@
                         "name": "value",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -103,7 +103,7 @@
                 "type": "operation",
                 "name": "removeByIndex",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -116,7 +116,7 @@
                         "name": "index",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -135,7 +135,7 @@
                 "type": "operation",
                 "name": "get",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -148,7 +148,7 @@
                         "name": "name",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -167,7 +167,7 @@
                 "type": "operation",
                 "name": "set",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -180,7 +180,7 @@
                         "name": "name",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -196,7 +196,7 @@
                         "name": "value",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -215,7 +215,7 @@
                 "type": "operation",
                 "name": "remove",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -228,7 +228,7 @@
                         "name": "name",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,

--- a/test/syntax/baseline/inherits-getter.json
+++ b/test/syntax/baseline/inherits-getter.json
@@ -8,7 +8,7 @@
                 "type": "attribute",
                 "name": "name",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -32,7 +32,7 @@
                 "type": "attribute",
                 "name": "age",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -47,7 +47,7 @@
                 "type": "attribute",
                 "name": "name",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,

--- a/test/syntax/baseline/interface-inherits.json
+++ b/test/syntax/baseline/interface-inherits.json
@@ -8,7 +8,7 @@
                 "type": "attribute",
                 "name": "name",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -32,7 +32,7 @@
                 "type": "attribute",
                 "name": "pet",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -56,7 +56,7 @@
                 "type": "attribute",
                 "name": "owner",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,

--- a/test/syntax/baseline/iterable.json
+++ b/test/syntax/baseline/iterable.json
@@ -8,7 +8,7 @@
                 "type": "iterable",
                 "idlType": [
                     {
-                        "type": null,
+                        "type": "idl-type",
                         "extAttrs": [],
                         "generic": "",
                         "nullable": false,
@@ -34,7 +34,7 @@
                 "type": "iterable",
                 "idlType": [
                     {
-                        "type": null,
+                        "type": "idl-type",
                         "extAttrs": [],
                         "generic": "",
                         "nullable": false,
@@ -42,7 +42,7 @@
                         "idlType": "short"
                     },
                     {
-                        "type": null,
+                        "type": "idl-type",
                         "extAttrs": [],
                         "generic": "",
                         "nullable": true,
@@ -68,7 +68,7 @@
                 "type": "iterable",
                 "idlType": [
                     {
-                        "type": null,
+                        "type": "idl-type",
                         "extAttrs": [
                             {
                                 "type": "extended-attribute",

--- a/test/syntax/baseline/maplike.json
+++ b/test/syntax/baseline/maplike.json
@@ -8,7 +8,7 @@
                 "type": "maplike",
                 "idlType": [
                     {
-                        "type": null,
+                        "type": "idl-type",
                         "extAttrs": [],
                         "generic": "",
                         "nullable": false,
@@ -16,7 +16,7 @@
                         "idlType": "long"
                     },
                     {
-                        "type": null,
+                        "type": "idl-type",
                         "extAttrs": [],
                         "generic": "",
                         "nullable": false,
@@ -42,7 +42,7 @@
                 "type": "maplike",
                 "idlType": [
                     {
-                        "type": null,
+                        "type": "idl-type",
                         "extAttrs": [],
                         "generic": "",
                         "nullable": false,
@@ -50,7 +50,7 @@
                         "idlType": "long"
                     },
                     {
-                        "type": null,
+                        "type": "idl-type",
                         "extAttrs": [],
                         "generic": "",
                         "nullable": false,
@@ -76,7 +76,7 @@
                 "type": "maplike",
                 "idlType": [
                     {
-                        "type": null,
+                        "type": "idl-type",
                         "extAttrs": [
                             {
                                 "type": "extended-attribute",
@@ -91,7 +91,7 @@
                         "idlType": "DOMString"
                     },
                     {
-                        "type": null,
+                        "type": "idl-type",
                         "extAttrs": [
                             {
                                 "type": "extended-attribute",

--- a/test/syntax/baseline/mixin.json
+++ b/test/syntax/baseline/mixin.json
@@ -8,7 +8,7 @@
                 "type": "attribute",
                 "name": "crypto",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -44,7 +44,7 @@
                 "type": "attribute",
                 "name": "crypto",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,

--- a/test/syntax/baseline/namedconstructor.json
+++ b/test/syntax/baseline/namedconstructor.json
@@ -27,7 +27,7 @@
                         "name": "src",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,

--- a/test/syntax/baseline/namespace.json
+++ b/test/syntax/baseline/namespace.json
@@ -8,7 +8,7 @@
                 "type": "attribute",
                 "name": "unit",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -23,7 +23,7 @@
                 "type": "operation",
                 "name": "dotProduct",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -36,7 +36,7 @@
                         "name": "x",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -52,7 +52,7 @@
                         "name": "y",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -71,7 +71,7 @@
                 "type": "operation",
                 "name": "crossProduct",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -84,7 +84,7 @@
                         "name": "x",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -100,7 +100,7 @@
                         "name": "y",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,

--- a/test/syntax/baseline/nointerfaceobject.json
+++ b/test/syntax/baseline/nointerfaceobject.json
@@ -8,7 +8,7 @@
                 "type": "operation",
                 "name": "lookupEntry",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -21,7 +21,7 @@
                         "name": "key",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,

--- a/test/syntax/baseline/nullable.json
+++ b/test/syntax/baseline/nullable.json
@@ -8,7 +8,7 @@
                 "type": "attribute",
                 "name": "namespaceURI",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": true,

--- a/test/syntax/baseline/nullableobjects.json
+++ b/test/syntax/baseline/nullableobjects.json
@@ -24,7 +24,7 @@
                 "type": "operation",
                 "name": "f",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -37,7 +37,7 @@
                         "name": "x",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": true,
@@ -56,7 +56,7 @@
                 "type": "operation",
                 "name": "f",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -69,7 +69,7 @@
                         "name": "x",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": true,

--- a/test/syntax/baseline/obsolete-keywords.json
+++ b/test/syntax/baseline/obsolete-keywords.json
@@ -8,7 +8,7 @@
                 "type": "operation",
                 "name": "implements",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -23,7 +23,7 @@
                 "type": "operation",
                 "name": "legacyiterable",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,

--- a/test/syntax/baseline/operation-optional-arg.json
+++ b/test/syntax/baseline/operation-optional-arg.json
@@ -8,7 +8,7 @@
                 "type": "operation",
                 "name": "createColor",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -21,7 +21,7 @@
                         "name": "v1",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -37,7 +37,7 @@
                         "name": "v2",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -53,7 +53,7 @@
                         "name": "v3",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -69,7 +69,7 @@
                         "name": "alpha",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,

--- a/test/syntax/baseline/overloading.json
+++ b/test/syntax/baseline/overloading.json
@@ -24,7 +24,7 @@
                 "type": "operation",
                 "name": "f",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -37,7 +37,7 @@
                         "name": "x",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -56,7 +56,7 @@
                 "type": "operation",
                 "name": "f",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -69,7 +69,7 @@
                         "name": "x",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -97,7 +97,7 @@
                 "type": "operation",
                 "name": "f",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -110,7 +110,7 @@
                         "name": "a",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -129,7 +129,7 @@
                 "type": "operation",
                 "name": "f",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -149,7 +149,7 @@
                             }
                         ],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -165,7 +165,7 @@
                         "name": "b",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -181,7 +181,7 @@
                         "name": "c",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -200,7 +200,7 @@
                 "type": "operation",
                 "name": "f",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -215,7 +215,7 @@
                 "type": "operation",
                 "name": "f",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -228,7 +228,7 @@
                         "name": "a",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -244,7 +244,7 @@
                         "name": "b",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -260,7 +260,7 @@
                         "name": "c",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -276,7 +276,7 @@
                         "name": "d",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,

--- a/test/syntax/baseline/overridebuiltins.json
+++ b/test/syntax/baseline/overridebuiltins.json
@@ -8,7 +8,7 @@
                 "type": "attribute",
                 "name": "length",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -23,7 +23,7 @@
                 "type": "operation",
                 "name": "lookup",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -36,7 +36,7 @@
                         "name": "key",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,

--- a/test/syntax/baseline/partial-interface.json
+++ b/test/syntax/baseline/partial-interface.json
@@ -8,7 +8,7 @@
                 "type": "attribute",
                 "name": "bar",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -32,7 +32,7 @@
                 "type": "attribute",
                 "name": "quux",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,

--- a/test/syntax/baseline/primitives.json
+++ b/test/syntax/baseline/primitives.json
@@ -8,7 +8,7 @@
                 "type": "attribute",
                 "name": "truth",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -23,7 +23,7 @@
                 "type": "attribute",
                 "name": "character",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -38,7 +38,7 @@
                 "type": "attribute",
                 "name": "value",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -53,7 +53,7 @@
                 "type": "attribute",
                 "name": "number",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -68,7 +68,7 @@
                 "type": "attribute",
                 "name": "positive",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -83,7 +83,7 @@
                 "type": "attribute",
                 "name": "big",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -98,7 +98,7 @@
                 "type": "attribute",
                 "name": "bigpositive",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -113,7 +113,7 @@
                 "type": "attribute",
                 "name": "bigbig",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -128,7 +128,7 @@
                 "type": "attribute",
                 "name": "bigbigpositive",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -143,7 +143,7 @@
                 "type": "attribute",
                 "name": "real",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -158,7 +158,7 @@
                 "type": "attribute",
                 "name": "bigreal",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -173,7 +173,7 @@
                 "type": "attribute",
                 "name": "realwithinfinity",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -188,7 +188,7 @@
                 "type": "attribute",
                 "name": "bigrealwithinfinity",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -203,7 +203,7 @@
                 "type": "attribute",
                 "name": "string",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -218,7 +218,7 @@
                 "type": "attribute",
                 "name": "bytes",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -233,7 +233,7 @@
                 "type": "attribute",
                 "name": "date",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -248,7 +248,7 @@
                 "type": "attribute",
                 "name": "regexp",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,

--- a/test/syntax/baseline/promise-void.json
+++ b/test/syntax/baseline/promise-void.json
@@ -8,14 +8,14 @@
                 "type": "attribute",
                 "name": "meow",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "Promise",
                     "nullable": false,
                     "union": false,
                     "idlType": [
                         {
-                            "type": "return-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,

--- a/test/syntax/baseline/prototyperoot.json
+++ b/test/syntax/baseline/prototyperoot.json
@@ -8,7 +8,7 @@
                 "type": "attribute",
                 "name": "nodeType",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,

--- a/test/syntax/baseline/putforwards.json
+++ b/test/syntax/baseline/putforwards.json
@@ -8,7 +8,7 @@
                 "type": "attribute",
                 "name": "name",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -33,7 +33,7 @@
                 "type": "attribute",
                 "name": "age",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,

--- a/test/syntax/baseline/record.json
+++ b/test/syntax/baseline/record.json
@@ -8,7 +8,7 @@
                 "type": "operation",
                 "name": "foo",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -21,21 +21,21 @@
                         "name": "param",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "sequence",
                             "nullable": false,
                             "union": false,
                             "idlType": [
                                 {
-                                    "type": "argument-type",
+                                    "type": "idl-type",
                                     "extAttrs": [],
                                     "generic": "record",
                                     "nullable": false,
                                     "union": false,
                                     "idlType": [
                                         {
-                                            "type": "argument-type",
+                                            "type": "idl-type",
                                             "extAttrs": [],
                                             "generic": "",
                                             "nullable": false,
@@ -43,7 +43,7 @@
                                             "idlType": "ByteString"
                                         },
                                         {
-                                            "type": "argument-type",
+                                            "type": "idl-type",
                                             "extAttrs": [],
                                             "generic": "",
                                             "nullable": false,
@@ -66,14 +66,14 @@
                 "type": "operation",
                 "name": "bar",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "record",
                     "nullable": false,
                     "union": false,
                     "idlType": [
                         {
-                            "type": "return-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -81,14 +81,14 @@
                             "idlType": "DOMString"
                         },
                         {
-                            "type": "return-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": true,
                             "union": true,
                             "idlType": [
                                 {
-                                    "type": null,
+                                    "type": "idl-type",
                                     "extAttrs": [],
                                     "generic": "",
                                     "nullable": false,
@@ -96,7 +96,7 @@
                                     "idlType": "float"
                                 },
                                 {
-                                    "type": null,
+                                    "type": "idl-type",
                                     "extAttrs": [],
                                     "generic": "",
                                     "nullable": false,
@@ -123,14 +123,14 @@
                         "name": "init",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "record",
                             "nullable": false,
                             "union": false,
                             "idlType": [
                                 {
-                                    "type": "argument-type",
+                                    "type": "idl-type",
                                     "extAttrs": [],
                                     "generic": "",
                                     "nullable": false,
@@ -138,7 +138,7 @@
                                     "idlType": "USVString"
                                 },
                                 {
-                                    "type": "argument-type",
+                                    "type": "idl-type",
                                     "extAttrs": [],
                                     "generic": "",
                                     "nullable": false,
@@ -165,14 +165,14 @@
                 "type": "operation",
                 "name": "bar",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "record",
                     "nullable": false,
                     "union": false,
                     "idlType": [
                         {
-                            "type": "return-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -180,7 +180,7 @@
                             "idlType": "DOMString"
                         },
                         {
-                            "type": "return-type",
+                            "type": "idl-type",
                             "extAttrs": [
                                 {
                                     "type": "extended-attribute",

--- a/test/syntax/baseline/reflector-interface.json
+++ b/test/syntax/baseline/reflector-interface.json
@@ -8,7 +8,7 @@
                 "type": "attribute",
                 "name": "toggle",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -39,7 +39,7 @@
                 "type": "attribute",
                 "name": "quarter",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -80,7 +80,7 @@
                 "type": "attribute",
                 "name": "span",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,

--- a/test/syntax/baseline/reg-operations.json
+++ b/test/syntax/baseline/reg-operations.json
@@ -8,7 +8,7 @@
                 "type": "attribute",
                 "name": "width",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -23,7 +23,7 @@
                 "type": "attribute",
                 "name": "height",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -47,7 +47,7 @@
                 "type": "operation",
                 "name": "isMouseOver",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -62,7 +62,7 @@
                 "type": "operation",
                 "name": "setDimensions",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -75,7 +75,7 @@
                         "name": "size",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -94,7 +94,7 @@
                 "type": "operation",
                 "name": "setDimensions",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -107,7 +107,7 @@
                         "name": "width",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -123,7 +123,7 @@
                         "name": "height",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,

--- a/test/syntax/baseline/replaceable.json
+++ b/test/syntax/baseline/replaceable.json
@@ -8,7 +8,7 @@
                 "type": "attribute",
                 "name": "value",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -30,7 +30,7 @@
                 "type": "operation",
                 "name": "increment",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,

--- a/test/syntax/baseline/sequence.json
+++ b/test/syntax/baseline/sequence.json
@@ -8,7 +8,7 @@
                 "type": "operation",
                 "name": "drawPolygon",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -21,14 +21,14 @@
                         "name": "coordinates",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "sequence",
                             "nullable": false,
                             "union": false,
                             "idlType": [
                                 {
-                                    "type": "argument-type",
+                                    "type": "idl-type",
                                     "extAttrs": [],
                                     "generic": "",
                                     "nullable": false,
@@ -49,14 +49,14 @@
                 "type": "operation",
                 "name": "getInflectionPoints",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "sequence",
                     "nullable": false,
                     "union": false,
                     "idlType": [
                         {
-                            "type": "return-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -82,7 +82,7 @@
                 "type": "operation",
                 "name": "f1",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -95,14 +95,14 @@
                         "name": "arg",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "sequence",
                             "nullable": false,
                             "union": false,
                             "idlType": [
                                 {
-                                    "type": "argument-type",
+                                    "type": "idl-type",
                                     "extAttrs": [
                                         {
                                             "type": "extended-attribute",

--- a/test/syntax/baseline/setlike.json
+++ b/test/syntax/baseline/setlike.json
@@ -8,7 +8,7 @@
                 "type": "setlike",
                 "idlType": [
                     {
-                        "type": null,
+                        "type": "idl-type",
                         "extAttrs": [],
                         "generic": "",
                         "nullable": false,
@@ -34,7 +34,7 @@
                 "type": "setlike",
                 "idlType": [
                     {
-                        "type": null,
+                        "type": "idl-type",
                         "extAttrs": [],
                         "generic": "",
                         "nullable": false,
@@ -60,7 +60,7 @@
                 "type": "setlike",
                 "idlType": [
                     {
-                        "type": null,
+                        "type": "idl-type",
                         "extAttrs": [
                             {
                                 "type": "extended-attribute",

--- a/test/syntax/baseline/static.json
+++ b/test/syntax/baseline/static.json
@@ -16,7 +16,7 @@
                 "type": "attribute",
                 "name": "cx",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -31,7 +31,7 @@
                 "type": "attribute",
                 "name": "cy",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -46,7 +46,7 @@
                 "type": "attribute",
                 "name": "radius",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -61,7 +61,7 @@
                 "type": "attribute",
                 "name": "triangulationCount",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -76,7 +76,7 @@
                 "type": "operation",
                 "name": "triangulate",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -89,7 +89,7 @@
                         "name": "c1",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -105,7 +105,7 @@
                         "name": "c2",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -121,7 +121,7 @@
                         "name": "c3",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,

--- a/test/syntax/baseline/stringifier-attribute.json
+++ b/test/syntax/baseline/stringifier-attribute.json
@@ -8,7 +8,7 @@
                 "type": "attribute",
                 "name": "id",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -23,7 +23,7 @@
                 "type": "attribute",
                 "name": "name",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,

--- a/test/syntax/baseline/stringifier-custom.json
+++ b/test/syntax/baseline/stringifier-custom.json
@@ -8,7 +8,7 @@
                 "type": "attribute",
                 "name": "id",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -23,7 +23,7 @@
                 "type": "attribute",
                 "name": "familyName",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": true,
@@ -38,7 +38,7 @@
                 "type": "attribute",
                 "name": "givenName",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -53,7 +53,7 @@
                 "type": "operation",
                 "name": "",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,

--- a/test/syntax/baseline/stringifier.json
+++ b/test/syntax/baseline/stringifier.json
@@ -8,7 +8,7 @@
                 "type": "operation",
                 "name": "",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,

--- a/test/syntax/baseline/treatasnull.json
+++ b/test/syntax/baseline/treatasnull.json
@@ -8,7 +8,7 @@
                 "type": "attribute",
                 "name": "name",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -23,7 +23,7 @@
                 "type": "attribute",
                 "name": "owner",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -38,7 +38,7 @@
                 "type": "operation",
                 "name": "isMemberOfBreed",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -61,7 +61,7 @@
                             }
                         ],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,

--- a/test/syntax/baseline/treatasundefined.json
+++ b/test/syntax/baseline/treatasundefined.json
@@ -8,7 +8,7 @@
                 "type": "attribute",
                 "name": "name",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -23,7 +23,7 @@
                 "type": "attribute",
                 "name": "owner",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -38,7 +38,7 @@
                 "type": "operation",
                 "name": "isMemberOfBreed",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -61,7 +61,7 @@
                             }
                         ],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,

--- a/test/syntax/baseline/typedef-union.json
+++ b/test/syntax/baseline/typedef-union.json
@@ -3,14 +3,14 @@
         "type": "typedef",
         "name": "TexImageSource",
         "idlType": {
-            "type": "typedef-type",
+            "type": "idl-type",
             "extAttrs": [],
             "generic": "",
             "nullable": false,
             "union": true,
             "idlType": [
                 {
-                    "type": null,
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -18,7 +18,7 @@
                     "idlType": "ImageData"
                 },
                 {
-                    "type": null,
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -26,7 +26,7 @@
                     "idlType": "HTMLImageElement"
                 },
                 {
-                    "type": null,
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -34,7 +34,7 @@
                     "idlType": "HTMLCanvasElement"
                 },
                 {
-                    "type": null,
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,

--- a/test/syntax/baseline/typedef.json
+++ b/test/syntax/baseline/typedef.json
@@ -8,7 +8,7 @@
                 "type": "attribute",
                 "name": "x",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -23,7 +23,7 @@
                 "type": "attribute",
                 "name": "y",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -42,14 +42,14 @@
         "type": "typedef",
         "name": "PointSequence",
         "idlType": {
-            "type": "typedef-type",
+            "type": "idl-type",
             "extAttrs": [],
             "generic": "sequence",
             "nullable": false,
             "union": false,
             "idlType": [
                 {
-                    "type": "typedef-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -69,7 +69,7 @@
                 "type": "attribute",
                 "name": "topleft",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -84,7 +84,7 @@
                 "type": "attribute",
                 "name": "bottomright",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -108,7 +108,7 @@
                 "type": "attribute",
                 "name": "bounds",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -123,7 +123,7 @@
                 "type": "operation",
                 "name": "pointWithinBounds",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -136,7 +136,7 @@
                         "name": "p",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -155,7 +155,7 @@
                 "type": "operation",
                 "name": "allPointsWithinBounds",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -168,7 +168,7 @@
                         "name": "ps",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -191,7 +191,7 @@
         "type": "typedef",
         "name": "value",
         "idlType": {
-            "type": "typedef-type",
+            "type": "idl-type",
             "extAttrs": [
                 {
                     "type": "extended-attribute",

--- a/test/syntax/baseline/typesuffixes.json
+++ b/test/syntax/baseline/typesuffixes.json
@@ -8,7 +8,7 @@
                 "type": "operation",
                 "name": "test",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -21,14 +21,14 @@
                         "name": "foo",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "sequence",
                             "nullable": true,
                             "union": false,
                             "idlType": [
                                 {
-                                    "type": "argument-type",
+                                    "type": "idl-type",
                                     "extAttrs": [],
                                     "generic": "",
                                     "nullable": true,

--- a/test/syntax/baseline/undefined.json
+++ b/test/syntax/baseline/undefined.json
@@ -8,7 +8,7 @@
                 "type": "operation",
                 "name": "foo",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -23,21 +23,21 @@
                 "type": "operation",
                 "name": "bar",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "Promise",
                     "nullable": false,
                     "union": false,
                     "idlType": [
                         {
-                            "type": "return-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
                             "union": true,
                             "idlType": [
                                 {
-                                    "type": null,
+                                    "type": "idl-type",
                                     "extAttrs": [],
                                     "generic": "",
                                     "nullable": false,
@@ -45,7 +45,7 @@
                                     "idlType": "DOMString"
                                 },
                                 {
-                                    "type": null,
+                                    "type": "idl-type",
                                     "extAttrs": [],
                                     "generic": "",
                                     "nullable": false,
@@ -64,7 +64,7 @@
                 "type": "operation",
                 "name": "baz",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -77,7 +77,7 @@
                         "name": "boo",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,

--- a/test/syntax/baseline/uniontype.json
+++ b/test/syntax/baseline/uniontype.json
@@ -8,14 +8,14 @@
                 "type": "attribute",
                 "name": "test",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
                     "union": true,
                     "idlType": [
                         {
-                            "type": null,
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -23,14 +23,14 @@
                             "idlType": "float"
                         },
                         {
-                            "type": null,
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
                             "union": true,
                             "idlType": [
                                 {
-                                    "type": null,
+                                    "type": "idl-type",
                                     "extAttrs": [],
                                     "generic": "",
                                     "nullable": false,
@@ -38,7 +38,7 @@
                                     "idlType": "Date"
                                 },
                                 {
-                                    "type": null,
+                                    "type": "idl-type",
                                     "extAttrs": [],
                                     "generic": "",
                                     "nullable": false,
@@ -48,14 +48,14 @@
                             ]
                         },
                         {
-                            "type": null,
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": true,
                             "union": true,
                             "idlType": [
                                 {
-                                    "type": null,
+                                    "type": "idl-type",
                                     "extAttrs": [],
                                     "generic": "",
                                     "nullable": false,
@@ -63,7 +63,7 @@
                                     "idlType": "Node"
                                 },
                                 {
-                                    "type": null,
+                                    "type": "idl-type",
                                     "extAttrs": [],
                                     "generic": "",
                                     "nullable": false,
@@ -82,14 +82,14 @@
                 "type": "attribute",
                 "name": "test2",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
                     "union": true,
                     "idlType": [
                         {
-                            "type": null,
+                            "type": "idl-type",
                             "extAttrs": [
                                 {
                                     "type": "extended-attribute",
@@ -104,7 +104,7 @@
                             "idlType": "long"
                         },
                         {
-                            "type": null,
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,

--- a/test/syntax/baseline/variadic-operations.json
+++ b/test/syntax/baseline/variadic-operations.json
@@ -8,7 +8,7 @@
                 "type": "attribute",
                 "name": "cardinality",
                 "idlType": {
-                    "type": "attribute-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -23,7 +23,7 @@
                 "type": "operation",
                 "name": "union",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -36,7 +36,7 @@
                         "name": "ints",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,
@@ -55,7 +55,7 @@
                 "type": "operation",
                 "name": "intersection",
                 "idlType": {
-                    "type": "return-type",
+                    "type": "idl-type",
                     "extAttrs": [],
                     "generic": "",
                     "nullable": false,
@@ -68,7 +68,7 @@
                         "name": "ints",
                         "extAttrs": [],
                         "idlType": {
-                            "type": "argument-type",
+                            "type": "idl-type",
                             "extAttrs": [],
                             "generic": "",
                             "nullable": false,

--- a/test/writer.js
+++ b/test/writer.js
@@ -89,7 +89,7 @@ describe("Writer template functions", () => {
       "[Exposed=Window] interface Momo : Kudamono { attribute Promise<unsigned  long> iro; };"
     );
     expect(result).toBe(
-      "[Exposed=<Window|Window|extended-attribute>] interface Momo : <Kudamono|Kudamono|interface> { attribute Promise<<unsigned  long|unsigned long|attribute-type>> iro; };"
+      "[Exposed=<Window|Window|extended-attribute>] interface Momo : <Kudamono|Kudamono|interface> { attribute Promise<<unsigned  long|unsigned long|idl-type>> iro; };"
     );
 
     const includes = rewriteReference("_A includes _B;");


### PR DESCRIPTION
This should make implementing #570 easier since every IDL type object will have the same type string.

This patch closes #537 and includes:
- [x] A relevant test
- [x] A relevant documentation update
