### PR TITLE
feat: expose non-top-level production classes

### DIFF
--- a/docs/custom-productions.md
+++ b/docs/custom-productions.md
@@ -97,3 +97,16 @@ This library exposes member productions in `webidl2/productions`. (Note that thi
 * `Type`
 
 You can call `Argument.parse(tokeniser)` inside your custom production to reuse it.
+
+It also exposes some helper functions:
+
+* `autoParenter`: This wraps your object in a proxy that assigns any object's `parent` field to `this`. Useful when tracking the parent of member productions.
+
+   ```js
+   const ret = autoParenter(this);
+   ret.default = Default.parse(tokeniser);
+   default.parent // this
+   ```
+
+* `argument_list`: Receives a tokeniser object and parses arguments separated by commas. Can be used to implement function-like syntax.
+* `unescape`: Trims preceding underscore `_` if the string argument has one.

--- a/docs/custom-productions.md
+++ b/docs/custom-productions.md
@@ -78,3 +78,22 @@ interface Tokeniser {
   unconsume(position: number);
 }
 ```
+
+## Using existing productions
+
+This library exposes member productions in `webidl2/productions`. (Note that this only works with ES module import)
+
+* `Argument`
+* `Attribute`
+* `Base`
+* `Constant`
+* `Constructor`
+* `Container`
+* `Default`
+* `ExtendedAttributes` / `SimpleExtendedAttribute`
+* `Field`
+* `IterableLike`
+* `Operation`
+* `Type`
+
+You can call `Argument.parse(tokeniser)` inside your custom production to reuse it.

--- a/lib/productions/index.js
+++ b/lib/productions/index.js
@@ -1,0 +1,17 @@
+export { Argument } from "./argument.js";
+export { Attribute } from "./attribute.js";
+export { Base } from "./base.js";
+export { Constant } from "./constant.js";
+export { Constructor } from "./constructor.js";
+export { Container } from "./container.js";
+export { Default } from "./default.js";
+export {
+  ExtendedAttributes,
+  SimpleExtendedAttribute,
+} from "./extended-attributes.js";
+export { Field } from "./field.js";
+export { IterableLike } from "./iterable.js";
+export { Operation } from "./operation.js";
+export { Type } from "./type.js";
+
+export { autoParenter } from "./helpers.js";

--- a/lib/productions/index.js
+++ b/lib/productions/index.js
@@ -14,4 +14,4 @@ export { IterableLike } from "./iterable.js";
 export { Operation } from "./operation.js";
 export { Type } from "./type.js";
 
-export { autoParenter } from "./helpers.js";
+export { autoParenter, argument_list, unescape } from "./helpers.js";

--- a/package.json
+++ b/package.json
@@ -39,8 +39,11 @@
   "repository": "git://github.com/w3c/webidl2.js",
   "main": "dist/webidl2.js",
   "exports": {
-    "import": "./index.js",
-    "require": "./dist/webidl2.js"
+    ".": {
+      "import": "./index.js",
+      "require": "./dist/webidl2.js"
+    },
+    "./productions": "./lib/productions/index.js"
   },
   "type": "module",
   "files": [


### PR DESCRIPTION
This does not expose top level productions for now, since the parse function of them have some weird internal-only behavior, e.g. `Interface.parse` does not parse `interface` keyword by itself. Technically same for `Attribute` and `Operation`, but they are usable at least.

This patch includes:
- [x] A relevant test (N/A, just exposes things)
- [x] A relevant documentation update
