### PR TITLE
refactor(container): remove redundant type parameter

### DIFF
--- a/lib/productions/callback-interface.js
+++ b/lib/productions/callback-interface.js
@@ -18,7 +18,6 @@ export class CallbackInterface extends Container {
       tokeniser,
       new CallbackInterface({ source: tokeniser.source, tokens }),
       {
-        type: "callback interface",
         inheritable: !partial,
         allowedMembers: [
           [Constant.parse],

--- a/lib/productions/container.js
+++ b/lib/productions/container.js
@@ -23,11 +23,11 @@ export class Container extends Base {
    * @param {T} instance
    * @param {*} args
    */
-  static parse(tokeniser, instance, { type, inheritable, allowedMembers }) {
-    const { tokens } = instance;
+  static parse(tokeniser, instance, { inheritable, allowedMembers }) {
+    const { tokens, type } = instance;
     tokens.name =
       tokeniser.consumeType("identifier") ||
-      tokeniser.error(`Missing name in ${instance.type}`);
+      tokeniser.error(`Missing name in ${type}`);
     tokeniser.current = instance;
     instance = autoParenter(instance);
     if (inheritable) {

--- a/lib/productions/dictionary.js
+++ b/lib/productions/dictionary.js
@@ -19,7 +19,6 @@ export class Dictionary extends Container {
       tokeniser,
       new Dictionary({ source: tokeniser.source, tokens }),
       {
-        type: "dictionary",
         inheritable: !partial,
         allowedMembers: [[Field.parse]],
       }

--- a/lib/productions/interface.js
+++ b/lib/productions/interface.js
@@ -41,7 +41,6 @@ export class Interface extends Container {
       tokeniser,
       new Interface({ source: tokeniser.source, tokens }),
       {
-        type: "interface",
         inheritable: !partial,
         allowedMembers: [
           [Constant.parse],

--- a/lib/productions/mixin.js
+++ b/lib/productions/mixin.js
@@ -23,7 +23,6 @@ export class Mixin extends Container {
       tokeniser,
       new Mixin({ source: tokeniser.source, tokens }),
       {
-        type: "interface mixin",
         allowedMembers: [
           [Constant.parse],
           [stringifier],

--- a/lib/productions/namespace.js
+++ b/lib/productions/namespace.js
@@ -21,7 +21,6 @@ export class Namespace extends Container {
       tokeniser,
       new Namespace({ source: tokeniser.source, tokens }),
       {
-        type: "namespace",
         allowedMembers: [
           [Attribute.parse, { noInherit: true, readonly: true }],
           [Constant.parse],


### PR DESCRIPTION
This patch closes #__ and includes:
- [x] A relevant test (N/A)
- [x] A relevant documentation update (N/A)
