### PR TITLE
Better errors for extended attributes

### DIFF
--- a/lib/productions/extended-attributes.js
+++ b/lib/productions/extended-attributes.js
@@ -241,7 +241,7 @@ export class ExtendedAttributes extends ArrayBase {
     );
     tokens.close =
       tokeniser.consume("]") ||
-      tokeniser.error("Expected closing token of extended attribute");
+      tokeniser.error("Expected a closing token of extended attribute");
     if (!ret.length) {
       tokeniser.error("Found an empty extended attribute");
     }

--- a/lib/productions/extended-attributes.js
+++ b/lib/productions/extended-attributes.js
@@ -75,7 +75,7 @@ class ExtendedAttributeParameters extends Base {
       tokens.close =
         tokeniser.consume(")") ||
         tokeniser.error("Unexpected token in extended attribute argument list");
-    } else if (ret.hasRhs && !tokens.secondaryName) {
+    } else if (tokens.assign && !tokens.secondaryName) {
       tokeniser.error("No right hand side to extended attribute assignment");
     }
     return ret.this;
@@ -241,7 +241,7 @@ export class ExtendedAttributes extends ArrayBase {
     );
     tokens.close =
       tokeniser.consume("]") ||
-      tokeniser.error("Unexpected closing token of extended attribute");
+      tokeniser.error("Expected closing token of extended attribute");
     if (!ret.length) {
       tokeniser.error("Found an empty extended attribute");
     }

--- a/lib/productions/extended-attributes.js
+++ b/lib/productions/extended-attributes.js
@@ -242,11 +242,11 @@ export class ExtendedAttributes extends ArrayBase {
     tokens.close =
       tokeniser.consume("]") ||
       tokeniser.error(
-        "Expected a closing token of the extended attribute list"
+        "Expected a closing token for the extended attribute list"
       );
     if (!ret.length) {
       tokeniser.unconsume(tokens.close.index);
-      tokeniser.error("Found an empty extended attribute list");
+      tokeniser.error("An extended attribute list must not be empty");
     }
     if (tokeniser.probe("[")) {
       tokeniser.error(

--- a/lib/productions/extended-attributes.js
+++ b/lib/productions/extended-attributes.js
@@ -241,9 +241,12 @@ export class ExtendedAttributes extends ArrayBase {
     );
     tokens.close =
       tokeniser.consume("]") ||
-      tokeniser.error("Expected a closing token of extended attribute");
+      tokeniser.error(
+        "Expected a closing token of the extended attribute list"
+      );
     if (!ret.length) {
-      tokeniser.error("Found an empty extended attribute");
+      tokeniser.unconsume(tokens.close.index);
+      tokeniser.error("Found an empty extended attribute list");
     }
     if (tokeniser.probe("[")) {
       tokeniser.error(

--- a/test/invalid/baseline/extattr-empty.txt
+++ b/test/invalid/baseline/extattr-empty.txt
@@ -1,3 +1,3 @@
 Syntax error at line 1 in extattr-empty.webidl:
 []
- ^ Found an empty extended attribute list
+ ^ An extended attribute list must not be empty

--- a/test/invalid/baseline/extattr-empty.txt
+++ b/test/invalid/baseline/extattr-empty.txt
@@ -1,0 +1,3 @@
+Syntax error at line 1 in extattr-empty.webidl:
+[]
+ ^ Found an empty extended attribute list

--- a/test/invalid/baseline/extattr-invalid-rhs.txt
+++ b/test/invalid/baseline/extattr-invalid-rhs.txt
@@ -1,3 +1,3 @@
 Syntax error at line 1 in extattr-invalid-rhs.webidl:
 [Exposed=*/]
-          ^ Expected a closing token of extended attribute
+          ^ Expected a closing token of the extended attribute list

--- a/test/invalid/baseline/extattr-invalid-rhs.txt
+++ b/test/invalid/baseline/extattr-invalid-rhs.txt
@@ -1,0 +1,3 @@
+Syntax error at line 1 in extattr-invalid-rhs.webidl:
+[Exposed=*/]
+          ^ Expected closing token of extended attribute

--- a/test/invalid/baseline/extattr-invalid-rhs.txt
+++ b/test/invalid/baseline/extattr-invalid-rhs.txt
@@ -1,3 +1,3 @@
 Syntax error at line 1 in extattr-invalid-rhs.webidl:
 [Exposed=*/]
-          ^ Expected a closing token of the extended attribute list
+          ^ Expected a closing token for the extended attribute list

--- a/test/invalid/baseline/extattr-invalid-rhs.txt
+++ b/test/invalid/baseline/extattr-invalid-rhs.txt
@@ -1,3 +1,3 @@
 Syntax error at line 1 in extattr-invalid-rhs.webidl:
 [Exposed=*/]
-          ^ Expected closing token of extended attribute
+          ^ Expected a closing token of extended attribute

--- a/test/invalid/baseline/extattr-no-rhs.txt
+++ b/test/invalid/baseline/extattr-no-rhs.txt
@@ -1,0 +1,3 @@
+Syntax error at line 1 in extattr-no-rhs.webidl:
+[Exposed=]
+         ^ No right hand side to extended attribute assignment

--- a/test/invalid/idl/extattr-empty.webidl
+++ b/test/invalid/idl/extattr-empty.webidl
@@ -1,0 +1,2 @@
+[]
+interface Foo {};

--- a/test/invalid/idl/extattr-invalid-rhs.webidl
+++ b/test/invalid/idl/extattr-invalid-rhs.webidl
@@ -1,0 +1,2 @@
+[Exposed=*/]
+interface Foo {};

--- a/test/invalid/idl/extattr-no-rhs.webidl
+++ b/test/invalid/idl/extattr-no-rhs.webidl
@@ -1,0 +1,2 @@
+[Exposed=]
+interface Foo {};


### PR DESCRIPTION
This patch closes #__ and includes:
- [x] A relevant test
- [x] A relevant documentation update (N/A)
