### PR TITLE
fix: change globalObject to `globalThis`

### DIFF
--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -7,7 +7,7 @@ module.exports = {
     path: path.resolve(__dirname, "dist"),
     library: "WebIDL2",
     libraryTarget: "umd",
-    globalObject: "this"
+    globalObject: "globalThis"
   },
   mode: "production",
   devtool: "source-map",


### PR DESCRIPTION
In ESM `this` is undefined at the top level. Instead to access the global object you must use `globalThis`.

This is causing some issues in Deno when running WPT idlharness tests, because all code is always executed in a module context.