### PR TITLE
Update package.json with license: MIT

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "engines": {
     "node": ">= 14"
   },
-  "license": "W3C",
+  "license": "MIT",
   "devDependencies": {
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",


### PR DESCRIPTION
This field doesn't mean much when LICENSE is still in MIT. (i.e. this library has been under MIT license forever regardless of this field.)

This patch closes #702 