### PR TITLE
feat: add Float16Array

### DIFF
--- a/lib/tokeniser.js
+++ b/lib/tokeniser.js
@@ -29,6 +29,7 @@ export const typeNameKeywords = [
   "Uint8ClampedArray",
   "BigInt64Array",
   "BigUint64Array",
+  "Float16Array",
   "Float32Array",
   "Float64Array",
   "any",

--- a/test/syntax/baseline/buffersource.json
+++ b/test/syntax/baseline/buffersource.json
@@ -346,6 +346,38 @@
                             "generic": "",
                             "nullable": false,
                             "union": false,
+                            "idlType": "Float16Array"
+                        },
+                        "default": null,
+                        "optional": false,
+                        "variadic": false
+                    }
+                ],
+                "extAttrs": [],
+                "special": ""
+            },
+            {
+                "type": "operation",
+                "name": "add",
+                "idlType": {
+                    "type": "return-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "undefined"
+                },
+                "arguments": [
+                    {
+                        "type": "argument",
+                        "name": "array",
+                        "extAttrs": [],
+                        "idlType": {
+                            "type": "argument-type",
+                            "extAttrs": [],
+                            "generic": "",
+                            "nullable": false,
+                            "union": false,
                             "idlType": "Float32Array"
                         },
                         "default": null,

--- a/test/syntax/idl/buffersource.webidl
+++ b/test/syntax/idl/buffersource.webidl
@@ -10,6 +10,7 @@ interface Buffer {
   undefined add(Uint8ClampedArray array);
   undefined add(BigInt64Array array);
   undefined add(BigUint64Array array);
+  undefined add(Float16Array array);
   undefined add(Float32Array array);
   undefined add(Float64Array array);
 


### PR DESCRIPTION
Adds support for Float16Array from the [Float16Array proposal for JS](https://github.com/tc39/proposal-float16array); corresponding webidl change at https://github.com/whatwg/webidl/pull/1398.