### PR TITLE
Replace heycam/webidl with whatwg/webidl

### DIFF
--- a/lib/productions/extended-attributes.js
+++ b/lib/productions/extended-attributes.js
@@ -159,7 +159,7 @@ export class SimpleExtendedAttribute extends Base {
     if (name === "LegacyNoInterfaceObject") {
       const message = `\`[LegacyNoInterfaceObject]\` extended attribute is an \
 undesirable feature that may be removed from Web IDL in the future. Refer to the \
-[relevant upstream PR](https://github.com/heycam/webidl/pull/609) for more \
+[relevant upstream PR](https://github.com/whatwg/webidl/pull/609) for more \
 information.`;
       yield validationError(
         this.tokens.name,
@@ -171,7 +171,7 @@ information.`;
     } else if (renamedLegacies.has(name)) {
       const message = `\`[${name}]\` extended attribute is a legacy feature \
 that is now renamed to \`[${renamedLegacies.get(name)}]\`. Refer to the \
-[relevant upstream PR](https://github.com/heycam/webidl/pull/870) for more \
+[relevant upstream PR](https://github.com/whatwg/webidl/pull/870) for more \
 information.`;
       yield validationError(this.tokens.name, this, "renamed-legacy", message, {
         level: "warning",

--- a/lib/productions/type.js
+++ b/lib/productions/type.js
@@ -196,7 +196,7 @@ export class Type extends Base {
 
     if (this.idlType === "void") {
       const message = `\`void\` is now replaced by \`undefined\`. Refer to the \
-[relevant GitHub issue](https://github.com/heycam/webidl/issues/60) \
+[relevant GitHub issue](https://github.com/whatwg/webidl/issues/60) \
 for more information.`;
       yield validationError(this.tokens.base, this, "replace-void", message, {
         autofix: replaceVoid(this),

--- a/test/invalid/baseline/exposed.txt
+++ b/test/invalid/baseline/exposed.txt
@@ -3,7 +3,7 @@ interface UnexposedInterface {};
           ^ Interfaces must have `[Exposed]` extended attribute. To fix, add, for example, `[Exposed=Window]`. Please also consider carefully if your interface should also be exposed in a Worker scope. Refer to the [WebIDL spec section on Exposed](https://heycam.github.io/webidl/#Exposed) for more information.
 (no-nointerfaceobject) Validation error at line 3 in exposed.webidl, inside `interface NoObjectInterface -> extended-attribute LegacyNoInterfaceObject`:
 [LegacyNoInterfaceObject]
- ^ `[LegacyNoInterfaceObject]` extended attribute is an undesirable feature that may be removed from Web IDL in the future. Refer to the [relevant upstream PR](https://github.com/heycam/webidl/pull/609) for more information.
+ ^ `[LegacyNoInterfaceObject]` extended attribute is an undesirable feature that may be removed from Web IDL in the future. Refer to the [relevant upstream PR](https://github.com/whatwg/webidl/pull/609) for more information.
 (require-exposed) Validation error at line 4 in exposed.webidl, inside `interface NoObjectInterface`:
 interface NoObjectInterface {};
           ^ Interfaces must have `[Exposed]` extended attribute. To fix, add, for example, `[Exposed=Window]`. Please also consider carefully if your interface should also be exposed in a Worker scope. Refer to the [WebIDL spec section on Exposed](https://heycam.github.io/webidl/#Exposed) for more information.

--- a/test/invalid/baseline/renamed-legacy-extattrs.txt
+++ b/test/invalid/baseline/renamed-legacy-extattrs.txt
@@ -1,24 +1,24 @@
 (renamed-legacy) Validation error at line 2 in renamed-legacy-extattrs.webidl, inside `interface HTMLTimeCapsule -> extended-attribute NamedConstructor`:
  NamedConstructor=TimeMachine()
- ^ `[NamedConstructor]` extended attribute is a legacy feature that is now renamed to `[LegacyFactoryFunction]`. Refer to the [relevant upstream PR](https://github.com/heycam/webidl/pull/870) for more information.
+ ^ `[NamedConstructor]` extended attribute is a legacy feature that is now renamed to `[LegacyFactoryFunction]`. Refer to the [relevant upstream PR](https://github.com/whatwg/webidl/pull/870) for more information.
 (renamed-legacy) Validation error at line 3 in renamed-legacy-extattrs.webidl, inside `interface HTMLTimeCapsule -> extended-attribute NoInterfaceObject`:
  NoInterfaceObject,
- ^ `[NoInterfaceObject]` extended attribute is a legacy feature that is now renamed to `[LegacyNoInterfaceObject]`. Refer to the [relevant upstream PR](https://github.com/heycam/webidl/pull/870) for more information.
+ ^ `[NoInterfaceObject]` extended attribute is a legacy feature that is now renamed to `[LegacyNoInterfaceObject]`. Refer to the [relevant upstream PR](https://github.com/whatwg/webidl/pull/870) for more information.
 (renamed-legacy) Validation error at line 4 in renamed-legacy-extattrs.webidl, inside `interface HTMLTimeCapsule -> extended-attribute OverrideBuiltins`:
  OverrideBuiltins]
- ^ `[OverrideBuiltins]` extended attribute is a legacy feature that is now renamed to `[LegacyOverrideBuiltIns]`. Refer to the [relevant upstream PR](https://github.com/heycam/webidl/pull/870) for more information.
+ ^ `[OverrideBuiltins]` extended attribute is a legacy feature that is now renamed to `[LegacyOverrideBuiltIns]`. Refer to the [relevant upstream PR](https://github.com/whatwg/webidl/pull/870) for more information.
 (renamed-legacy) Validation error at line 6 in renamed-legacy-extattrs.webidl, inside `interface HTMLTimeCapsule -> attribute lenientSetter -> extended-attribute LenientSetter`:
   [LenientSetter] readonly attribute DOMString
-   ^ `[LenientSetter]` extended attribute is a legacy feature that is now renamed to `[LegacyLenientSetter]`. Refer to the [relevant upstream PR](https://github.com/heycam/webidl/pull/870) for more information.
+   ^ `[LenientSetter]` extended attribute is a legacy feature that is now renamed to `[LegacyLenientSetter]`. Refer to the [relevant upstream PR](https://github.com/whatwg/webidl/pull/870) for more information.
 (renamed-legacy) Validation error at line 7 in renamed-legacy-extattrs.webidl, inside `interface HTMLTimeCapsule -> attribute lenientThis -> extended-attribute LenientThis`:
   [LenientThis] readonly attribute DOMString
-   ^ `[LenientThis]` extended attribute is a legacy feature that is now renamed to `[LegacyLenientThis]`. Refer to the [relevant upstream PR](https://github.com/heycam/webidl/pull/870) for more information.
+   ^ `[LenientThis]` extended attribute is a legacy feature that is now renamed to `[LegacyLenientThis]`. Refer to the [relevant upstream PR](https://github.com/whatwg/webidl/pull/870) for more information.
 (renamed-legacy) Validation error at line 8 in renamed-legacy-extattrs.webidl, inside `interface HTMLTimeCapsule -> attribute treatNullAs -> attribute-type -> extended-attribute TreatNullAs`:
   attribute [TreatNullAs=EmptyString] DOMString
-             ^ `[TreatNullAs]` extended attribute is a legacy feature that is now renamed to `[LegacyNullToEmptyString]`. Refer to the [relevant upstream PR](https://github.com/heycam/webidl/pull/870) for more information.
+             ^ `[TreatNullAs]` extended attribute is a legacy feature that is now renamed to `[LegacyNullToEmptyString]`. Refer to the [relevant upstream PR](https://github.com/whatwg/webidl/pull/870) for more information.
 (renamed-legacy) Validation error at line 9 in renamed-legacy-extattrs.webidl, inside `interface HTMLTimeCapsule -> attribute unforgeable -> extended-attribute Unforgeable`:
   [Unforgeable] readonly attribute DOMString
-   ^ `[Unforgeable]` extended attribute is a legacy feature that is now renamed to `[LegacyUnforgeable]`. Refer to the [relevant upstream PR](https://github.com/heycam/webidl/pull/870) for more information.
+   ^ `[Unforgeable]` extended attribute is a legacy feature that is now renamed to `[LegacyUnforgeable]`. Refer to the [relevant upstream PR](https://github.com/whatwg/webidl/pull/870) for more information.
 (renamed-legacy) Validation error at line 12 in renamed-legacy-extattrs.webidl, inside `callback TreatsNonObjectAsNull -> extended-attribute TreatNonObjectAsNull`:
 [TreatNonObjectAsNull]
- ^ `[TreatNonObjectAsNull]` extended attribute is a legacy feature that is now renamed to `[LegacyTreatNonObjectAsNull]`. Refer to the [relevant upstream PR](https://github.com/heycam/webidl/pull/870) for more information.
+ ^ `[TreatNonObjectAsNull]` extended attribute is a legacy feature that is now renamed to `[LegacyTreatNonObjectAsNull]`. Refer to the [relevant upstream PR](https://github.com/whatwg/webidl/pull/870) for more information.

--- a/test/invalid/baseline/void-keyword.txt
+++ b/test/invalid/baseline/void-keyword.txt
@@ -1,3 +1,3 @@
 (replace-void) Validation error at line 3 in void-keyword.webidl:
   void foo();
-  ^ `void` is now replaced by `undefined`. Refer to the [relevant GitHub issue](https://github.com/heycam/webidl/issues/60) for more information.
+  ^ `void` is now replaced by `undefined`. Refer to the [relevant GitHub issue](https://github.com/whatwg/webidl/issues/60) for more information.

--- a/test/invalid/idl/array.webidl
+++ b/test/invalid/idl/array.webidl
@@ -1,5 +1,5 @@
 // Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06
-// T[] is removed by https://github.com/heycam/webidl/commit/079cbb861a99e9e857a3f2a169c0beeb49cd020a
+// T[] is removed by https://github.com/whatwg/webidl/commit/079cbb861a99e9e857a3f2a169c0beeb49cd020a
 [Constructor]
 interface LotteryResults {
   readonly attribute unsigned short[][] numbers;

--- a/test/invalid/idl/caller.webidl
+++ b/test/invalid/idl/caller.webidl
@@ -1,5 +1,5 @@
 // Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06
-// legacycallers are removed by https://github.com/heycam/webidl/pull/412
+// legacycallers are removed by https://github.com/whatwg/webidl/pull/412
 
 interface NumberQuadrupler {
   // This operation simply returns four times the given number x.

--- a/test/invalid/idl/exception.webidl
+++ b/test/invalid/idl/exception.webidl
@@ -1,5 +1,5 @@
 // Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06
-// IDL exceptions are removed by https://github.com/heycam/webidl/commit/50e172ec079db073c3724c9beac1b576fb5dbc47
+// IDL exceptions are removed by https://github.com/whatwg/webidl/commit/50e172ec079db073c3724c9beac1b576fb5dbc47
 
 exception SomeException {
 };


### PR DESCRIPTION
Reflecting the recent move to WHATWG.

This patch closes #__ and includes:
- [x] A relevant test
- [x] A relevant documentation update (N/A)