### PR TITLE
Fix online checker link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is a parser for [Web IDL](https://heycam.github.io/webidl/), a language
 [to specify web APIs in interoperable way](https://heycam.github.io/webidl/#introduction).
 This library supports both Node.js and the browser environment.
 
-Try the online checker [here](/checker).
+Try the online checker [here](https://w3c.github.io/webidl2.js/checker/).
 
 ## Installation
 


### PR DESCRIPTION
Currently, the `checker` link refers to the [`checker` folder](https://github.com/w3c/webidl2.js/tree/main/checker) in this repository but I wonder maybe the https://w3c.github.io/webidl2.js/checker/ online checker might be the right one.


This patch closes #__ and includes:
- [ ] A relevant test
- [x] A relevant documentation update
