### PR TITLE
fix(productions/extended-attribute): pass correct parent object

### DIFF
--- a/lib/productions/extended-attributes.js
+++ b/lib/productions/extended-attributes.js
@@ -107,7 +107,7 @@ class ExtendedAttributeParameters extends Base {
         ? []
         : this.list.map((p) => {
             return rhsType === "identifier-list"
-              ? w.identifier(p, this)
+              ? w.identifier(p, this.parent)
               : rhsType && rhsType.endsWith("-list")
               ? extended_attribute_listitem(p)
               : p.write(w);

--- a/test/writer.js
+++ b/test/writer.js
@@ -94,6 +94,13 @@ describe("Writer template functions", () => {
 
     const includes = rewriteReference("_A includes _B;");
     expect(includes).toBe("<_A|A|includes> includes <_B|B|includes>;");
+
+    const extAttrList = rewriteReference(
+      "[Exposed=(Window, Worker)] interface Sekai {};"
+    );
+    expect(extAttrList).toBe(
+      "[Exposed=(<Window|Window|extended-attribute>, <Worker|Worker|extended-attribute>)] interface Sekai {};"
+    );
   });
 
   it("catches references as unescaped", () => {


### PR DESCRIPTION
Should fix the error in https://github.com/w3c/respec/pull/3536.

This patch closes #__ and includes:
- [x] A relevant test
- [x] A relevant documentation update (N/A)
