### PR TITLE
fix(tokeniser): match CRLF inside a comment

### DIFF
--- a/lib/tokeniser.js
+++ b/lib/tokeniser.js
@@ -12,7 +12,7 @@ const tokenRe = {
   identifier: /[_-]?[A-Za-z][0-9A-Z_a-z-]*/y,
   string: /"[^"]*"/y,
   whitespace: /[\t\n\r ]+/y,
-  comment: /\/\/.*|\/\*(.|\n)*?\*\//y,
+  comment: /\/\/.*|\/\*[\s\S]*?\*\//y,
   other: /[^\t\n\r 0-9A-Za-z]/y,
 };
 

--- a/test/syntax.js
+++ b/test/syntax.js
@@ -22,3 +22,11 @@ describe("Options", () => {
     expect(parsed.length).toBe(0);
   });
 });
+
+describe("Newlines", () => {
+  it("should match CRLF within a comment", () => {
+    const comment = "/*\r\n * this comment is multiline with CRLF\r\n*/";
+    const parsed = parse(comment, { concrete: true });
+    expect(parsed[0].trivia).toBe(comment);
+  });
+});


### PR DESCRIPTION
Regressed by #566. The spec is explicitly using Perl regex syntax where `.` also matches `\r` but that doesn't apply to JavaScript.

This patch closes #__ and includes:
- [x] A relevant test
- [x] A relevant documentation update (N/A)
